### PR TITLE
[BUILDR-701] update harmcrest dependancy version - new Harmcrest module

### DIFF
--- a/lib/buildr/java/tests.rb
+++ b/lib/buildr/java/tests.rb
@@ -134,6 +134,13 @@ module Buildr #:nodoc:
         @dependencies ||= ["org.hamcrest:hamcrest-core:jar:#{version}", "org.hamcrest:hamcrest-library:jar:#{version}"]
       end
 
+    private
+      def const_missing(const)
+        return super unless const == :REQUIRES # TODO: remove in 1.5
+        Buildr.application.deprecated "Please use Harmcrest.dependencies/.version instead of Harmcrest::REQUIRES/VERSION"
+        dependencies
+      end
+    end
   end
 
 


### PR DESCRIPTION
as seen in https://issues.apache.org/jira/browse/BUILDR-701
junit doesn't come with harmcrest dependancy, we have to add it explicitely

without, some people might experience some ClassNotFoundException

it is possible to overide harmcrest version with Buildr.settings.build['harmcrest'],
as it is done with junit or jmock
