### PR TITLE
[BUILDR-701] update harmcrest dependancy version in Jmock module

### DIFF
--- a/lib/buildr/java/tests.rb
+++ b/lib/buildr/java/tests.rb
@@ -103,8 +103,8 @@ module Buildr #:nodoc:
         @dependencies ||= ["#{group}:jmock:jar:#{version}"]
         if two_or_later
           @dependencies << "org.jmock:jmock-junit#{Buildr::JUnit.version.to_s[0,1]}:jar:#{version}"
-          @dependencies << "org.hamcrest:hamcrest-core:jar:1.1"
-          @dependencies << "org.hamcrest:hamcrest-library:jar:1.1"
+          @dependencies << "org.hamcrest:hamcrest-core:jar:1.3"
+          @dependencies << "org.hamcrest:hamcrest-library:jar:1.3"
         end
         @dependencies
       end


### PR DESCRIPTION
as seen in https://issues.apache.org/jira/browse/BUILDR-701
junit doesn't come with harmcrest dependancy, we have ta add it

without, some people might experience some ClassNotFoundException

alternative to https://github.com/apache/buildr/pull/11
