### PR TITLE
JRE container entries declared before user sources and dependencies.

### DIFF
--- a/lib/buildr/ide/eclipse.rb
+++ b/lib/buildr/ide/eclipse.rb
@@ -250,16 +250,16 @@ module Buildr
                     classpathentry.src project.test.resources
                   end
 
-                  # Classpath elements from other projects
-                  classpathentry.src_projects project_libs
-
-                  classpathentry.output project.compile.target if project.compile.target
-                  classpathentry.lib libs
-                  classpathentry.var vars
-
                   project.eclipse.classpath_containers.each { |container|
                     classpathentry.con container
                   }
+                  
+                  # Classpath elements from other projects
+                  classpathentry.src_projects project_libs
+                  
+                  classpathentry.output project.compile.target if project.compile.target
+                  classpathentry.lib libs
+                  classpathentry.var vars
                 end
               end
             end


### PR DESCRIPTION
See https://gist.github.com/1605072 in order to reproduce the bug. In summary, if you use Drools, it already ships a jre container. Since the user's dependencies are written to '.classpath' first, Drools container will be taken, instead of Eclipse's. In my case, it produces undesired effects like disabling Java Generics.

This change fixes the problem... I hope it doesn't break anything else :-) I'm not very much into Eclipse classpath stuff.
