### PR TITLE
Enable building jekyll and rdoc under more rubies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,6 @@
 # the License.
 
 # To work-around a bug with gemcutter: http://stackoverflow.com/questions/4932881/gemcutter-rake-build-now-throws-undefined-method-write-for-syckemitter
-require 'psych' unless RUBY_PLATFORM[/java/]
-
 # We need JAVA_HOME for most things (setup, spec, etc).
 unless ENV['JAVA_HOME']
   if RUBY_PLATFORM[/java/]

--- a/buildr.gemspec
+++ b/buildr.gemspec
@@ -73,17 +73,17 @@ for those one-off tasks, with a language that's a joy to use.
   spec.add_dependency 'jruby-openssl',        '>= 0.7' if spec.platform.to_s == 'java'
 
   # The documentation is currently not generated whe building via jruby
-  unless spec.platform.to_s == 'java'
-    spec.add_development_dependency 'jekyll', '0.11.0'
-    spec.add_development_dependency 'RedCloth', '4.2.9'
-    spec.add_development_dependency 'jekylltask', '1.1.0'
-    spec.add_development_dependency 'rdoc', '3.8'
-    spec.add_development_dependency 'rcov', '0.9.9'
-  end
+  spec.add_development_dependency 'jekyll', '0.11.0'
+  spec.add_development_dependency 'RedCloth', '4.2.9'
+  spec.add_development_dependency 'jekylltask', '1.1.0'
+  spec.add_development_dependency 'rdoc', '3.8'
+  spec.add_development_dependency 'rcov', '0.9.9'
 
   spec.add_development_dependency 'ci_reporter', '1.6.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'win32console' if spec.platform.to_s == 'x86-mswin32'
   spec.add_development_dependency 'rubyforge'
+  spec.add_development_dependency 'psych' if RUBY_VERSION >= '1.9.2'
+  spec.add_development_dependency 'pygmentize', '0.0.3'
 end

--- a/rakelib/doc.rake
+++ b/rakelib/doc.rake
@@ -13,7 +13,9 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-if !RUBY_PLATFORM[/java/]
+if (RUBY_PLATFORM[/java/] and JRUBY_VERSION < '1.6.6')
+  puts "Running jekyll under jruby < 1.6.6 would never complete!"
+else
   gem 'rdoc'
   require 'rdoc/task'
   desc "Creates a symlink to rake's lib directory to support combined rdoc generation"


### PR DESCRIPTION
This commit has been tested on my jenkins. 

See the results with this patch under
- http://ngiger.dyndns.org/jenkins/job/buildr-matrix-ngiger/

Compared to the previous und
- http://ngiger.dyndns.org/jenkins/job/buildr-matrix/
