### PR TITLE
Upgrade rspec to 3.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 *.rbc
 /site
 /lib/buildr/scala/org/apache/buildr/Specs2Runner.class
+/spec/reports

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@
 * Change: Update jekyll to 3.1.3
 * Change: Update rdoc to 4.2.2
 * Added:  Travis badge to README.rdoc
-
+* Change: Update to Rspec 3.4.0
 
 1.4.25 (2016-04-18)
 * Change: BUILDR-712 Update jruby-openssl dependency version or support a range of versions

--- a/buildr.gemspec
+++ b/buildr.gemspec
@@ -84,12 +84,13 @@ for those one-off tasks, with a language that's a joy to use.
     spec.add_development_dependency 'rdoc', '4.2.2'
   end
 
-  spec.add_development_dependency 'rspec-expectations',   '2.14.3'
-  spec.add_development_dependency 'rspec-mocks',          '2.14.3'
-  spec.add_development_dependency 'rspec-core',           '2.14.5'
-  spec.add_development_dependency 'rspec',                '2.14.1'
-  spec.add_development_dependency 'rspec-retry',          '0.2.1'
-  spec.add_development_dependency 'ci_reporter',          '1.9.0'
+  spec.add_development_dependency 'rspec-expectations',   '3.4.0'
+  spec.add_development_dependency 'rspec-mocks',          '3.4.0'
+  spec.add_development_dependency 'rspec-core',           '3.4.0'
+  spec.add_development_dependency 'rspec',                '3.4.0'
+  spec.add_development_dependency 'rspec-retry',          '0.4.5'
+  spec.add_development_dependency 'ci_reporter',          '2.0.0'
+  spec.add_development_dependency 'ci_reporter_rspec',    '1.0.0'
   # Ideally we would depend on psych when the platform has >= 1.9.2 support and jruby platform version > 1.6.6
   #spec.add_development_dependency 'psych' if RUBY_VERSION >= '1.9.2'
   spec.add_development_dependency 'pygmentize', '0.0.3'

--- a/lib/buildr/core/checks.rb
+++ b/lib/buildr/core/checks.rb
@@ -43,7 +43,7 @@ module Buildr #:nodoc:
                 args = " " + @expects.map{ |arg| "'#{arg}'" }.join(", ") unless @expects.empty?
                 "Expected #{@actual} to #{name}#{args}"
               end
-              define_method :negative_failure_message do
+              define_method :failure_message_when_negated do
                 args = " " + @expects.map{ |arg| "'#{arg}'" }.join(", ") unless @expects.empty?
                 "Expected #{@actual} to not #{name}#{args}"
               end

--- a/rakelib/rspec.rake
+++ b/rakelib/rspec.rake
@@ -14,6 +14,7 @@
 # the License.
 
 require 'rspec/core/rake_task'
+require 'ci/reporter/rake/rspec'
 directory '_reports'
 
 def default_spec_opts
@@ -41,17 +42,8 @@ RSpec::Core::RakeTask.new :spec => ['_reports', :compile] do |task|
 end
 file('_reports/specs.html') { task(:spec).invoke }
 
-task :load_ci_reporter do
-  gem 'ci_reporter'
-  ENV['CI_REPORTS'] = '_reports/ci'
-  # CI_Reporter does not quote the path to rspec_loader which causes problems when ruby is installed in C:/Program Files.
-  # However, newer versions of rspec don't like double quotes escaping as well, so removing them for now.
-  ci_rep_path = Gem.loaded_specs['ci_reporter'].full_gem_path
-  ENV['SPEC_OPTS'] = [ENV['SPEC_OPTS'], default_spec_opts, '--require', "#{ci_rep_path}/lib/ci/reporter/rake/rspec_loader.rb", '--format', 'CI::Reporter::RSpec'].join(" ")
-end
-
 desc 'Run all specs with CI reporter'
-task 'ci' => %w(clobber load_ci_reporter spec)
+task 'ci' => %w(clobber ci:setup:rspec spec)
 
 task 'clobber' do
   rm_f 'failed'

--- a/spec/addon/bnd_spec.rb
+++ b/spec/addon/bnd_spec.rb
@@ -19,7 +19,7 @@ Sandbox.require_optional_extension 'buildr/bnd'
 
 def open_zip_file(file = 'target/foo-2.1.3.jar')
   jar_filename = @foo._(file)
-  File.should be_exist(jar_filename)
+  expect(File).to be_exist(jar_filename)
   Zip::File.open(jar_filename) do |zip|
     yield zip
   end
@@ -27,7 +27,7 @@ end
 
 def open_main_manifest_section(file = 'target/foo-2.1.3.jar')
   jar_filename = @foo._(file)
-  File.should be_exist(jar_filename)
+  expect(File).to be_exist(jar_filename)
   yield Buildr::Packaging::Java::Manifest.from_zip(jar_filename).main
 end
 
@@ -77,11 +77,11 @@ SRC
 
       it "version 0.0.384 does not export the version and wrong import-package" do
         open_main_manifest_section do |attribs|
-          attribs['Bundle-Name'].should eql('foo')
-          attribs['Bundle-Version'].should eql('2.1.3')
-          attribs['Bundle-SymbolicName'].should eql('mygroup.foo')
-          attribs['Export-Package'].should eql('com.biz')
-          attribs['Import-Package'].should eql('com.biz')
+          expect(attribs['Bundle-Name']).to eql('foo')
+          expect(attribs['Bundle-Version']).to eql('2.1.3')
+          expect(attribs['Bundle-SymbolicName']).to eql('mygroup.foo')
+          expect(attribs['Export-Package']).to eql('com.biz')
+          expect(attribs['Import-Package']).to eql('com.biz')
         end
       end
   end
@@ -121,70 +121,70 @@ SRC
       end
 
       it "produces a .bnd in the correct location for root project" do
-        File.should be_exist(@foo._("target/foo-2.1.3.bnd"))
+        expect(File).to be_exist(@foo._("target/foo-2.1.3.bnd"))
       end
 
       it "produces a .jar in the correct location for root project" do
-        File.should be_exist(@foo._("target/foo-2.1.3.jar"))
+        expect(File).to be_exist(@foo._("target/foo-2.1.3.jar"))
       end
 
       it "produces a .jar containing correct .class files for root project" do
         open_zip_file do |zip|
-          zip.exist?('com/biz/Foo.class').should be_true
+          expect(zip.exist?('com/biz/Foo.class')).to be_truthy
         end
       end
 
       it "produces a .jar containing resoruces from resource directory root project" do
         open_zip_file do |zip|
-          zip.exist?('IRIS-INF/iris.config').should be_true
+          expect(zip.exist?('IRIS-INF/iris.config')).to be_truthy
         end
       end
 
       it "produces a .jar containing expected manifest entries derived from project.bnd for root project" do
         open_main_manifest_section do |attribs|
-          attribs['Bundle-Name'].should eql('foo')
-          attribs['Bundle-Version'].should eql('2.1.3')
-          attribs['Bundle-SymbolicName'].should eql('mygroup.foo')
-          attribs['Export-Package'].should eql('com.biz;version="2.1.3"')
-          attribs['Import-Package'].should be_nil
+          expect(attribs['Bundle-Name']).to eql('foo')
+          expect(attribs['Bundle-Version']).to eql('2.1.3')
+          expect(attribs['Bundle-SymbolicName']).to eql('mygroup.foo')
+          expect(attribs['Export-Package']).to eql('com.biz;version="2.1.3"')
+          expect(attribs['Import-Package']).to be_nil
         end
       end
 
       it "produces a .jar containing expected manifest entries derived from project.manifest root project" do
         open_main_manifest_section do |attribs|
-          attribs['Magic-Drink'].should eql('Wine')
-          attribs['Magic-Food'].should eql('Chocolate')
+          expect(attribs['Magic-Drink']).to eql('Wine')
+          expect(attribs['Magic-Food']).to eql('Chocolate')
         end
       end
 
       it "produces a .bnd in the correct location for subproject project" do
-        File.should be_exist(@foo._("bar/target/foo-bar-2.2.bnd"))
+        expect(File).to be_exist(@foo._("bar/target/foo-bar-2.2.bnd"))
       end
 
       it "produces a .jar in the correct location for subproject project" do
-        File.should be_exist(@foo._("bar/target/foo-bar-2.2.jar"))
+        expect(File).to be_exist(@foo._("bar/target/foo-bar-2.2.jar"))
       end
 
       it "produces a .jar containing correct .class files for subproject project" do
         open_zip_file('bar/target/foo-bar-2.2.jar') do |zip|
-          zip.exist?('com/biz/bar/Bar.class').should be_true
+          expect(zip.exist?('com/biz/bar/Bar.class')).to be_truthy
         end
       end
 
       it "produces a .jar containing expected manifest entries derived from project.bnd for subproject project" do
         open_main_manifest_section('bar/target/foo-bar-2.2.jar') do |attribs|
-          attribs['Bundle-Name'].should eql('foo:bar')
-          attribs['Bundle-Version'].should eql('2.2')
-          attribs['Bundle-SymbolicName'].should eql('mygroup.foo.bar')
-          attribs['Export-Package'].should eql('com.biz.bar;version="2.2"')
-          attribs['Import-Package'].should be_nil
+          expect(attribs['Bundle-Name']).to eql('foo:bar')
+          expect(attribs['Bundle-Version']).to eql('2.2')
+          expect(attribs['Bundle-SymbolicName']).to eql('mygroup.foo.bar')
+          expect(attribs['Export-Package']).to eql('com.biz.bar;version="2.2"')
+          expect(attribs['Import-Package']).to be_nil
         end
       end
 
       it "produces a .jar containing expected manifest entries derived from project.manifest subproject project" do
         open_main_manifest_section('bar/target/foo-bar-2.2.jar') do |attribs|
-          attribs['Magic-Drink'].should eql('Wine')
-          attribs['Magic-Food'].should eql('Cheese')
+          expect(attribs['Magic-Drink']).to eql('Wine')
+          expect(attribs['Magic-Food']).to eql('Cheese')
         end
       end
     end
@@ -202,12 +202,12 @@ SRC
       end
 
       it "raise an error if unable to build a valid bundle" do
-        lambda { task('package').invoke }.should raise_error
+        expect { task('package').invoke }.to raise_error /Failed to execute java aQute\.bnd\.main\.bnd/
       end
 
       it "raise not produce an invalid jar file" do
-        lambda { task('package').invoke }.should raise_error
-        File.should_not be_exist(@foo._("target/foo-2.1.3.jar"))
+        expect { task('package').invoke }.to raise_error /Failed to execute java aQute\.bnd\.main\.bnd/
+        expect(File).not_to be_exist(@foo._("target/foo-2.1.3.jar"))
       end
     end
 
@@ -226,13 +226,13 @@ SRC
       end
 
       it "should not raise an error during packaging" do
-        lambda { task('package').invoke }.should_not raise_error
+        expect { task('package').invoke }.not_to raise_error
       end
 
       it "should generate package with files exported from dependency" do
         task('package').invoke
         open_main_manifest_section do |attribs|
-          attribs['Export-Package'].should eql('org.apache.tools.zip;version="2.1.3"')
+          expect(attribs['Export-Package']).to eql('org.apache.tools.zip;version="2.1.3"')
         end
       end
     end
@@ -258,13 +258,13 @@ SRC
       end
 
       it "should not raise an error during packaging" do
-        lambda { task('package').invoke }.should_not raise_error
+        expect { task('package').invoke }.not_to raise_error
       end
 
       it "should generate package with files exported from dependency" do
         task('package').invoke
         open_main_manifest_section do |attribs|
-          attribs['Export-Package'].should eql('org.apache.tools.zip;version="2.1.3"')
+          expect(attribs['Export-Package']).to eql('org.apache.tools.zip;version="2.1.3"')
         end
       end
     end
@@ -282,13 +282,13 @@ SRC
       end
 
       it "should not raise an error during packaging" do
-        lambda { task('package').invoke }.should_not raise_error
+        expect { task('package').invoke }.not_to raise_error
       end
 
       it "should generate package with files exported from dependency" do
         task('package').invoke
         open_main_manifest_section do |attribs|
-          attribs['Export-Package'].should eql('org.apache.tools.zip;version="2.1.3"')
+          expect(attribs['Export-Package']).to eql('org.apache.tools.zip;version="2.1.3"')
         end
       end
     end
@@ -320,64 +320,64 @@ SRC
     end
 
     it "defaults Bundle-Version to project.version" do
-      @foo.packages[0].to_params['Bundle-Version'].should eql('2.1.3')
-      @bar.packages[0].to_params['Bundle-Version'].should eql('2.1.3')
+      expect(@foo.packages[0].to_params['Bundle-Version']).to eql('2.1.3')
+      expect(@bar.packages[0].to_params['Bundle-Version']).to eql('2.1.3')
     end
 
     it "defaults -classpath to compile path and dependencies" do
-      @foo.packages[0].to_params['-classpath'].should include(@foo.compile.target.to_s)
-      @foo.packages[0].to_params['-classpath'].should include(Buildr.artifact(Buildr::Ant.dependencies[0]).to_s)
-      @bar.packages[0].to_params['-classpath'].should include(@bar.compile.target.to_s)
+      expect(@foo.packages[0].to_params['-classpath']).to include(@foo.compile.target.to_s)
+      expect(@foo.packages[0].to_params['-classpath']).to include(Buildr.artifact(Buildr::Ant.dependencies[0]).to_s)
+      expect(@bar.packages[0].to_params['-classpath']).to include(@bar.compile.target.to_s)
     end
 
     it "classpath method returns compile path and dependencies" do
-      @foo.packages[0].classpath.should include(@foo.compile.target)
+      expect(@foo.packages[0].classpath).to include(@foo.compile.target)
       Buildr::Ant.dependencies.each do |dependency|
-        @foo.packages[0].classpath.to_s.should include(Buildr.artifact(dependency).to_s)
+        expect(@foo.packages[0].classpath.to_s).to include(Buildr.artifact(dependency).to_s)
       end
-      @bar.packages[0].classpath.should include(@bar.compile.target)
+      expect(@bar.packages[0].classpath).to include(@bar.compile.target)
     end
 
     it "defaults Bundle-SymbolicName to combination of group and name" do
-      @foo.packages[0].to_params['Bundle-SymbolicName'].should eql('mygroup.foo')
-      @bar.packages[0].to_params['Bundle-SymbolicName'].should eql('mygroup.foo.bar')
+      expect(@foo.packages[0].to_params['Bundle-SymbolicName']).to eql('mygroup.foo')
+      expect(@bar.packages[0].to_params['Bundle-SymbolicName']).to eql('mygroup.foo.bar')
     end
 
     it "defaults Export-Package to nil" do
-      @foo.packages[0].to_params['Export-Package'].should be_nil
-      @bar.packages[0].to_params['Export-Package'].should be_nil
+      expect(@foo.packages[0].to_params['Export-Package']).to be_nil
+      expect(@bar.packages[0].to_params['Export-Package']).to be_nil
     end
 
     it "defaults Import-Package to nil" do
-      @foo.packages[0].to_params['Import-Package'].should be_nil
-      @bar.packages[0].to_params['Import-Package'].should be_nil
+      expect(@foo.packages[0].to_params['Import-Package']).to be_nil
+      expect(@bar.packages[0].to_params['Import-Package']).to be_nil
     end
 
     it "defaults Bundle-Name to project.name if comment not present" do
-      @foo.packages[0].to_params['Bundle-Name'].should eql('foo')
+      expect(@foo.packages[0].to_params['Bundle-Name']).to eql('foo')
     end
 
     it "defaults Bundle-Name to comment if present" do
-      @bar.packages[0].to_params['Bundle-Name'].should eql('My Bar Project')
+      expect(@bar.packages[0].to_params['Bundle-Name']).to eql('My Bar Project')
     end
 
     it "defaults Bundle-Description to project.full_comment" do
-      @foo.packages[0].to_params['Bundle-Description'].should be_nil
-      @bar.packages[0].to_params['Bundle-Description'].should eql('My Bar Project')
+      expect(@foo.packages[0].to_params['Bundle-Description']).to be_nil
+      expect(@bar.packages[0].to_params['Bundle-Description']).to eql('My Bar Project')
     end
 
     it "defaults -removeheaders to" do
-      @foo.packages[0].to_params['-removeheaders'].should eql("Include-Resource,Bnd-LastModified,Created-By,Implementation-Title,Tool")
+      expect(@foo.packages[0].to_params['-removeheaders']).to eql("Include-Resource,Bnd-LastModified,Created-By,Implementation-Title,Tool")
     end
   end
 
   describe "project extension" do
     it "provides an 'bnd:print' task" do
-      Rake::Task.tasks.detect { |task| task.to_s == "bnd:print" }.should_not be_nil
+      expect(Rake::Task.tasks.detect { |task| task.to_s == "bnd:print" }).not_to be_nil
     end
 
     it "documents the 'bnd:print' task" do
-      Rake::Task.tasks.detect { |task| task.to_s == "bnd:print" }.comment.should_not be_nil
+      expect(Rake::Task.tasks.detect { |task| task.to_s == "bnd:print" }.comment).not_to be_nil
     end
   end
 

--- a/spec/addon/checkstyle_spec.rb
+++ b/spec/addon/checkstyle_spec.rb
@@ -47,13 +47,13 @@ describe Buildr::Checkstyle do
   it 'should generate an XML report' do
     define 'foo'
     task('foo:checkstyle:xml').invoke
-    file(project('foo')._('reports/checkstyle/checkstyle.xml')).should exist
+    expect(file(project('foo')._('reports/checkstyle/checkstyle.xml'))).to exist
   end
 
   it 'should generate an HTML report' do
     define 'foo'
     task('foo:checkstyle:html').invoke
-    file(project('foo')._('reports/checkstyle/checkstyle.html')).should exist
+    expect(file(project('foo')._('reports/checkstyle/checkstyle.html'))).to exist
   end
 
 end

--- a/spec/addon/custom_pom_spec.rb
+++ b/spec/addon/custom_pom_spec.rb
@@ -26,7 +26,7 @@ Sandbox.require_optional_extension 'buildr/custom_pom'
 describe Buildr::CustomPom do
 
   def xml_document(filename)
-    File.should be_exist(filename)
+    expect(File).to be_exist(filename)
     REXML::Document.new(File.read(filename))
   end
 
@@ -35,7 +35,7 @@ describe Buildr::CustomPom do
   end
 
   def verify_license(pom_xml, name, url)
-    pom_xml.should match_xpath("/project/licenses/license/url[../name/text() = '#{name}']", url)
+    expect(pom_xml).to match_xpath("/project/licenses/license/url[../name/text() = '#{name}']", url)
   end
 
   def dependency_xpath(artifact_id)
@@ -43,19 +43,19 @@ describe Buildr::CustomPom do
   end
 
   def verify_dependency_group(pom_xml, artifact_id, group)
-    pom_xml.should match_xpath("#{dependency_xpath(artifact_id)}/groupId", group)
+    expect(pom_xml).to match_xpath("#{dependency_xpath(artifact_id)}/groupId", group)
   end
 
   def verify_dependency_version(pom_xml, artifact_id, version)
-    pom_xml.should match_xpath("#{dependency_xpath(artifact_id)}/version", version)
+    expect(pom_xml).to match_xpath("#{dependency_xpath(artifact_id)}/version", version)
   end
 
   def verify_dependency_scope(pom_xml, artifact_id, scope)
-    pom_xml.should match_xpath("#{dependency_xpath(artifact_id)}/scope", scope)
+    expect(pom_xml).to match_xpath("#{dependency_xpath(artifact_id)}/scope", scope)
   end
 
   def verify_dependency_optional(pom_xml, artifact_id, optional)
-    pom_xml.should match_xpath("#{dependency_xpath(artifact_id)}/optional", optional)
+    expect(pom_xml).to match_xpath("#{dependency_xpath(artifact_id)}/optional", optional)
   end
 
   def verify_dependency(pom_xml, artifact_id, group, version, scope, optional)
@@ -104,38 +104,38 @@ describe Buildr::CustomPom do
     end
 
     it "has correct static metadata" do
-      @pom_xml.should match_xpath("/project/modelVersion", '4.0.0')
-      @pom_xml.should match_xpath("/project/parent/groupId", 'org.sonatype.oss')
-      @pom_xml.should match_xpath("/project/parent/artifactId", 'oss-parent')
-      @pom_xml.should match_xpath("/project/parent/version", '7')
+      expect(@pom_xml).to match_xpath("/project/modelVersion", '4.0.0')
+      expect(@pom_xml).to match_xpath("/project/parent/groupId", 'org.sonatype.oss')
+      expect(@pom_xml).to match_xpath("/project/parent/artifactId", 'oss-parent')
+      expect(@pom_xml).to match_xpath("/project/parent/version", '7')
     end
 
     it "has correct project level metadata" do
-      @pom_xml.should match_xpath("/project/groupId", 'org.myproject')
-      @pom_xml.should match_xpath("/project/artifactId", 'foo')
-      @pom_xml.should match_xpath("/project/version", '1.0')
-      @pom_xml.should match_xpath("/project/packaging", 'jar')
-      @pom_xml.should match_xpath("/project/name", 'foo')
-      @pom_xml.should match_xpath("/project/description", 'foo')
-      @pom_xml.should match_xpath("/project/url", 'https://github.com/jbloggs/myproject')
+      expect(@pom_xml).to match_xpath("/project/groupId", 'org.myproject')
+      expect(@pom_xml).to match_xpath("/project/artifactId", 'foo')
+      expect(@pom_xml).to match_xpath("/project/version", '1.0')
+      expect(@pom_xml).to match_xpath("/project/packaging", 'jar')
+      expect(@pom_xml).to match_xpath("/project/name", 'foo')
+      expect(@pom_xml).to match_xpath("/project/description", 'foo')
+      expect(@pom_xml).to match_xpath("/project/url", 'https://github.com/jbloggs/myproject')
     end
 
     it "has correct scm details" do
-      @pom_xml.should match_xpath("/project/scm/connection", 'scm:git:git@github.com:jbloggs/myproject')
-      @pom_xml.should match_xpath("/project/scm/developerConnection", 'scm:git:git@github.com:jbloggs/myproject')
-      @pom_xml.should match_xpath("/project/scm/url", 'git@github.com:jbloggs/myproject')
+      expect(@pom_xml).to match_xpath("/project/scm/connection", 'scm:git:git@github.com:jbloggs/myproject')
+      expect(@pom_xml).to match_xpath("/project/scm/developerConnection", 'scm:git:git@github.com:jbloggs/myproject')
+      expect(@pom_xml).to match_xpath("/project/scm/url", 'git@github.com:jbloggs/myproject')
     end
 
     it "has correct issueManagement details" do
-      @pom_xml.should match_xpath("/project/issueManagement/url", 'https://github.com/jbloggs/myproject/issues')
-      @pom_xml.should match_xpath("/project/issueManagement/system", 'GitHub Issues')
+      expect(@pom_xml).to match_xpath("/project/issueManagement/url", 'https://github.com/jbloggs/myproject/issues')
+      expect(@pom_xml).to match_xpath("/project/issueManagement/system", 'GitHub Issues')
     end
 
     it "has correct developers details" do
-      @pom_xml.should match_xpath("/project/developers/developer/id", 'jbloggs')
-      @pom_xml.should match_xpath("/project/developers/developer/name", 'Joe Bloggs')
-      @pom_xml.should match_xpath("/project/developers/developer/email", 'jbloggs@example.com')
-      @pom_xml.should match_xpath("/project/developers/developer/roles/role", 'Project Lead')
+      expect(@pom_xml).to match_xpath("/project/developers/developer/id", 'jbloggs')
+      expect(@pom_xml).to match_xpath("/project/developers/developer/name", 'Joe Bloggs')
+      expect(@pom_xml).to match_xpath("/project/developers/developer/email", 'jbloggs@example.com')
+      expect(@pom_xml).to match_xpath("/project/developers/developer/roles/role", 'Project Lead')
     end
 
     it "has correct license details" do

--- a/spec/addon/drb_spec.rb
+++ b/spec/addon/drb_spec.rb
@@ -99,16 +99,16 @@ describe Buildr::DRbApplication do
 
   describe '.run' do
     it 'starts server if no server is running' do
-      drb.should_receive(:connect).and_raise DRb::DRbConnError
-      drb.should_receive(:run_server!)
-      drb.should_not_receive(:run_client)
+      expect(drb).to receive(:connect).and_raise DRb::DRbConnError
+      expect(drb).to receive(:run_server!)
+      expect(drb).not_to receive(:run_client)
       drb.run
     end
 
     it 'connects to an already started server' do
-      drb.should_receive(:connect).and_return "client"
-      drb.should_receive(:run_client).with "client"
-      drb.should_not_receive(:run_server!)
+      expect(drb).to receive(:connect).and_return "client"
+      expect(drb).to receive(:run_client).with "client"
+      expect(drb).not_to receive(:run_server!)
       drb.run
     end
   end
@@ -118,42 +118,42 @@ describe Buildr::DRbApplication do
     describe 'stdout' do
       it 'is redirected to client' do
         use_stdio
-        Buildr.application.should_receive(:remote_run) do
+        expect(Buildr.application).to receive(:remote_run) do
           $stdout.puts "HELLO"
         end
         remote_run
-        output.should eql("HELLO\n")
+        expect(output).to eql("HELLO\n")
       end
     end
 
     describe 'stderr' do
       it 'is redirected to client' do
         use_stdio
-        Buildr.application.should_receive(:remote_run) do
+        expect(Buildr.application).to receive(:remote_run) do
           $stderr.puts "HELLO"
         end
         remote_run
-        cfg[:err].string.should eql("HELLO\n")
+        expect(cfg[:err].string).to eql("HELLO\n")
       end
     end
 
     describe 'stdin' do
       it 'is redirected to client' do
         use_stdio
-        cfg[:in].should_receive(:gets).and_return("HELLO\n")
+        expect(cfg[:in]).to receive(:gets).and_return("HELLO\n")
         result = nil
-        Buildr.application.should_receive(:remote_run) do
+        expect(Buildr.application).to receive(:remote_run) do
           result = $stdin.gets
         end
         remote_run
-        result.should eql("HELLO\n")
+        expect(result).to eql("HELLO\n")
       end
     end
 
     describe 'server ARGV' do
       it 'is replaced with client argv' do
-        Buildr.application.should_receive(:remote_run) do
-          ARGV.should eql(['hello'])
+        expect(Buildr.application).to receive(:remote_run) do
+          expect(ARGV).to eql(['hello'])
         end
         remote_run 'hello'
       end
@@ -166,8 +166,8 @@ describe Buildr::DRbApplication do
       end
 
       it 'should load the buildfile' do
-        app.should_receive(:top_level)
-        lambda { remote_run }.should run_task('foo')
+        expect(app).to receive(:top_level)
+        expect { remote_run }.to run_task('foo')
       end
     end
 
@@ -181,59 +181,59 @@ describe Buildr::DRbApplication do
       end
 
       it 'should not reload the buildfile' do
-        app.should_not_receive(:reload_buildfile)
-        app.should_receive(:top_level)
+        expect(app).not_to receive(:reload_buildfile)
+        expect(app).to receive(:top_level)
         remote_run
       end
 
       it 'should not define projects again' do
         use_stdio
-        lambda { 2.times { remote_run 'foo:hello' } }.should_not run_task('foo')
-        output.should eql("hi\nhi\n")
+        expect { 2.times { remote_run 'foo:hello' } }.not_to run_task('foo')
+        expect(output).to eql("hi\nhi\n")
       end
 
       it 'should restore task actions' do
         use_stdio
         remote_run 'foo:empty'
-        output.should be_empty
+        expect(output).to be_empty
         2.times { remote_run 'foo:no' }
         remote_run 'foo:empty'
         actions = app.lookup('foo:empty').instance_eval { @actions }
-        actions.should be_empty # as originally defined
-        output.should be_empty
+        expect(actions).to be_empty # as originally defined
+        expect(output).to be_empty
       end
 
       it 'should restore task prerequisites' do
         use_stdio
         remote_run 'foo:empty'
-        output.should be_empty
+        expect(output).to be_empty
         2.times { remote_run 'foo:no' }
         remote_run 'foo:empty'
         pres = app.lookup('foo:empty').send(:prerequisites).map(&:to_s)
-        pres.should be_empty # as originally defined
-        output.should be_empty
+        expect(pres).to be_empty # as originally defined
+        expect(output).to be_empty
       end
 
       it 'should drop runtime created tasks' do
         remote_run 'foo:create'
-        app.lookup('created').should_not be_nil
+        expect(app.lookup('created')).not_to be_nil
         remote_run 'foo:empty'
-        app.lookup('created').should be_nil
+        expect(app.lookup('created')).to be_nil
       end
 
       it 'should restore options' do
         remote_run 'foo:setopt[bar,baz]'
-        app.options.bar.should eql("baz")
+        expect(app.options.bar).to eql("baz")
         remote_run 'foo:empty'
-        app.options.bar.should be_nil
+        expect(app.options.bar).to be_nil
       end
 
       it 'should restore rules' do
         orig = app.instance_eval { @rules.size }
         remote_run 'foo:create'
-        app.instance_eval { @rules.size }.should eql(orig + 1)
+        expect(app.instance_eval { @rules.size }).to eql(orig + 1)
         remote_run 'foo:empty'
-        app.instance_eval { @rules.size }.should eql(orig)
+        expect(app.instance_eval { @rules.size }).to eql(orig)
       end
 
     end
@@ -263,62 +263,62 @@ describe Buildr::DRbApplication do
       end
 
       it 'should reload the buildfile' do
-        app.should_receive(:reload_buildfile)
-        app.should_receive(:top_level)
+        expect(app).to receive(:reload_buildfile)
+        expect(app).to receive(:top_level)
         remote_run
       end
 
       it 'should redefine projects' do
-        lambda { remote_run }.should run_tasks('foo', 'foo:bar')
+        expect { remote_run }.to run_tasks('foo', 'foo:bar')
       end
 
       it 'should remove tasks deleted from buildfile' do
-        app.lookup('foo:delete_me').should_not be_nil
+        expect(app.lookup('foo:delete_me')).not_to be_nil
         remote_run
-        app.lookup('foo:delete_me').should be_nil
+        expect(app.lookup('foo:delete_me')).to be_nil
       end
 
       it 'should redefine tasks actions' do
         actions = app.lookup('foo:empty').instance_eval { @actions }
-        actions.should be_empty # no action
+        expect(actions).to be_empty # no action
         app.lookup('foo:no').invoke # enhance the empty task
         actions = app.lookup('foo:empty').instance_eval { @actions }
-        actions.should_not be_empty
+        expect(actions).not_to be_empty
         remote_run # cause to reload the buildfile
         actions = app.lookup('foo:empty').instance_eval { @actions }
-        actions.should be_empty # as defined on the new buildfile
+        expect(actions).to be_empty # as defined on the new buildfile
       end
 
       it 'should redefine task prerequisites' do
         pres = app.lookup('foo:empty').send(:prerequisites).map(&:to_s)
-        pres.should be_empty # no action
+        expect(pres).to be_empty # no action
         app.lookup('foo:no').invoke # enhance the empty task
         pres = app.lookup('foo:empty').send(:prerequisites).map(&:to_s)
-        pres.should_not be_empty
+        expect(pres).not_to be_empty
         remote_run # cause to reload the buildfile
         pres = app.lookup('foo:empty').send(:prerequisites).map(&:to_s)
-        pres.should be_empty # as defined on the new buildfile
+        expect(pres).to be_empty # as defined on the new buildfile
       end
 
       it 'should drop runtime created tasks' do
         app.lookup('foo:create').invoke
-        app.lookup('created').should_not be_nil
+        expect(app.lookup('created')).not_to be_nil
         remote_run 'foo:empty'
-        app.lookup('created').should be_nil
+        expect(app.lookup('created')).to be_nil
       end
 
       it 'should restore options' do
         app.options.bar = 'baz'
         remote_run 'foo:empty'
-        app.options.bar.should be_nil
+        expect(app.options.bar).to be_nil
       end
 
       it 'should redefine rules' do
         orig = app.instance_eval { @rules.size }
         app.lookup('foo:create').invoke
-        app.instance_eval { @rules.size }.should eql(orig + 1)
+        expect(app.instance_eval { @rules.size }).to eql(orig + 1)
         remote_run 'foo:empty'
-        app.instance_eval { @rules.size }.should eql(orig)
+        expect(app.instance_eval { @rules.size }).to eql(orig)
       end
 
     end

--- a/spec/addon/jaxb_xjc_spec.rb
+++ b/spec/addon/jaxb_xjc_spec.rb
@@ -110,17 +110,17 @@ describe Buildr::JaxbXjc do
     end
 
     it "produce .java files in the correct location" do
-      File.should be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/Agency.java"))
-      File.should be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/LatLongCoordinate.java"))
-      File.should be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/ObjectFactory.java"))
-      File.should be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/Wildfire.java"))
+      expect(File).to be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/Agency.java"))
+      expect(File).to be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/LatLongCoordinate.java"))
+      expect(File).to be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/ObjectFactory.java"))
+      expect(File).to be_exist(@foo._("target/generated/jaxb/main/java/org/foo/api/Wildfire.java"))
     end
 
     it "produce .class files in the correct location" do
-      File.should be_exist(@foo._("target/classes/org/foo/api/Agency.class"))
-      File.should be_exist(@foo._("target/classes/org/foo/api/LatLongCoordinate.class"))
-      File.should be_exist(@foo._("target/classes/org/foo/api/ObjectFactory.class"))
-      File.should be_exist(@foo._("target/classes/org/foo/api/Wildfire.class"))
+      expect(File).to be_exist(@foo._("target/classes/org/foo/api/Agency.class"))
+      expect(File).to be_exist(@foo._("target/classes/org/foo/api/LatLongCoordinate.class"))
+      expect(File).to be_exist(@foo._("target/classes/org/foo/api/ObjectFactory.class"))
+      expect(File).to be_exist(@foo._("target/classes/org/foo/api/Wildfire.class"))
     end
   end
 end

--- a/spec/core/application_spec.rb
+++ b/spec/core/application_spec.rb
@@ -21,37 +21,37 @@ describe Buildr::Application do
 
   describe 'home_dir' do
     it 'should point to ~/.buildr' do
-      Buildr.application.home_dir.should eql(File.expand_path('.buildr', ENV['HOME']))
+      expect(Buildr.application.home_dir).to eql(File.expand_path('.buildr', ENV['HOME']))
     end
 
     it 'should point to existing directory' do
-      File.directory?(Buildr.application.home_dir).should be_true
+      expect(File.directory?(Buildr.application.home_dir)).to be_truthy
     end
   end
 
   describe '#run' do
     it 'should execute *_load methods in order' do
       order = [:load_gems, :load_artifact_ns, :load_tasks, :raw_load_buildfile]
-      order.each { |method| Buildr.application.should_receive(method).ordered }
-      Buildr.application.stub(:exit) # With this, shows the correct error instead of SystemExit.
+      order.each { |method| expect(Buildr.application).to receive(method).ordered }
+      allow(Buildr.application).to receive(:exit) # With this, shows the correct error instead of SystemExit.
       Buildr.application.run
     end
 
     it 'should load imports after loading buildfile' do
       method = Buildr.application.method(:raw_load_buildfile)
-      Buildr.application.should_receive(:raw_load_buildfile) do
-        Buildr.application.should_receive(:load_imports)
+      expect(Buildr.application).to receive(:raw_load_buildfile) do
+        expect(Buildr.application).to receive(:load_imports)
         method.call
       end
-      Buildr.application.stub(:exit) # With this, shows the correct error instead of SystemExit.
+      allow(Buildr.application).to receive(:exit) # With this, shows the correct error instead of SystemExit.
       Buildr.application.run
     end
 
     it 'should evaluate all projects after loading buildfile' do
-      Buildr.application.should_receive(:load_imports) do
-        Buildr.should_receive(:projects)
+      expect(Buildr.application).to receive(:load_imports) do
+        expect(Buildr).to receive(:projects)
       end
-      Buildr.application.stub(:exit) # With this, shows the correct error instead of SystemExit.
+      allow(Buildr.application).to receive(:exit) # With this, shows the correct error instead of SystemExit.
       Buildr.application.run
     end
   end
@@ -59,65 +59,65 @@ describe Buildr::Application do
   describe 'environment' do
     it 'should return value of BUILDR_ENV' do
       ENV['BUILDR_ENV'] = 'qa'
-      Buildr.application.environment.should eql('qa')
+      expect(Buildr.application.environment).to eql('qa')
     end
 
     it 'should default to development' do
-      Buildr.application.environment.should eql('development')
+      expect(Buildr.application.environment).to eql('development')
     end
 
     it 'should set environment name from -e argument' do
       ARGV.push('-e', 'test')
       Buildr.application.send(:handle_options)
-      Buildr.application.environment.should eql('test')
-      ENV['BUILDR_ENV'].should eql('test')
+      expect(Buildr.application.environment).to eql('test')
+      expect(ENV['BUILDR_ENV']).to eql('test')
     end
 
     it 'should be echoed to user' do
       write 'buildfile'
       ENV['BUILDR_ENV'] = 'spec'
       Buildr.application.send(:handle_options)
-      lambda { Buildr.application.send :load_buildfile }.should show(%r{(in .*, spec)})
+      expect { Buildr.application.send :load_buildfile }.to show(%r{(in .*, spec)})
     end
   end
 
   describe 'options' do
     it "should have 'tasks' as the sole default rakelib" do
       Buildr.application.send(:handle_options)
-      Buildr.application.options.rakelib.should == ['tasks']
+      expect(Buildr.application.options.rakelib).to eq(['tasks'])
     end
 
     it 'should show the version when prompted with -V' do
       ARGV.push('-V')
-      test_exit(0) { Buildr.application.send(:handle_options) }.should show(/Buildr #{Buildr::VERSION}.*/)
+      expect(test_exit(0) { Buildr.application.send(:handle_options) }).to show(/Buildr #{Buildr::VERSION}.*/)
     end
 
     it 'should show the version when prompted with --version' do
       ARGV.push('--version')
-      test_exit(0) { Buildr.application.send(:handle_options) }.should show(/Buildr #{Buildr::VERSION}.*/)
+      expect(test_exit(0) { Buildr.application.send(:handle_options) }).to show(/Buildr #{Buildr::VERSION}.*/)
     end
 
     it 'should enable tracing with --trace' do
       ARGV.push('--trace')
       Buildr.application.send(:handle_options)
-      Buildr.application.options.trace.should == true
+      expect(Buildr.application.options.trace).to eq(true)
     end
 
     it 'should enable tracing of [:foo, :bar] categories with --trace=foo,bar' do
       ARGV.push('--trace=foo,bar')
       Buildr.application.send(:handle_options)
-      Buildr.application.options.trace.should == true
-      Buildr.application.options.trace_categories.should == [:foo, :bar]
-      trace?(:foo).should == true
-      trace?(:not).should == false
+      expect(Buildr.application.options.trace).to eq(true)
+      expect(Buildr.application.options.trace_categories).to eq([:foo, :bar])
+      expect(trace?(:foo)).to eq(true)
+      expect(trace?(:not)).to eq(false)
     end
 
     it 'should enable tracing for all categories with --trace=all' do
       ARGV.push('--trace=all')
       Buildr.application.send(:handle_options)
-      Buildr.application.options.trace.should == true
-      Buildr.application.options.trace_all.should == true
-      trace?(:foo).should == true
+      expect(Buildr.application.options.trace).to eq(true)
+      expect(Buildr.application.options.trace_all).to eq(true)
+      expect(trace?(:foo)).to eq(true)
     end
 
   end
@@ -135,33 +135,33 @@ describe Buildr::Application do
         - rake
         - rspec ~> 2.9.0
       YAML
-      Buildr.application.should_receive(:listed_gems).and_return([[Gem.loaded_specs['rspec'],Gem.loaded_specs['rake']],[]])
+      expect(Buildr.application).to receive(:listed_gems).and_return([[Gem.loaded_specs['rspec'],Gem.loaded_specs['rake']],[]])
       Buildr.application.load_gems
     end
 
     it 'should return empty array if no gems specified' do
       Buildr.application.load_gems
-      Buildr.application.gems.should be_empty
+      expect(Buildr.application.gems).to be_empty
     end
 
     it 'should return one entry for each gem specified in buildr.yaml' do
       load_with_yaml
-      Buildr.application.gems.size.should be(2)
+      expect(Buildr.application.gems.size).to be(2)
     end
 
     it 'should return a Gem::Specification for each installed gem' do
       load_with_yaml
-      Buildr.application.gems.each { |gem| gem.should be_kind_of(Bundler::StubSpecification) }
+      Buildr.application.gems.each { |gem| expect(gem).to be_kind_of(Bundler::StubSpecification) }
     end
 
     it 'should parse Gem name correctly' do
       load_with_yaml
-      Buildr.application.gems.map(&:name).should include('rspec', 'rake')
+      expect(Buildr.application.gems.map(&:name)).to include('rspec', 'rake')
     end
 
     it 'should find installed version of Gem' do
       load_with_yaml
-      Buildr.application.gems.each { |gem| gem.version.should eql(Gem.loaded_specs[gem.name].version) }
+      Buildr.application.gems.each { |gem| expect(gem.version).to eql(Gem.loaded_specs[gem.name].version) }
     end
   end
 
@@ -174,27 +174,27 @@ describe Buildr::Application do
         spec.name = 'buildr-foo'
         spec.version = '1.2'
       end
-      $stdout.stub(:isatty).and_return(true)
+      allow($stdout).to receive(:isatty).and_return(true)
     end
 
     it 'should do nothing if no gems specified' do
-      lambda { Buildr.application.load_gems }.should_not raise_error
+      expect { Buildr.application.load_gems }.not_to raise_error
     end
 
     it 'should install nothing if specified gems already installed' do
-      Buildr.application.should_receive(:listed_gems).and_return([[Gem.loaded_specs['rspec']],[]])
-      Util.should_not_receive(:ruby)
-      lambda { Buildr.application.load_gems }.should_not raise_error
+      expect(Buildr.application).to receive(:listed_gems).and_return([[Gem.loaded_specs['rspec']],[]])
+      expect(Util).not_to receive(:ruby)
+      expect { Buildr.application.load_gems }.not_to raise_error
     end
 
     it 'should fail if required gem not installed' do
-      Buildr.application.should_receive(:listed_gems).and_return([[],[Gem::Dependency.new('buildr-foo', '>=1.1')]])
-      lambda { Buildr.application.load_gems }.should raise_error(LoadError, /cannot be found/i)
+      expect(Buildr.application).to receive(:listed_gems).and_return([[],[Gem::Dependency.new('buildr-foo', '>=1.1')]])
+      expect { Buildr.application.load_gems }.to raise_error(LoadError, /cannot be found/i)
     end
 
     it 'should load previously installed gems' do
-      Gem.loaded_specs['rspec'].should_receive(:activate)
-      Buildr.application.should_receive(:listed_gems).and_return([[Gem.loaded_specs['rspec']],[]])
+      expect(Gem.loaded_specs['rspec']).to receive(:activate)
+      expect(Buildr.application).to receive(:listed_gems).and_return([[Gem.loaded_specs['rspec']],[]])
       #Buildr.application.should_receive(:gem).with('rspec', Gem.loaded_specs['rspec'].version.to_s)
       Buildr.application.load_gems
     end
@@ -221,7 +221,7 @@ describe Buildr::Application do
 
     def should_attempt_to_load_dependency(dep)
       missing_gems = Buildr.application.send(:listed_gems)[1]
-      missing_gems.size.should eql(1)
+      expect(missing_gems.size).to eql(1)
       missing_gems[0].eql?(dep)
     end
   end
@@ -256,21 +256,21 @@ describe Buildr::Application do
 
     it "should load {options.rakelib}/foo.rake" do
       write_task 'tasks/foo.rake'
-      loaded_tasks.should have(1).task
-      loaded_tasks.first.should =~ %r{tasks/foo\.rake$}
+      expect(loaded_tasks.size).to eq(1)
+      expect(loaded_tasks.first).to match(%r{tasks/foo\.rake$})
     end
 
     it 'should load all *.rake files from the rakelib' do
       write_task 'tasks/bar.rake'
       write_task 'tasks/quux.rake'
-      loaded_tasks.should have(2).tasks
+      expect(loaded_tasks.size).to eq(2)
     end
 
     it 'should not load files which do not have the .rake extension' do
       write_task 'tasks/foo.rb'
       write_task 'tasks/bar.rake'
-      loaded_tasks.should have(1).task
-      loaded_tasks.first.should =~ %r{tasks/bar\.rake$}
+      expect(loaded_tasks.size).to eq(1)
+      expect(loaded_tasks.first).to match(%r{tasks/bar\.rake$})
     end
 
     it 'should load files only from the directory specified in the rakelib option' do
@@ -278,9 +278,9 @@ describe Buildr::Application do
       write_task 'extensions/amp.rake'
       write_task 'tasks/bar.rake'
       write_task 'extensions/foo.rake'
-      loaded_tasks.should have(2).tasks
+      expect(loaded_tasks.size).to eq(2)
       %w[amp foo].each do |filename|
-        loaded_tasks.select{|x| x =~ %r{extensions/#{filename}\.rake}}.should have(1).entry
+        expect(loaded_tasks.select{|x| x =~ %r{extensions/#{filename}\.rake}}.size).to eq(1)
       end
     end
 
@@ -290,7 +290,7 @@ describe Buildr::Application do
       write_task 'tasks/bar.rake'
       write_task 'tasks/zeb.rake'
       write_task 'more/baz.rake'
-      loaded_tasks.should have(4).tasks
+      expect(loaded_tasks.size).to eq(4)
     end
 
     it 'should not load files from the rakelib more than once' do
@@ -298,8 +298,8 @@ describe Buildr::Application do
       write_task 'tasks/already.rake'
       $LOADED_FEATURES << File.expand_path('tasks/already.rake')
 
-      loaded_tasks.should have(1).task
-      loaded_tasks.first.should =~ %r{tasks/new_one\.rake$}
+      expect(loaded_tasks.size).to eq(1)
+      expect(loaded_tasks.first).to match(%r{tasks/new_one\.rake$})
     end
   end
 
@@ -344,14 +344,14 @@ describe Buildr::Application do
             raise MyOwnNicelyNamedException.new('My message')
           end
         }.call
-        $stderr.messages.select {|msg| msg =~ /.*MyOwnNicelyNamedException : My message.*/}.size.should == 1
+        expect($stderr.messages.select {|msg| msg =~ /.*MyOwnNicelyNamedException : My message.*/}.size).to eq(1)
         $stderr.messages.clear
         test_exit(1) {
           Buildr.application.send :standard_exception_handling do
             raise Exception.new('My message')
           end
         }.call
-        $stderr.messages.select {|msg| msg =~ /.*My message.*/ && !(msg =~ /Exception/)}.size.should == 1
+        expect($stderr.messages.select {|msg| msg =~ /.*My message.*/ && !(msg =~ /Exception/)}.size).to eq(1)
       end
       $stderr = old_stderr
     end
@@ -365,59 +365,59 @@ describe Buildr, 'settings' do
   describe 'user' do
 
     it 'should be empty hash if no settings.yaml file' do
-      Buildr.settings.user.should == {}
+      expect(Buildr.settings.user).to eq({})
     end
 
     it 'should return loaded settings.yaml file' do
       write 'home/.buildr/settings.yaml', 'foo: bar'
-      Buildr.settings.user.should == { 'foo'=>'bar' }
+      expect(Buildr.settings.user).to eq({ 'foo'=>'bar' })
     end
 
     it 'should return loaded settings.yml file' do
       write 'home/.buildr/settings.yml', 'foo: bar'
-      Buildr.settings.user.should == { 'foo'=>'bar' }
+      expect(Buildr.settings.user).to eq({ 'foo'=>'bar' })
     end
 
     it 'should fail if settings.yaml file is not a hash' do
       write 'home/.buildr/settings.yaml', 'foo bar'
-      lambda { Buildr.settings.user }.should raise_error(RuntimeError, /expecting.*settings.yaml/i)
+      expect { Buildr.settings.user }.to raise_error(RuntimeError, /expecting.*settings.yaml/i)
     end
 
     it 'should be empty hash if settings.yaml file is empty' do
       write 'home/.buildr/settings.yaml'
-      Buildr.settings.user.should == {}
+      expect(Buildr.settings.user).to eq({})
     end
   end
 
   describe 'configuration' do
     it 'should be empty hash if no build.yaml file' do
-      Buildr.settings.build.should == {}
+      expect(Buildr.settings.build).to eq({})
     end
 
     it 'should return loaded build.yaml file' do
       write 'build.yaml', 'foo: bar'
-      Buildr.settings.build.should == { 'foo'=>'bar' }
+      expect(Buildr.settings.build).to eq({ 'foo'=>'bar' })
     end
 
     it 'should return loaded build.yml file' do
       write 'build.yml', 'foo: bar'
-      Buildr.settings.build.should == { 'foo'=>'bar' }
+      expect(Buildr.settings.build).to eq({ 'foo'=>'bar' })
     end
 
     it 'should fail if build.yaml file is not a hash' do
       write 'build.yaml', 'foo bar'
-      lambda { Buildr.settings.build }.should raise_error(RuntimeError, /expecting.*build.yaml/i)
+      expect { Buildr.settings.build }.to raise_error(RuntimeError, /expecting.*build.yaml/i)
     end
 
     it 'should be empty hash if build.yaml file is empty' do
       write 'build.yaml'
-      Buildr.settings.build.should == {}
+      expect(Buildr.settings.build).to eq({})
     end
   end
 
   describe 'profiles' do
     it 'should be empty hash if no profiles.yaml file' do
-      Buildr.settings.profiles.should == {}
+      expect(Buildr.settings.profiles).to eq({})
     end
 
     it 'should return loaded profiles.yaml file' do
@@ -425,7 +425,7 @@ describe Buildr, 'settings' do
         development:
           foo: bar
       YAML
-      Buildr.settings.profiles.should == { 'development'=> { 'foo'=>'bar' } }
+      expect(Buildr.settings.profiles).to eq({ 'development'=> { 'foo'=>'bar' } })
     end
 
     it 'should return loaded profiles.yml file' do
@@ -433,17 +433,17 @@ describe Buildr, 'settings' do
         development:
           foo: bar
       YAML
-      Buildr.settings.profiles.should == { 'development'=> { 'foo'=>'bar' } }
+      expect(Buildr.settings.profiles).to eq({ 'development'=> { 'foo'=>'bar' } })
     end
 
     it 'should fail if profiles.yaml file is not a hash' do
       write 'profiles.yaml', 'foo bar'
-      lambda { Buildr.settings.profiles }.should raise_error(RuntimeError, /expecting.*profiles.yaml/i)
+      expect { Buildr.settings.profiles }.to raise_error(RuntimeError, /expecting.*profiles.yaml/i)
     end
 
     it 'should be empty hash if profiles.yaml file is empty' do
       write 'profiles.yaml'
-      Buildr.settings.profiles.should == {}
+      expect(Buildr.settings.profiles).to eq({})
     end
   end
 
@@ -452,7 +452,7 @@ describe Buildr, 'settings' do
     end
 
     it 'should be empty hash if no profiles.yaml' do
-      Buildr.settings.profile.should == {}
+      expect(Buildr.settings.profile).to eq({})
     end
 
     it 'should be empty hash if no matching profile' do
@@ -460,7 +460,7 @@ describe Buildr, 'settings' do
         test:
           foo: bar
       YAML
-      Buildr.settings.profile.should == {}
+      expect(Buildr.settings.profile).to eq({})
     end
 
     it 'should return profile matching environment name' do
@@ -470,7 +470,7 @@ describe Buildr, 'settings' do
         test:
           foo: baz
       YAML
-      Buildr.settings.profile.should == { 'foo'=>'bar' }
+      expect(Buildr.settings.profile).to eq({ 'foo'=>'bar' })
     end
   end
 
@@ -481,37 +481,37 @@ describe Buildr, 'settings' do
     end
 
     it 'should point to the buildfile' do
-      Buildr.application.buildfile.should point_to_path('buildfile')
+      expect(Buildr.application.buildfile).to point_to_path('buildfile')
     end
 
     it 'should be a defined task' do
-      Buildr.application.buildfile.should == file(File.expand_path('buildfile'))
+      expect(Buildr.application.buildfile).to eq(file(File.expand_path('buildfile')))
     end
 
     it 'should ignore any rake namespace' do
       namespace 'dummy_ns' do
-        Buildr.application.buildfile.should point_to_path('buildfile')
+        expect(Buildr.application.buildfile).to point_to_path('buildfile')
       end
     end
 
     it 'should have the same timestamp as the buildfile' do
-      Buildr.application.buildfile.timestamp.should be_within(1).of(@buildfile_time)
+      expect(Buildr.application.buildfile.timestamp).to be_within(1).of(@buildfile_time)
     end
 
     it 'should have the same timestamp as build.yaml if the latter is newer' do
       write 'build.yaml'; File.utime(@buildfile_time + 5, @buildfile_time + 5, 'build.yaml')
       Buildr.application.run
-      Buildr.application.buildfile.timestamp.should be_within(1).of(@buildfile_time + 5)
+      expect(Buildr.application.buildfile.timestamp).to be_within(1).of(@buildfile_time + 5)
     end
 
     it 'should have the same timestamp as the buildfile if build.yaml is older' do
       write 'build.yaml'; File.utime(@buildfile_time - 5, @buildfile_time - 5, 'build.yaml')
       Buildr.application.run
-      Buildr.application.buildfile.timestamp.should be_within(1).of(@buildfile_time)
+      expect(Buildr.application.buildfile.timestamp).to be_within(1).of(@buildfile_time)
     end
 
     it 'should have the same timestamp as build.rb in home dir if the latter is newer (until version 1.6)' do
-      Buildr::VERSION.should < '1.6'
+      expect(Buildr::VERSION).to be < '1.6'
       buildfile_should_have_same_timestamp_as 'home/buildr.rb'
     end
 
@@ -530,7 +530,7 @@ describe Buildr, 'settings' do
     def buildfile_should_have_same_timestamp_as(file)
       write file; File.utime(@buildfile_time + 5, @buildfile_time + 5, file)
       Buildr.application.send :load_tasks
-      Buildr.application.buildfile.timestamp.should be_within(1).of(@buildfile_time + 5)
+      expect(Buildr.application.buildfile.timestamp).to be_within(1).of(@buildfile_time + 5)
     end
   end
 end
@@ -540,19 +540,19 @@ describe Buildr do
 
   describe 'environment' do
     it 'should be same as Buildr.application.environment' do
-      Buildr.environment.should eql(Buildr.application.environment)
+      expect(Buildr.environment).to eql(Buildr.application.environment)
     end
   end
 
   describe 'application' do
     it 'should be same as Rake.application' do
-      Buildr.application.should == Rake.application
+      expect(Buildr.application).to eq(Rake.application)
     end
   end
 
   describe 'settings' do
     it 'should be same as Buildr.application.settings' do
-      Buildr.settings.should == Buildr.application.settings
+      expect(Buildr.settings).to eq(Buildr.application.settings)
     end
   end
 
@@ -568,7 +568,7 @@ describe Rake do
        chain1 = Thread.current[:rake_chain]
        task1.invoke
        chain2 = Thread.current[:rake_chain]
-       chain2.should == chain1
+       expect(chain2).to eq(chain1)
      end
 
      task2.invoke

--- a/spec/core/build_spec.rb
+++ b/spec/core/build_spec.rb
@@ -19,12 +19,12 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers')
 shared_examples_for 'local task' do
   it "should execute task for project in current directory" do
     define 'foobar'
-    lambda { @task.invoke }.should run_task("foobar:#{@task.name}")
+    expect { @task.invoke }.to run_task("foobar:#{@task.name}")
   end
 
   it "should not execute task for projects in other directory" do
     define 'foobar', :base_dir=>'elsewhere'
-    lambda { task('build').invoke }.should_not run_task('foobar:build')
+    expect { task('build').invoke }.not_to run_task('foobar:build')
   end
 end
 
@@ -44,7 +44,7 @@ describe 'package task' do
   before(:each) { @task = task('package') }
 
   it 'should execute build task as prerequisite' do
-    lambda { @task.invoke }.should run_task('build')
+    expect { @task.invoke }.to run_task('build')
   end
 end
 
@@ -53,7 +53,7 @@ describe 'install task' do
   before(:each) { @task = task('install') }
 
   it 'should execute package task as prerequisite' do
-    lambda { @task.invoke }.should run_task('package')
+    expect { @task.invoke }.to run_task('package')
   end
 end
 
@@ -67,14 +67,14 @@ describe 'upload task' do
   before(:each) { @task = task('upload') }
 
   it 'should execute package task as prerequisite' do
-    lambda { @task.invoke }.should run_task('package')
+    expect { @task.invoke }.to run_task('package')
   end
 end
 
 
 describe Project, '#build' do
   it 'should return the project\'s build task' do
-    define('foo').build.should eql(task('foo:build'))
+    expect(define('foo').build).to eql(task('foo:build'))
   end
 
   it 'should enhance the project\'s build task' do
@@ -85,27 +85,27 @@ describe Project, '#build' do
         task('action').invoke
       end
     end
-    lambda { project('foo').build.invoke }.should run_tasks('prereq', 'action')
+    expect { project('foo').build.invoke }.to run_tasks('prereq', 'action')
   end
 
   it 'should execute build task for sub-project' do
     define 'foo' do
       define 'bar'
     end
-    lambda { task('foo:build').invoke }.should run_task('foo:bar:build')
+    expect { task('foo:build').invoke }.to run_task('foo:bar:build')
   end
 
   it 'should not execute build task of other projects' do
     define 'foo'
     define 'bar'
-    lambda { task('foo:build').invoke }.should_not run_task('bar:build')
+    expect { task('foo:build').invoke }.not_to run_task('bar:build')
   end
 end
 
 
 describe Project, '#clean' do
   it 'should return the project\'s clean task' do
-    define('foo').clean.should eql(task('foo:clean'))
+    expect(define('foo').clean).to eql(task('foo:clean'))
   end
 
   it 'should enhance the project\'s clean task' do
@@ -116,7 +116,7 @@ describe Project, '#clean' do
         task('action').invoke
       end
     end
-    lambda { project('foo').clean.invoke }.should run_tasks('prereq', 'action')
+    expect { project('foo').clean.invoke }.to run_tasks('prereq', 'action')
   end
 
   it 'should remove target directory' do
@@ -124,7 +124,7 @@ describe Project, '#clean' do
       self.layout[:target] = 'targeted'
     end
     mkpath 'targeted'
-    lambda { project('foo').clean.invoke }.should change { File.exist?('targeted') }.from(true).to(false)
+    expect { project('foo').clean.invoke }.to change { File.exist?('targeted') }.from(true).to(false)
   end
 
   it 'should remove reports directory' do
@@ -132,20 +132,20 @@ describe Project, '#clean' do
       self.layout[:reports] = 'reported'
     end
     mkpath 'reported'
-    lambda { project('foo').clean.invoke }.should change { File.exist?('reported') }.from(true).to(false)
+    expect { project('foo').clean.invoke }.to change { File.exist?('reported') }.from(true).to(false)
   end
 
   it 'should execute clean task for sub-project' do
     define 'foo' do
       define 'bar'
     end
-    lambda { task('foo:clean').invoke }.should run_task('foo:bar:clean')
+    expect { task('foo:clean').invoke }.to run_task('foo:bar:clean')
   end
 
   it 'should not execute clean task of other projects' do
     define 'foo'
     define 'bar'
-    lambda { task('foo:clean').invoke }.should_not run_task('bar:clean')
+    expect { task('foo:clean').invoke }.not_to run_task('bar:clean')
   end
 end
 
@@ -156,21 +156,21 @@ describe Project, '#target' do
   end
 
   it 'should default to target' do
-    @project.target.should eql('target')
+    expect(@project.target).to eql('target')
   end
 
   it 'should set layout :target' do
     @project.target = 'bar'
-    @project.layout.expand(:target).should point_to_path('bar')
+    expect(@project.layout.expand(:target)).to point_to_path('bar')
   end
 
   it 'should come from layout :target' do
     @project.layout[:target] = 'baz'
-    @project.target.should eql('baz')
+    expect(@project.target).to eql('baz')
   end
 
   it 'should be removed in version 1.5 since it was deprecated in version 1.3' do
-    Buildr::VERSION.should < '1.5'
+    expect(Buildr::VERSION).to be < '1.5'
   end
 end
 
@@ -181,21 +181,21 @@ describe Project, '#reports' do
   end
 
   it 'should default to reports' do
-    @project.reports.should eql('reports')
+    expect(@project.reports).to eql('reports')
   end
 
   it 'should set layout :reports' do
     @project.reports = 'bar'
-    @project.layout.expand(:reports).should point_to_path('bar')
+    expect(@project.layout.expand(:reports)).to point_to_path('bar')
   end
 
   it 'should come from layout :reports' do
     @project.layout[:reports] = 'baz'
-    @project.reports.should eql('baz')
+    expect(@project.reports).to eql('baz')
   end
 
   it 'should be removed in version 1.5 since it was deprecated in version 1.3' do
-    Buildr::VERSION.should < '1.5'
+    expect(Buildr::VERSION).to be < '1.5'
   end
 end
 
@@ -203,14 +203,14 @@ end
 describe Hg do
   describe '#current_branch' do
     it 'should return the correct branch' do
-      Hg.should_receive(:hg).with('branch').and_return("default\n")
-      Hg.send(:current_branch).should == 'default'
+      expect(Hg).to receive(:hg).with('branch').and_return("default\n")
+      expect(Hg.send(:current_branch)).to eq('default')
     end
   end
 
   describe '#uncommitted_files' do
     it 'should return an array of modified files' do
-      Hg.should_receive(:`).with('hg status').and_return <<-EOF
+      expect(Hg).to receive(:`).with('hg status').and_return <<-EOF
 M abc.txt
 M xyz.txt
 R hello
@@ -219,42 +219,42 @@ R removed
 A README
 ? ignore.txt
       EOF
-      Hg.uncommitted_files.should include('abc.txt', 'xyz.txt', 'hello', 'README', 'conflict', 'ignore.txt')
+      expect(Hg.uncommitted_files).to include('abc.txt', 'xyz.txt', 'hello', 'README', 'conflict', 'ignore.txt')
     end
   end
 
   describe '#uncommitted_files' do
     it 'should return an empty array on a clean repository' do
-      Hg.should_receive(:`).with('hg status').and_return "\n"
-      Hg.uncommitted_files.should be_empty
+      expect(Hg).to receive(:`).with('hg status').and_return "\n"
+      expect(Hg.uncommitted_files).to be_empty
     end
   end
 
   describe '#remote' do
     it 'should return the aliases of the default remote repositories' do
-      Hg.should_receive(:hg).with('paths').and_return <<-EOF
+      expect(Hg).to receive(:hg).with('paths').and_return <<-EOF
 default = https://hg.apache.org/repo/my-repo
     EOF
-    Hg.send(:remote).should include('https://hg.apache.org/repo/my-repo')
+    expect(Hg.send(:remote)).to include('https://hg.apache.org/repo/my-repo')
     end
 
     it 'should return the aliases of the default push remote repositories' do
-      Hg.should_receive(:hg).with('paths').and_return <<-EOF
+      expect(Hg).to receive(:hg).with('paths').and_return <<-EOF
 default-push = https://hg.apache.org/repo/my-repo
     EOF
-    Hg.send(:remote).should include('https://hg.apache.org/repo/my-repo')
+    expect(Hg.send(:remote)).to include('https://hg.apache.org/repo/my-repo')
     end
 
     it 'should return empty array when no remote repositories found' do
-      Hg.should_receive(:hg).with('paths').and_return "\n"
-      Hg.send(:remote).should be_empty
+      expect(Hg).to receive(:hg).with('paths').and_return "\n"
+      expect(Hg.send(:remote)).to be_empty
     end
 
     it 'should return empty array when no default-push remote repository found' do
-      Hg.should_receive(:hg).with('paths').and_return <<-EOF
+      expect(Hg).to receive(:hg).with('paths').and_return <<-EOF
 blah = https://bitbucket.org/sample-repo
       EOF
-      Hg.send(:remote).should be_empty
+      expect(Hg.send(:remote)).to be_empty
     end
   end
 end # end of Hg
@@ -263,15 +263,15 @@ end # end of Hg
 describe Git do
   describe '#uncommitted_files' do
     it 'should return an empty array on a clean repository' do
-      Git.should_receive(:`).with('git status').and_return <<-EOF
+      expect(Git).to receive(:`).with('git status').and_return <<-EOF
 # On branch master
 nothing to commit (working directory clean)
       EOF
-      Git.uncommitted_files.should be_empty
+      expect(Git.uncommitted_files).to be_empty
     end
 
     it 'should reject a dirty repository, Git 1.4.2 or former' do
-      Git.should_receive(:`).with('git status').and_return <<-EOF
+      expect(Git).to receive(:`).with('git status').and_return <<-EOF
 # On branch master
 #
 # Changed but not updated:
@@ -286,11 +286,11 @@ nothing to commit (working directory clean)
 #
 #       error.log
       EOF
-      Git.uncommitted_files.should include('lib/buildr.rb', 'error.log')
+      expect(Git.uncommitted_files).to include('lib/buildr.rb', 'error.log')
     end
 
     it 'should reject a dirty repository, Git 1.4.3 or higher' do
-      Git.should_receive(:`).with('git status').and_return <<-EOF
+      expect(Git).to receive(:`).with('git status').and_return <<-EOF
 # On branch master
 # Changed but not updated:
 #   (use "git add <file>..." to update what will be committed)
@@ -304,28 +304,28 @@ nothing to commit (working directory clean)
 #\terror.log
 no changes added to commit (use "git add" and/or "git commit -a")
       EOF
-      Git.uncommitted_files.should include('lib/buildr.rb', 'error.log')
+      expect(Git.uncommitted_files).to include('lib/buildr.rb', 'error.log')
     end
   end
 
   describe '#remote' do
     it 'should return the name of the corresponding remote' do
-      Git.should_receive(:git).with('config', '--get', 'branch.master.remote').and_return "origin\n"
-      Git.should_receive(:git).with('remote').and_return "upstream\norigin\n"
-      Git.send(:remote, 'master').should == 'origin'
+      expect(Git).to receive(:git).with('config', '--get', 'branch.master.remote').and_return "origin\n"
+      expect(Git).to receive(:git).with('remote').and_return "upstream\norigin\n"
+      expect(Git.send(:remote, 'master')).to eq('origin')
     end
 
     it 'should return nil if no remote for the given branch' do
-      Git.should_receive(:git).with('config', '--get', 'branch.master.remote').and_return "\n"
-      Git.should_not_receive(:git).with('remote')
-      Git.send(:remote, 'master').should be_nil
+      expect(Git).to receive(:git).with('config', '--get', 'branch.master.remote').and_return "\n"
+      expect(Git).not_to receive(:git).with('remote')
+      expect(Git.send(:remote, 'master')).to be_nil
     end
   end
 
   describe '#current_branch' do
     it 'should return the current branch' do
-      Git.should_receive(:git).with('branch').and_return("  master\n* a-clever-idea\n  ze-great-idea")
-      Git.send(:current_branch).should == 'a-clever-idea'
+      expect(Git).to receive(:git).with('branch').and_return("  master\n* a-clever-idea\n  ze-great-idea")
+      expect(Git.send(:current_branch)).to eq('a-clever-idea')
     end
   end
 
@@ -335,17 +335,17 @@ end # of Git
 describe Svn do
   describe '#tag' do
     it 'should remove any existing tag with the same name' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/trunk')
-      Svn.stub(:copy)
-      Svn.should_receive(:remove).with('http://my.repo.org/foo/tags/1.0.0', 'Removing old copy')
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/trunk')
+      allow(Svn).to receive(:copy)
+      expect(Svn).to receive(:remove).with('http://my.repo.org/foo/tags/1.0.0', 'Removing old copy')
 
       Svn.tag '1.0.0'
     end
 
     it 'should do an svn copy with the release version' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/trunk')
-      Svn.stub(:remove)
-      Svn.should_receive(:copy).with(Dir.pwd, 'http://my.repo.org/foo/tags/1.0.0', 'Release 1.0.0')
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/trunk')
+      allow(Svn).to receive(:remove)
+      expect(Svn).to receive(:copy).with(Dir.pwd, 'http://my.repo.org/foo/tags/1.0.0', 'Release 1.0.0')
 
       Svn.tag '1.0.0'
     end
@@ -354,24 +354,24 @@ describe Svn do
   # Reference: http://svnbook.red-bean.com/en/1.4/svn.reposadmin.planning.html#svn.reposadmin.projects.chooselayout
   describe '#tag_url' do
     it 'should accept to tag foo/trunk' do
-      Svn.tag_url('http://my.repo.org/foo/trunk', '1.0.0').should == 'http://my.repo.org/foo/tags/1.0.0'
+      expect(Svn.tag_url('http://my.repo.org/foo/trunk', '1.0.0')).to eq('http://my.repo.org/foo/tags/1.0.0')
     end
 
     it 'should accept to tag foo/branches/1.0' do
-      Svn.tag_url('http://my.repo.org/foo/branches/1.0', '1.0.1').should == 'http://my.repo.org/foo/tags/1.0.1'
+      expect(Svn.tag_url('http://my.repo.org/foo/branches/1.0', '1.0.1')).to eq('http://my.repo.org/foo/tags/1.0.1')
     end
 
     it 'should accept to tag trunk/foo' do
-      Svn.tag_url('http://my.repo.org/trunk/foo', '1.0.0').should == 'http://my.repo.org/tags/foo/1.0.0'
+      expect(Svn.tag_url('http://my.repo.org/trunk/foo', '1.0.0')).to eq('http://my.repo.org/tags/foo/1.0.0')
     end
 
     it 'should accept to tag branches/foo/1.0' do
-      Svn.tag_url('http://my.repo.org/branches/foo/1.0', '1.0.0').should == 'http://my.repo.org/tags/foo/1.0.0'
+      expect(Svn.tag_url('http://my.repo.org/branches/foo/1.0', '1.0.0')).to eq('http://my.repo.org/tags/foo/1.0.0')
     end
 
     describe '#repo_url' do
       it 'should extract the SVN URL from svn info' do
-        Svn.should_receive(:svn).and_return <<-XML
+        expect(Svn).to receive(:svn).and_return <<-XML
 <?xml version="1.0"?>
 <info>
 <entry
@@ -395,7 +395,7 @@ describe Svn do
 </entry>
 </info>
         XML
-        Svn.repo_url.should == 'http://my.repo.org/foo/trunk'
+        expect(Svn.repo_url).to eq('http://my.repo.org/foo/trunk')
       end
     end
 
@@ -408,17 +408,17 @@ describe Release do
   describe 'find' do
     it 'should return HgRelease if project uses Hg' do
       write '.hg/requires'
-      Release.find.should be_instance_of(HgRelease)
+      expect(Release.find).to be_instance_of(HgRelease)
     end
 
     it 'should return GitRelease if project uses Git' do
       write '.git/config'
-      Release.find.should be_instance_of(GitRelease)
+      expect(Release.find).to be_instance_of(GitRelease)
     end
 
     it 'should return SvnRelease if project uses SVN' do
       write '.svn/xml'
-      Release.find.should be_instance_of(SvnRelease)
+      expect(Release.find).to be_instance_of(SvnRelease)
     end
 
     # TravisCI seems to place the tmp directory
@@ -426,7 +426,7 @@ describe Release do
     unless ENV['TRAVIS_BUILD_ID']
       it 'should return nil if no known release process' do
         Dir.chdir(Dir.tmpdir) do
-          Release.find.should be_nil
+          expect(Release.find).to be_nil
         end
       end
     end
@@ -444,55 +444,55 @@ shared_examples_for 'a release process' do
     before do
       write 'buildfile', "VERSION_NUMBER = '1.0.0-SNAPSHOT'"
       # Prevent a real call to a spawned buildr process.
-      @release.stub(:buildr)
-      @release.stub(:check)
-      @release.should_receive(:sh).with('buildr', '--buildfile', File.expand_path('buildfile.next'),
+      allow(@release).to receive(:buildr)
+      allow(@release).to receive(:check)
+      expect(@release).to receive(:sh).with('buildr', '--buildfile', File.expand_path('buildfile.next'),
                                           '--environment', 'development', 'clean', 'upload', 'DEBUG=no')
     end
 
     it 'should tag a release with the release version' do
-      @release.stub(:update_version_to_next)
-      @release.should_receive(:tag_release).with('1.0.0')
+      allow(@release).to receive(:update_version_to_next)
+      expect(@release).to receive(:tag_release).with('1.0.0')
       @release.make
     end
 
     it 'should not alter the buildfile before tagging' do
-      @release.stub(:update_version_to_next)
-      @release.should_receive(:tag_release).with('1.0.0')
+      allow(@release).to receive(:update_version_to_next)
+      expect(@release).to receive(:tag_release).with('1.0.0')
       @release.make
-      file('buildfile').should contain('VERSION_NUMBER = "1.0.0"')
+      expect(file('buildfile')).to contain('VERSION_NUMBER = "1.0.0"')
     end
 
     it 'should update the buildfile with the next version number' do
-      @release.stub(:tag_release)
+      allow(@release).to receive(:tag_release)
       @release.make
-      file('buildfile').should contain('VERSION_NUMBER = "1.0.1-SNAPSHOT"')
+      expect(file('buildfile')).to contain('VERSION_NUMBER = "1.0.1-SNAPSHOT"')
     end
 
     it 'should keep leading zeros in the next version number' do
       write 'buildfile', "VERSION_NUMBER = '1.0.001-SNAPSHOT'"
-      @release.stub(:tag_release)
+      allow(@release).to receive(:tag_release)
       @release.make
-      file('buildfile').should contain('VERSION_NUMBER = "1.0.002-SNAPSHOT"')
+      expect(file('buildfile')).to contain('VERSION_NUMBER = "1.0.002-SNAPSHOT"')
     end
 
     it 'should commit the updated buildfile' do
-      @release.stub(:tag_release)
+      allow(@release).to receive(:tag_release)
       @release.make
-      file('buildfile').should contain('VERSION_NUMBER = "1.0.1-SNAPSHOT"')
+      expect(file('buildfile')).to contain('VERSION_NUMBER = "1.0.1-SNAPSHOT"')
     end
 
     it 'should not consider "-rc" as "-SNAPSHOT"' do
       write 'buildfile', "VERSION_NUMBER = '1.0.0-rc1'"
-      @release.stub(:tag_release)
+      allow(@release).to receive(:tag_release)
       @release.make
-      file('buildfile').should contain('VERSION_NUMBER = "1.0.0-rc1"')
+      expect(file('buildfile')).to contain('VERSION_NUMBER = "1.0.0-rc1"')
     end
 
     it 'should only commit the updated buildfile if the version changed' do
       write 'buildfile', "VERSION_NUMBER = '1.0.0-rc1'"
-      @release.should_not_receive(:update_version_to_next)
-      @release.stub(:tag_release)
+      expect(@release).not_to receive(:update_version_to_next)
+      allow(@release).to receive(:tag_release)
       @release.make
     end
   end
@@ -500,39 +500,39 @@ shared_examples_for 'a release process' do
   describe '#resolve_next_version' do
 
     it 'should increment the version number if SNAPSHOT' do
-      @release.send(:resolve_next_version, "1.0.0-SNAPSHOT").should == '1.0.1-SNAPSHOT'
+      expect(@release.send(:resolve_next_version, "1.0.0-SNAPSHOT")).to eq('1.0.1-SNAPSHOT')
     end
 
     it 'should NOT increment the version number if no SNAPSHOT' do
-      @release.send(:resolve_next_version, "1.0.0").should == '1.0.0'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('1.0.0')
     end
 
     it 'should return the version specified by NEXT_VERSION env var' do
       ENV['NEXT_VERSION'] = "version_from_env"
-      @release.send(:resolve_next_version, "1.0.0").should == 'version_from_env'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('version_from_env')
     end
 
     it 'should return the version specified by next_version' do
       Release.next_version = "ze_next_version"
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_next_version'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_next_version')
     end
 
     it 'should return the version specified by next_version if next_version is a proc' do
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == '1.0.0++'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('1.0.0++')
     end
 
     it "should return the version specified by 'NEXT_VERSION' env var even if next_version is non nil" do
       ENV['NEXT_VERSION'] = "ze_version_from_env"
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_version_from_env'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_version_from_env')
     end
 
     it "should return the version specified by 'next_version' env var even if next_version is non nil" do
       ENV['NEXT_VERSION'] = nil
       ENV['next_version'] = "ze_version_from_env_lowercase"
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_version_from_env_lowercase'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_version_from_env_lowercase')
     end
     after {
       Release.next_version = nil
@@ -544,39 +544,39 @@ shared_examples_for 'a release process' do
   describe '#resolve_next_version' do
 
     it 'should increment the version number if SNAPSHOT' do
-      @release.send(:resolve_next_version, "1.0.0-SNAPSHOT").should == '1.0.1-SNAPSHOT'
+      expect(@release.send(:resolve_next_version, "1.0.0-SNAPSHOT")).to eq('1.0.1-SNAPSHOT')
     end
 
     it 'should NOT increment the version number if no SNAPSHOT' do
-      @release.send(:resolve_next_version, "1.0.0").should == '1.0.0'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('1.0.0')
     end
 
     it 'should return the version specified by NEXT_VERSION env var' do
       ENV['NEXT_VERSION'] = "version_from_env"
-      @release.send(:resolve_next_version, "1.0.0").should == 'version_from_env'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('version_from_env')
     end
 
     it 'should return the version specified by next_version' do
       Release.next_version = "ze_next_version"
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_next_version'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_next_version')
     end
 
     it 'should return the version specified by next_version if next_version is a proc' do
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == '1.0.0++'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('1.0.0++')
     end
 
     it "should return the version specified by 'NEXT_VERSION' env var even if next_version is non nil" do
       ENV['NEXT_VERSION'] = "ze_version_from_env"
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_version_from_env'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_version_from_env')
     end
 
     it "should return the version specified by 'next_version' env var even if next_version is non nil" do
       ENV['NEXT_VERSION'] = nil
       ENV['next_version'] = "ze_version_from_env_lowercase"
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_version_from_env_lowercase'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_version_from_env_lowercase')
     end
     after {
       Release.next_version = nil
@@ -588,39 +588,39 @@ shared_examples_for 'a release process' do
   describe '#resolve_next_version' do
 
     it 'should increment the version number if SNAPSHOT' do
-      @release.send(:resolve_next_version, "1.0.0-SNAPSHOT").should == '1.0.1-SNAPSHOT'
+      expect(@release.send(:resolve_next_version, "1.0.0-SNAPSHOT")).to eq('1.0.1-SNAPSHOT')
     end
 
     it 'should NOT increment the version number if no SNAPSHOT' do
-      @release.send(:resolve_next_version, "1.0.0").should == '1.0.0'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('1.0.0')
     end
 
     it 'should return the version specified by NEXT_VERSION env var' do
       ENV['NEXT_VERSION'] = "version_from_env"
-      @release.send(:resolve_next_version, "1.0.0").should == 'version_from_env'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('version_from_env')
     end
 
     it 'should return the version specified by next_version' do
       Release.next_version = "ze_next_version"
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_next_version'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_next_version')
     end
 
     it 'should return the version specified by next_version if next_version is a proc' do
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == '1.0.0++'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('1.0.0++')
     end
 
     it "should return the version specified by 'NEXT_VERSION' env var even if next_version is non nil" do
       ENV['NEXT_VERSION'] = "ze_version_from_env"
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_version_from_env'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_version_from_env')
     end
 
     it "should return the version specified by 'next_version' env var even if next_version is non nil" do
       ENV['NEXT_VERSION'] = nil
       ENV['next_version'] = "ze_version_from_env_lowercase"
       Release.next_version = lambda {|version| "#{version}++"}
-      @release.send(:resolve_next_version, "1.0.0").should == 'ze_version_from_env_lowercase'
+      expect(@release.send(:resolve_next_version, "1.0.0")).to eq('ze_version_from_env_lowercase')
     end
     after {
       Release.next_version = nil
@@ -631,70 +631,70 @@ shared_examples_for 'a release process' do
 
   describe '#resolve_tag' do
     before do
-      @release.stub(:extract_version).and_return('1.0.0')
+      allow(@release).to receive(:extract_version).and_return('1.0.0')
     end
 
     it 'should return tag specified by tag_name' do
       Release.tag_name  = 'first'
-      @release.send(:resolve_tag).should == 'first'
+      expect(@release.send(:resolve_tag)).to eq('first')
     end
 
     it 'should use tag returned by tag_name if tag_name is a proc' do
       Release.tag_name  = lambda { |version| "buildr-#{version}" }
-      @release.send(:resolve_tag).should == 'buildr-1.0.0'
+      expect(@release.send(:resolve_tag)).to eq('buildr-1.0.0')
     end
     after { Release.tag_name = nil }
   end
 
   describe '#tag_release' do
     it 'should inform the user' do
-      @release.stub(:extract_version).and_return('1.0.0')
-      lambda { @release.tag_release('1.0.0') }.should show_info('Tagging release 1.0.0')
+      allow(@release).to receive(:extract_version).and_return('1.0.0')
+      expect { @release.tag_release('1.0.0') }.to show_info('Tagging release 1.0.0')
     end
   end
 
   describe '#extract_version' do
     it 'should extract VERSION_NUMBER with single quotes' do
       write 'buildfile', "VERSION_NUMBER = '1.0.0-SNAPSHOT'"
-      @release.extract_version.should == '1.0.0-SNAPSHOT'
+      expect(@release.extract_version).to eq('1.0.0-SNAPSHOT')
     end
 
     it 'should extract VERSION_NUMBER with double quotes' do
       write 'buildfile', %{VERSION_NUMBER = "1.0.1-SNAPSHOT"}
-      @release.extract_version.should == '1.0.1-SNAPSHOT'
+      expect(@release.extract_version).to eq('1.0.1-SNAPSHOT')
     end
 
     it 'should extract VERSION_NUMBER without any spaces' do
       write 'buildfile', "VERSION_NUMBER='1.0.2-SNAPSHOT'"
-      @release.extract_version.should == '1.0.2-SNAPSHOT'
+      expect(@release.extract_version).to eq('1.0.2-SNAPSHOT')
     end
 
     it 'should extract THIS_VERSION as an alternative to VERSION_NUMBER' do
       write 'buildfile', "THIS_VERSION = '1.0.3-SNAPSHOT'"
-      @release.extract_version.should == '1.0.3-SNAPSHOT'
+      expect(@release.extract_version).to eq('1.0.3-SNAPSHOT')
     end
 
     it 'should complain if no current version number' do
       write 'buildfile', 'define foo'
-      lambda { @release.extract_version }.should raise_error('Looking for THIS_VERSION = "..." in your Buildfile, none found')
+      expect { @release.extract_version }.to raise_error('Looking for THIS_VERSION = "..." in your Buildfile, none found')
     end
   end
 
   describe '#with_release_candidate_version' do
     before do
-      Buildr.application.stub(:buildfile).and_return(file('buildfile'))
+      allow(Buildr.application).to receive(:buildfile).and_return(file('buildfile'))
       write 'buildfile', "THIS_VERSION = '1.1.0-SNAPSHOT'"
     end
 
     it 'should yield the name of the release candidate buildfile' do
       @release.send :with_release_candidate_version do |new_filename|
-        File.read(new_filename).should == %{THIS_VERSION = "1.1.0"}
+        expect(File.read(new_filename)).to eq(%{THIS_VERSION = "1.1.0"})
       end
     end
 
     it 'should yield a name different from the original buildfile' do
       @release.send :with_release_candidate_version do |new_filename|
-        new_filename.should_not point_to_path('buildfile')
+        expect(new_filename).not_to point_to_path('buildfile')
       end
     end
   end
@@ -708,31 +708,31 @@ shared_examples_for 'a release process' do
     it 'should update the buildfile with a new version number' do
       @release.send :update_version_to_next
       `cp buildfile /tmp/out`
-      file('buildfile').should contain('VERSION_NUMBER = "1.0.6-SNAPSHOT"')
+      expect(file('buildfile')).to contain('VERSION_NUMBER = "1.0.6-SNAPSHOT"')
     end
 
     it 'should commit the new buildfile on the trunk' do
-      @release.should_receive(:message).and_return('Changed version number to 1.0.1-SNAPSHOT')
+      expect(@release).to receive(:message).and_return('Changed version number to 1.0.1-SNAPSHOT')
       @release.update_version_to_next
     end
 
     it 'should use the commit message specified by commit_message' do
       Release.commit_message  = 'Here is my custom message'
-      @release.should_receive(:message).and_return('Here is my custom message')
+      expect(@release).to receive(:message).and_return('Here is my custom message')
       @release.update_version_to_next
     end
 
     it 'should use the commit message returned by commit_message if commit_message is a proc' do
       Release.commit_message  = lambda { |new_version|
-        new_version.should == '1.0.1-SNAPSHOT'
+        expect(new_version).to eq('1.0.1-SNAPSHOT')
         "increment version number to #{new_version}"
       }
-      @release.should_receive(:message).and_return('increment version number to 1.0.1-SNAPSHOT')
+      expect(@release).to receive(:message).and_return('increment version number to 1.0.1-SNAPSHOT')
       @release.update_version_to_next
     end
 
     it 'should inform the user of the new version' do
-      lambda { @release.update_version_to_next }.should show_info('Current version is now 1.0.6-SNAPSHOT')
+      expect { @release.update_version_to_next }.to show_info('Current version is now 1.0.6-SNAPSHOT')
     end
     after { Release.commit_message = nil }
   end
@@ -741,8 +741,8 @@ shared_examples_for 'a release process' do
   describe '#check' do
     before { @release.send(:this_version=, "1.0.0-SNAPSHOT") }
     it 'should fail if THIS_VERSION equals the next_version' do
-      @release.stub(:resolve_next_version).and_return('1.0.0-SNAPSHOT')
-      lambda { @release.check }.should raise_error("The next version can't be equal to the current version 1.0.0-SNAPSHOT.\nUpdate THIS_VERSION/VERSION_NUMBER, specify Release.next_version or use NEXT_VERSION env var")
+      allow(@release).to receive(:resolve_next_version).and_return('1.0.0-SNAPSHOT')
+      expect { @release.check }.to raise_error("The next version can't be equal to the current version 1.0.0-SNAPSHOT.\nUpdate THIS_VERSION/VERSION_NUMBER, specify Release.next_version or use NEXT_VERSION env var")
     end
   end
 end
@@ -754,22 +754,22 @@ describe HgRelease do
   before do
     write 'buildfile', "VERSION_NUMBER = '1.0.0-SNAPSHOT'"
     @release = HgRelease.new
-    Hg.stub(:hg)
-    Hg.stub(:remote).and_return('https://bitbucket.org/sample-repo')
-    Hg.stub(:current_branch).and_return('default')
+    allow(Hg).to receive(:hg)
+    allow(Hg).to receive(:remote).and_return('https://bitbucket.org/sample-repo')
+    allow(Hg).to receive(:current_branch).and_return('default')
   end
 
   describe '#applies_to?' do
     it 'should reject a non-hg repo' do
       Dir.chdir(Dir.tmpdir) do
-        HgRelease.applies_to?.should be_false
+        expect(HgRelease.applies_to?).to be_falsey
       end
     end
 
     it 'should accept a hg repo' do
       FileUtils.mkdir '.hg'
       FileUtils.touch File.join('.hg', 'requires')
-      HgRelease.applies_to?.should be_true
+      expect(HgRelease.applies_to?).to be_truthy
     end
   end
 
@@ -780,20 +780,20 @@ describe HgRelease do
     end
 
     it 'should accept a clean repo' do
-      Hg.should_receive(:uncommitted_files).and_return([])
-      Hg.should_receive(:remote).and_return(["http://bitbucket.org/sample-repo"])
-      lambda { @release.check }.should_not raise_error
+      expect(Hg).to receive(:uncommitted_files).and_return([])
+      expect(Hg).to receive(:remote).and_return(["http://bitbucket.org/sample-repo"])
+      expect { @release.check }.not_to raise_error
     end
 
     it 'should reject a dirty repo' do
-      Hg.should_receive(:uncommitted_files).and_return(['dirty_file.txt'])
-      lambda { @release.check }.should raise_error(RuntimeError, /uncommitted files/i)
+      expect(Hg).to receive(:uncommitted_files).and_return(['dirty_file.txt'])
+      expect { @release.check }.to raise_error(RuntimeError, /uncommitted files/i)
     end
 
     it 'should reject a local branch not tracking a remote repo' do
-      Hg.should_receive(:uncommitted_files).and_return([])
-      Hg.should_receive(:remote).and_return([])
-      lambda{ @release.check }.should raise_error(RuntimeError,
+      expect(Hg).to receive(:uncommitted_files).and_return([])
+      expect(Hg).to receive(:remote).and_return([])
+      expect{ @release.check }.to raise_error(RuntimeError,
         "You are releasing from a local branch that does not track a remote!")
     end
   end
@@ -806,8 +806,8 @@ describe GitRelease do
   before do
     write 'buildfile', "VERSION_NUMBER = '1.0.0-SNAPSHOT'"
     @release = GitRelease.new
-    Git.stub(:git)
-    Git.stub(:current_branch).and_return('master')
+    allow(Git).to receive(:git)
+    allow(Git).to receive(:current_branch).and_return('master')
   end
 
   describe '#applies_to?' do
@@ -817,7 +817,7 @@ describe GitRelease do
     unless ENV['TRAVIS_BUILD_ID']
       it 'should reject a non-git repo' do
         Dir.chdir(Dir.tmpdir) do
-          GitRelease.applies_to?.should be_false
+          expect(GitRelease.applies_to?).to be_falsey
         end
       end
     end
@@ -825,7 +825,7 @@ describe GitRelease do
     it 'should accept a git repo' do
       FileUtils.mkdir '.git'
       FileUtils.touch File.join('.git', 'config')
-      GitRelease.applies_to?.should be_true
+      expect(GitRelease.applies_to?).to be_truthy
     end
   end
 
@@ -836,29 +836,29 @@ describe GitRelease do
     end
 
     it 'should accept a clean repository' do
-      Git.should_receive(:`).with('git status').and_return <<-EOF
+      expect(Git).to receive(:`).with('git status').and_return <<-EOF
 # On branch master
 nothing to commit (working directory clean)
       EOF
-      Git.should_receive(:remote).and_return('master')
-      lambda { @release.check }.should_not raise_error
+      expect(Git).to receive(:remote).and_return('master')
+      expect { @release.check }.not_to raise_error
     end
 
     it 'should reject a dirty repository' do
-      Git.should_receive(:`).with('git status').and_return <<-EOF
+      expect(Git).to receive(:`).with('git status').and_return <<-EOF
 # On branch master
 # Untracked files:
 #   (use "git add <file>..." to include in what will be committed)
 #
 #       foo.temp
 EOF
-      lambda { @release.check }.should raise_error(RuntimeError, /uncommitted files/i)
+      expect { @release.check }.to raise_error(RuntimeError, /uncommitted files/i)
     end
 
     it 'should reject a repository not tracking remote branch' do
-      Git.should_receive(:uncommitted_files).and_return([])
-      Git.should_receive(:remote).and_return(nil)
-      lambda{ @release.check }.should raise_error(RuntimeError,
+      expect(Git).to receive(:uncommitted_files).and_return([])
+      expect(Git).to receive(:remote).and_return(nil)
+      expect{ @release.check }.to raise_error(RuntimeError,
         "You are releasing from a local branch that does not track a remote!")
     end
   end
@@ -866,37 +866,37 @@ EOF
   describe '#tag_release' do
     before do
       @release = GitRelease.new
-      @release.stub(:extract_version).and_return('1.0.1')
-      @release.stub(:resolve_tag).and_return('TEST_TAG')
-      Git.stub(:git).with('tag', '-a', 'TEST_TAG', '-m', '[buildr] Cutting release TEST_TAG')
-      Git.stub(:git).with('push', 'origin', 'tag', 'TEST_TAG')
-      Git.stub(:commit)
-      Git.stub(:push)
-      Git.stub(:remote).and_return('origin')
+      allow(@release).to receive(:extract_version).and_return('1.0.1')
+      allow(@release).to receive(:resolve_tag).and_return('TEST_TAG')
+      allow(Git).to receive(:git).with('tag', '-a', 'TEST_TAG', '-m', '[buildr] Cutting release TEST_TAG')
+      allow(Git).to receive(:git).with('push', 'origin', 'tag', 'TEST_TAG')
+      allow(Git).to receive(:commit)
+      allow(Git).to receive(:push)
+      allow(Git).to receive(:remote).and_return('origin')
     end
 
     it 'should delete any existing tag with the same name' do
-      Git.should_receive(:git).with('tag', '-d', 'TEST_TAG')
-      Git.should_receive(:git).with('push', 'origin', ':refs/tags/TEST_TAG')
+      expect(Git).to receive(:git).with('tag', '-d', 'TEST_TAG')
+      expect(Git).to receive(:git).with('push', 'origin', ':refs/tags/TEST_TAG')
       @release.tag_release 'TEST_TAG'
     end
 
     it 'should commit the buildfile before tagging' do
-      Git.should_receive(:commit).with(File.basename(Buildr.application.buildfile.to_s), "Changed version number to 1.0.1")
+      expect(Git).to receive(:commit).with(File.basename(Buildr.application.buildfile.to_s), "Changed version number to 1.0.1")
       @release.tag_release 'TEST_TAG'
     end
 
     it 'should push the tag if a remote is tracked' do
-      Git.should_receive(:git).with('tag', '-d', 'TEST_TAG')
-      Git.should_receive(:git).with('push', 'origin', ':refs/tags/TEST_TAG')
-      Git.should_receive(:git).with('tag', '-a', 'TEST_TAG', '-m', '[buildr] Cutting release TEST_TAG')
-      Git.should_receive(:git).with('push', 'origin', 'tag',  'TEST_TAG')
+      expect(Git).to receive(:git).with('tag', '-d', 'TEST_TAG')
+      expect(Git).to receive(:git).with('push', 'origin', ':refs/tags/TEST_TAG')
+      expect(Git).to receive(:git).with('tag', '-a', 'TEST_TAG', '-m', '[buildr] Cutting release TEST_TAG')
+      expect(Git).to receive(:git).with('push', 'origin', 'tag',  'TEST_TAG')
       @release.tag_release 'TEST_TAG'
     end
 
     it 'should NOT push the tag if no remote is tracked' do
-      Git.stub(:remote).and_return(nil)
-      Git.should_not_receive(:git).with('push', 'origin', 'tag',  'TEST_TAG')
+      allow(Git).to receive(:remote).and_return(nil)
+      expect(Git).not_to receive(:git).with('push', 'origin', 'tag',  'TEST_TAG')
       @release.tag_release 'TEST_TAG'
     end
   end
@@ -909,53 +909,53 @@ describe SvnRelease do
   before do
     write 'buildfile', "VERSION_NUMBER = '1.0.0-SNAPSHOT'"
     @release = SvnRelease.new
-    Svn.stub(:svn)
-    Svn.stub(:repo_url).and_return('http://my.repo.org/foo/trunk')
-    Svn.stub(:tag)
+    allow(Svn).to receive(:svn)
+    allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/trunk')
+    allow(Svn).to receive(:tag)
   end
 
   describe '#applies_to?' do
     it 'should reject a non-git repo' do
-      SvnRelease.applies_to?.should be_false
+      expect(SvnRelease.applies_to?).to be_falsey
     end
 
     it 'should accept a git repo' do
       FileUtils.touch '.svn'
-      SvnRelease.applies_to?.should be_true
+      expect(SvnRelease.applies_to?).to be_truthy
     end
   end
 
   describe '#check' do
     before do
-      Svn.stub(:uncommitted_files).and_return([])
+      allow(Svn).to receive(:uncommitted_files).and_return([])
       @release = SvnRelease.new
       @release.send(:this_version=, "1.0.0-SNAPSHOT")
     end
 
     it 'should accept to release from the trunk' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/trunk')
-      lambda { @release.check }.should_not raise_error
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/trunk')
+      expect { @release.check }.not_to raise_error
     end
 
     it 'should accept to release from a branch' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/branches/1.0')
-      lambda { @release.check }.should_not raise_error
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/branches/1.0')
+      expect { @release.check }.not_to raise_error
     end
 
     it 'should reject releasing from a tag' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/tags/1.0.0')
-      lambda { @release.check }.should raise_error(RuntimeError, "SVN URL must contain 'trunk' or 'branches/...'")
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/tags/1.0.0')
+      expect { @release.check }.to raise_error(RuntimeError, "SVN URL must contain 'trunk' or 'branches/...'")
     end
 
     it 'should reject a non standard repository layout' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/bar')
-      lambda { @release.check }.should raise_error(RuntimeError, "SVN URL must contain 'trunk' or 'branches/...'")
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/bar')
+      expect { @release.check }.to raise_error(RuntimeError, "SVN URL must contain 'trunk' or 'branches/...'")
     end
 
     it 'should reject an uncommitted file' do
-      Svn.stub(:repo_url).and_return('http://my.repo.org/foo/trunk')
-      Svn.stub(:uncommitted_files).and_return(['foo.rb'])
-      lambda { @release.check }.should raise_error(RuntimeError,
+      allow(Svn).to receive(:repo_url).and_return('http://my.repo.org/foo/trunk')
+      allow(Svn).to receive(:uncommitted_files).and_return(['foo.rb'])
+      expect { @release.check }.to raise_error(RuntimeError,
         "Uncommitted files violate the First Principle Of Release!\n" +
         "foo.rb")
     end

--- a/spec/core/cc_spec.rb
+++ b/spec/core/cc_spec.rb
@@ -53,7 +53,7 @@ describe Buildr::CCTask do
   include CCHelper
 
   it 'should default to a delay of 0.2' do
-    define('foo').cc.delay.should == 0.2
+    expect(define('foo').cc.delay).to eq(0.2)
   end
 
   it 'should compile and test:compile on initial start' do
@@ -74,8 +74,8 @@ describe Buildr::CCTask do
 
     wait_while { foo.test.compile.run_count != 1 }
 
-    foo.compile.run_count.should == 1
-    foo.test.compile.run_count.should == 1
+    expect(foo.compile.run_count).to eq(1)
+    expect(foo.test.compile.run_count).to eq(1)
 
     thread.exit
   end
@@ -98,17 +98,17 @@ describe Buildr::CCTask do
 
     wait_while { foo.test.compile.run_count != 1 }
 
-    foo.compile.run_count.should == 1
-    foo.test.compile.run_count.should == 1
-    foo.resources.run_count.should == 1
+    expect(foo.compile.run_count).to eq(1)
+    expect(foo.test.compile.run_count).to eq(1)
+    expect(foo.resources.run_count).to eq(1)
 
     modify_file_times(File.join(Dir.pwd, 'src/main/java/Example.java'))
 
     wait_while { foo.test.compile.run_count != 2 }
 
-    foo.compile.run_count.should == 2
-    foo.test.compile.run_count.should == 2
-    foo.resources.run_count.should == 2
+    expect(foo.compile.run_count).to eq(2)
+    expect(foo.test.compile.run_count).to eq(2)
+    expect(foo.resources.run_count).to eq(2)
 
     thread.exit
   end
@@ -135,21 +135,21 @@ describe Buildr::CCTask do
 
     wait_while { foo.test.compile.run_count != 1 }
 
-    foo.compile.run_count.should == 1
-    foo.test.compile.run_count.should == 1
-    foo.resources.run_count.should == 1
+    expect(foo.compile.run_count).to eq(1)
+    expect(foo.test.compile.run_count).to eq(1)
+    expect(foo.resources.run_count).to eq(1)
 
-    file("foo/target/classes/Example.class").should exist
+    expect(file("foo/target/classes/Example.class")).to exist
 
     tstamp = File.mtime("foo/target/classes/Example.class")
 
     modify_file_times(File.join(Dir.pwd, 'foo/src/main/java/Example.java'))
     wait_while { foo.test.compile.run_count != 2 }
 
-    foo.compile.run_count.should == 2
-    foo.test.compile.run_count.should == 2
-    foo.resources.run_count.should == 2
-    File.mtime("foo/target/classes/Example.class").should_not == tstamp
+    expect(foo.compile.run_count).to eq(2)
+    expect(foo.test.compile.run_count).to eq(2)
+    expect(foo.resources.run_count).to eq(2)
+    expect(File.mtime("foo/target/classes/Example.class")).not_to eq(tstamp)
 
     thread.exit
   end
@@ -206,38 +206,38 @@ describe Buildr::CCTask do
     wait_while { all.any? { |p| p.test.compile.run_count != 1 } }
 
     all.each do |p|
-      p.compile.run_count.should == 1
-      p.test.compile.run_count.should == 1
-      p.resources.run_count.should == 1
+      expect(p.compile.run_count).to eq(1)
+      expect(p.test.compile.run_count).to eq(1)
+      expect(p.resources.run_count).to eq(1)
     end
 
-    file("foo/target/classes/Example.class").should exist
+    expect(file("foo/target/classes/Example.class")).to exist
     tstamp = File.mtime("foo/target/classes/Example.class")
 
     modify_file_times('foo/src/main/java/Example.java')
     wait_while { project("container:foo").test.compile.run_count != 2 }
 
     project("container:foo").tap do |p|
-      p.compile.run_count.should == 2
-      p.test.compile.run_count.should == 2
-      p.resources.run_count.should == 2
+      expect(p.compile.run_count).to eq(2)
+      expect(p.test.compile.run_count).to eq(2)
+      expect(p.resources.run_count).to eq(2)
     end
 
     wait_while { project("container").resources.run_count != 2 }
 
     project("container").tap do |p|
-      p.compile.run_count.should == 1 # not_needed
-      p.resources.run_count.should == 2
+      expect(p.compile.run_count).to eq(1) # not_needed
+      expect(p.resources.run_count).to eq(2)
     end
-    File.mtime("foo/target/classes/Example.class").should_not == tstamp
+    expect(File.mtime("foo/target/classes/Example.class")).not_to eq(tstamp)
 
     modify_file_times('src/main/java/Example.java')
 
     wait_while { project("container").resources.run_count != 3 }
 
     project("container").tap do |p|
-      p.compile.run_count.should == 2
-      p.resources.run_count.should == 3
+      expect(p.compile.run_count).to eq(2)
+      expect(p.resources.run_count).to eq(3)
     end
 
     thread.exit

--- a/spec/core/checks_spec.rb
+++ b/spec/core/checks_spec.rb
@@ -25,7 +25,7 @@ describe Project, 'check task' do
       package :jar
       task('package').enhance { task('action').invoke }
     end
-    lambda { project('foo').task('package').invoke }.should run_tasks(['foo:package', 'action', 'foo:check'])
+    expect { project('foo').task('package').invoke }.to run_tasks(['foo:package', 'action', 'foo:check'])
   end
 
   it "should execute all project's expectations" do
@@ -33,12 +33,12 @@ describe Project, 'check task' do
     define 'foo', :version=>'1.0' do
       check  { task('expectation').invoke }
     end
-    lambda { project('foo').task('package').invoke }.should run_task('expectation')
+    expect { project('foo').task('package').invoke }.to run_task('expectation')
   end
 
   it "should succeed if there are no expectations" do
     define 'foo', :version=>'1.0'
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should succeed if all expectations passed" do
@@ -46,7 +46,7 @@ describe Project, 'check task' do
       check { true }
       check { false }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should fail if any expectation failed" do
@@ -55,7 +55,7 @@ describe Project, 'check task' do
       check { fail 'sorry' }
       check
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 end
 
@@ -64,9 +64,9 @@ describe Project, '#check' do
 
   it "should add expectation" do
     define 'foo' do
-      expectations.should be_empty
+      expect(expectations).to be_empty
       check
-      expectations.size.should be(1)
+      expect(expectations.size).to be(1)
     end
   end
 
@@ -74,63 +74,63 @@ describe Project, '#check' do
     define 'foo' do
       subject = self
       check do
-        it.should be(subject)
-        description.should eql(subject.to_s)
+        expect(it).to be(subject)
+        expect(description).to eql(subject.to_s)
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should treat single string argument as description, expectation against project" do
     define 'foo' do
       subject = self
       check "should be project" do
-        it.should be(subject)
-        description.should eql("#{subject} should be project")
+        expect(it).to be(subject)
+        expect(description).to eql("#{subject} should be project")
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should treat single object argument as subject" do
     define 'foo' do
       subject = Object.new
       check subject do
-        it.should be(subject)
-        description.should eql(subject.to_s)
+        expect(it).to be(subject)
+        expect(description).to eql(subject.to_s)
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should treat first object as subject, second object as description" do
     define 'foo' do
       subject = Object.new
       check subject, "should exist" do
-        it.should be(subject)
-        description.should eql("#{subject} should exist")
+        expect(it).to be(subject)
+        expect(description).to eql("#{subject} should exist")
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should work without block" do
     define 'foo' do
       check "implement later"
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it 'should pass method calls to context' do
     define 'foo', :version=>'1.0' do
       subject = self
       check "should be project" do
-        it.should be(subject)
-        name.should eql(subject.name)
-        package(:jar).should eql(subject.package(:jar))
+        expect(it).to be(subject)
+        expect(name).to eql(subject.name)
+        expect(package(:jar)).to eql(subject.package(:jar))
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 end
 
@@ -140,31 +140,31 @@ describe Buildr::Checks::Expectation, 'matchers' do
   it "should include Buildr matchers exist and contain" do
     define 'foo' do
       check do
-        self.should respond_to(:exist)
-        self.should respond_to(:contain)
+        expect(self).to respond_to(:exist)
+        expect(self).to respond_to(:contain)
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should include RSpec matchers like be and eql" do
     define 'foo' do
       check do
-        self.should respond_to(:be)
-        self.should respond_to(:eql)
+        expect(self).to respond_to(:be)
+        expect(self).to respond_to(:eql)
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should include RSpec predicates like be_nil and be_empty" do
     define 'foo' do
       check do
-        nil.should be_nil
-        [].should be_empty
+        expect(nil).to be_nil
+        expect([]).to be_empty
       end
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 end
 
@@ -174,24 +174,24 @@ describe Buildr::Checks::Expectation, 'exist' do
   it "should pass if file exists" do
     define 'foo' do
       build file('test') { |task| write task.name }
-      check(file('test')) { it.should exist }
+      check(file('test')) { expect(it).to exist }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should fail if file does not exist" do
     define 'foo' do
-      check(file('test')) { it.should exist }
+      check(file('test')) { expect(it).to exist }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should not attempt to invoke task" do
     define 'foo' do
       file('test') { |task| write task.name }
-      check(file('test')) { it.should exist }
+      check(file('test')) { expect(it).to exist }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 end
 
@@ -201,40 +201,40 @@ describe Buildr::Checks::Expectation, " be_empty" do
   it "should pass if file has no content" do
     define 'foo' do
       build file('test') { write 'test' }
-      check(file('test')) { it.should be_empty }
+      check(file('test')) { expect(it).to be_empty }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should fail if file has content" do
     define 'foo' do
       build file('test') { write 'test', "something" }
-      check(file('test')) { it.should be_empty }
+      check(file('test')) { expect(it).to be_empty }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should fail if file does not exist" do
     define 'foo' do
-      check(file('test')) { it.should be_empty }
+      check(file('test')) { expect(it).to be_empty }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should pass if directory is empty" do
     define 'foo' do
       build file('test') { mkpath 'test' }
-      check(file('test')) { it.should be_empty }
+      check(file('test')) { expect(it).to be_empty }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should fail if directory has any files" do
     define 'foo' do
       build file('test') { write 'test/file' }
-      check(file('test')) { it.should be_empty }
+      check(file('test')) { expect(it).to be_empty }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 end
 
@@ -244,48 +244,48 @@ describe Buildr::Checks::Expectation, " contain(file)" do
   it "should pass if file content matches string" do
     define 'foo' do
       build file('test') { write 'test', 'something' }
-      check(file('test')) { it.should contain('thing') }
+      check(file('test')) { expect(it).to contain('thing') }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should pass if file content matches pattern" do
     define 'foo' do
       build file('test') { write 'test', "something\nor\nanother" }
-      check(file('test')) { it.should contain(/or/) }
+      check(file('test')) { expect(it).to contain(/or/) }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should pass if file content matches all arguments" do
     define 'foo' do
       build file('test') { write 'test', "something\nor\nanother" }
-      check(file('test')) { it.should contain(/or/, /other/) }
+      check(file('test')) { expect(it).to contain(/or/, /other/) }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should fail unless file content matchs all arguments" do
     define 'foo' do
       build file('test') { write 'test', 'something' }
-      check(file('test')) { it.should contain(/some/, /other/) }
+      check(file('test')) { expect(it).to contain(/some/, /other/) }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should fail if file content does not match" do
     define 'foo' do
       build file('test') { write 'test', "something" }
-      check(file('test')) { it.should contain(/other/) }
+      check(file('test')) { expect(it).to contain(/other/) }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should fail if file does not exist" do
     define 'foo' do
-      check(file('test')) { it.should contain(/anything/) }
+      check(file('test')) { expect(it).to contain(/anything/) }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 end
 
@@ -295,48 +295,48 @@ describe Buildr::Checks::Expectation, 'contain(directory)' do
   it "should pass if directory contains file" do
     write 'resources/test'
     define 'foo' do
-      check(file('resources')) { it.should contain('test') }
+      check(file('resources')) { expect(it).to contain('test') }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should pass if directory contains glob pattern" do
     write 'resources/with/test'
     define 'foo' do
-      check(file('resources')) { it.should contain('**/t*st') }
+      check(file('resources')) { expect(it).to contain('**/t*st') }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should pass if directory contains all arguments" do
     write 'resources/with/test'
     define 'foo' do
-      check(file('resources')) { it.should contain('**/test', '**/*') }
+      check(file('resources')) { expect(it).to contain('**/test', '**/*') }
     end
-    lambda { project('foo').task('package').invoke }.should_not raise_error
+    expect { project('foo').task('package').invoke }.not_to raise_error
   end
 
   it "should fail unless directory contains all arguments" do
     write 'resources/test'
     define 'foo' do
-      check(file('resources')) { it.should contain('test', 'or-not') }
+      check(file('resources')) { expect(it).to contain('test', 'or-not') }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should fail if directory is empty" do
     mkpath 'resources'
     define 'foo' do
-      check(file('resources')) { it.should contain('test') }
+      check(file('resources')) { expect(it).to contain('test') }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 
   it "should fail if directory does not exist" do
     define 'foo' do
-      check(file('resources')) { it.should contain }
+      check(file('resources')) { expect(it).to contain }
     end
-    lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+    expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
   end
 end
 
@@ -364,60 +364,60 @@ describe Buildr::Checks::Expectation do
 
       it "should pass if archive path exists" do
         write 'resources/test'
-        check(package.path('resources')) { it.should exist }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.path('resources')) { expect(it).to exist }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should fail if archive path does not exist" do
         mkpath 'resources'
-        check(package) { it.path('not-resources').should exist }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package) { expect(it.path('not-resources')).to exist }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
 
       it "should pass if archive entry exists" do
         write 'resources/test'
-        check(package.entry('resources/test')) { it.should exist }
-        check(package.path('resources').entry('test')) { it.should exist }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.entry('resources/test')) { expect(it).to exist }
+        check(package.path('resources').entry('test')) { expect(it).to exist }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should fail if archive path does not exist" do
         mkpath 'resources'
-        check(package.entry('resources/test')) { it.should exist }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.entry('resources/test')) { expect(it).to exist }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
     end
 
     describe '#be_empty' do
       it "should pass if archive path is empty" do
         mkpath 'resources'
-        check(package.path('resources')) { it.should be_empty }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.path('resources')) { expect(it).to be_empty }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should fail if archive path has any entries" do
         write 'resources/test'
-        check(package.path('resources')) { it.should be_empty }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.path('resources')) { expect(it).to be_empty }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
 
       it "should pass if archive entry has no content" do
         write 'resources/test'
-        check(package.entry('resources/test')) { it.should be_empty }
-        check(package.path('resources').entry('test')) { it.should be_empty }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.entry('resources/test')) { expect(it).to be_empty }
+        check(package.path('resources').entry('test')) { expect(it).to be_empty }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should fail if archive entry has content" do
         write 'resources/test', 'something'
-        check(package.entry('resources/test')) { it.should be_empty }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.entry('resources/test')) { expect(it).to be_empty }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
 
       it "should fail if archive entry does not exist" do
         mkpath 'resources'
-        check(package.entry('resources/test')) { it.should be_empty }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.entry('resources/test')) { expect(it).to be_empty }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
     end
 
@@ -425,38 +425,38 @@ describe Buildr::Checks::Expectation do
 
       it "should pass if archive entry content matches string" do
         write 'resources/test', 'something'
-        check(package.entry('resources/test')) { it.should contain('thing') }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.entry('resources/test')) { expect(it).to contain('thing') }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should pass if archive entry content matches pattern" do
         write 'resources/test', "something\nor\another"
-        check(package.entry('resources/test')) { it.should contain(/or/) }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.entry('resources/test')) { expect(it).to contain(/or/) }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should pass if archive entry content matches all arguments" do
         write 'resources/test', "something\nor\nanother"
-        check(package.entry('resources/test')) { it.should contain(/or/, /other/) }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.entry('resources/test')) { expect(it).to contain(/or/, /other/) }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should fail unless archive path contains all arguments" do
         write 'resources/test', 'something'
-        check(package.entry('resources/test')) { it.should contain(/some/, /other/) }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.entry('resources/test')) { expect(it).to contain(/some/, /other/) }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
 
       it "should fail if archive entry content does not match" do
         write 'resources/test', 'something'
-        check(package.entry('resources/test')) { it.should contain(/other/) }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.entry('resources/test')) { expect(it).to contain(/other/) }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
 
       it "should fail if archive entry does not exist" do
         mkpath 'resources'
-        check(package.entry('resources/test')) { it.should contain(/anything/) }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.entry('resources/test')) { expect(it).to contain(/anything/) }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
     end
 
@@ -464,40 +464,40 @@ describe Buildr::Checks::Expectation do
 
       it "should pass if archive path contains file" do
         write 'resources/test'
-        check(package.path('resources')) { it.should contain('test') }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.path('resources')) { expect(it).to contain('test') }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should handle deep nesting" do
         write 'resources/test/test2.efx'
-        check(package) { it.should contain('resources/test/test2.efx') }
-        check(package.path('resources')) { it.should contain('test/test2.efx') }
-        check(package.path('resources/test')) { it.should contain('test2.efx') }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package) { expect(it).to contain('resources/test/test2.efx') }
+        check(package.path('resources')) { expect(it).to contain('test/test2.efx') }
+        check(package.path('resources/test')) { expect(it).to contain('test2.efx') }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should pass if archive path contains pattern" do
         write 'resources/with/test'
-        check(package.path('resources')) { it.should contain('**/t*st') }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.path('resources')) { expect(it).to contain('**/t*st') }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should pass if archive path contains all arguments" do
         write 'resources/with/test'
-        check(package.path('resources')) { it.should contain('**/test', '**/*') }
-        lambda { project('foo').task('package').invoke }.should_not raise_error
+        check(package.path('resources')) { expect(it).to contain('**/test', '**/*') }
+        expect { project('foo').task('package').invoke }.not_to raise_error
       end
 
       it "should fail unless archive path contains all arguments" do
         write 'resources/test'
-        check(package.path('resources')) { it.should contain('test', 'or-not') }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.path('resources')) { expect(it).to contain('test', 'or-not') }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
 
       it "should fail if archive path is empty" do
         mkpath 'resources'
-        check(package.path('resources')) { it.should contain('test') }
-        lambda { project('foo').task('package').invoke }.should raise_error(RuntimeError, /Checks failed/)
+        check(package.path('resources')) { expect(it).to contain('test') }
+        expect { project('foo').task('package').invoke }.to raise_error(RuntimeError, /Checks failed/)
       end
     end
   end

--- a/spec/core/common_spec.rb
+++ b/spec/core/common_spec.rb
@@ -23,20 +23,20 @@ describe Buildr.method(:struct) do
   end
 
   it 'should be object with key-value pairs' do
-    @struct.foo.should eql('foo:jar')
-    @struct.bar.should eql('bar:jar')
+    expect(@struct.foo).to eql('foo:jar')
+    expect(@struct.bar).to eql('bar:jar')
   end
 
   it 'should fail when requesting non-existent key' do
-    lambda { @struct.foobar }.should raise_error(NoMethodError)
+    expect { @struct.foobar }.to raise_error(NoMethodError)
   end
 
   it 'should return members when requested' do
-    @struct.members.map(&:to_s).sort.should eql(@hash.keys.map(&:to_s).sort)
+    expect(@struct.members.map(&:to_s).sort).to eql(@hash.keys.map(&:to_s).sort)
   end
 
   it 'should return valued when requested' do
-    @struct.values.sort.should eql(@hash.values.sort)
+    expect(@struct.values.sort).to eql(@hash.values.sort)
   end
 end
 
@@ -44,31 +44,31 @@ end
 describe Buildr.method(:write) do
   it 'should create path' do
     write 'foo/test'
-    File.directory?('foo').should be_true
-    File.exist?('foo/test').should be_true
+    expect(File.directory?('foo')).to be_truthy
+    expect(File.exist?('foo/test')).to be_truthy
   end
 
   it 'should write content to file' do
     write 'test', 'content'
-    File.read('test').should eql('content')
+    expect(File.read('test')).to eql('content')
   end
 
   it 'should retrieve content from block, if block given' do
     write('test') { 'block' }
-    File.read('test').should eql('block')
+    expect(File.read('test')).to eql('block')
   end
 
   it 'should write empty file if no content provided' do
     write 'test'
-    File.read('test').should eql('')
+    expect(File.read('test')).to eql('')
   end
 
   it 'should return content as a string' do
-    write('test', 'content').should eql('content')
+    expect(write('test', 'content')).to eql('content')
   end
 
   it 'should return empty string if no content provided' do
-    write('test').should eql('')
+    expect(write('test')).to eql('')
   end
 end
 
@@ -79,17 +79,17 @@ describe Buildr.method(:read) do
   end
 
   it 'should return contents of named file' do
-    read(@file).should eql(@content)
+    expect(read(@file)).to eql(@content)
   end
 
   it 'should yield to block if block given' do
     read @file do |content|
-      content.should eql(@content)
+      expect(content).to eql(@content)
     end
   end
 
   it 'should return block response if block given' do
-    read(@file) { 5 }.should be(5)
+    expect(read(@file) { 5 }).to be(5)
   end
 end
 
@@ -98,7 +98,7 @@ describe Buildr.method(:download) do
   before do
     @content = 'we has download!'
     @http = double('http')
-    @http.stub(:request).and_return(Net::HTTPNotModified.new(nil, nil, nil))
+    allow(@http).to receive(:request).and_return(Net::HTTPNotModified.new(nil, nil, nil))
   end
 
   def tasks()
@@ -106,7 +106,7 @@ describe Buildr.method(:download) do
   end
 
   it 'should be a file task' do
-    tasks.each { |task| task.should be_kind_of(Rake::FileTask) }
+    tasks.each { |task| expect(task).to be_kind_of(Rake::FileTask) }
   end
 
   it 'should accept a String and download from that URL' do
@@ -114,7 +114,7 @@ describe Buildr.method(:download) do
       download('http://localhost/download').tap do |task|
         task.source.should_receive(:read).and_yield [@content]
         task.invoke
-        task.should contain(@content)
+        expect(task).to contain(@content)
       end
     end
   end
@@ -124,7 +124,7 @@ describe Buildr.method(:download) do
       download(URI.parse('http://localhost/download')).tap do |task|
         task.source.should_receive(:read).and_yield [@content]
         task.invoke
-        task.should contain(@content)
+        expect(task).to contain(@content)
       end
     end
   end
@@ -134,7 +134,7 @@ describe Buildr.method(:download) do
       download('downloaded'=>'http://localhost/download').tap do |task|
         task.source.should_receive(:read).and_yield [@content]
         task.invoke
-        task.should contain(@content)
+        expect(task).to contain(@content)
       end
     end
   end
@@ -144,7 +144,7 @@ describe Buildr.method(:download) do
       artifact('com.example:library:jar:2.0').tap do |artifact|
         download(artifact=>'http://localhost/download').source.should_receive(:read).and_yield [@content]
         artifact.invoke
-        artifact.should contain(@content)
+        expect(artifact).to contain(@content)
       end
     end
   end
@@ -154,7 +154,7 @@ describe Buildr.method(:download) do
       download('downloaded'=>URI.parse('http://localhost/download')).tap do |task|
         task.source.should_receive(:read).and_yield [@content]
         task.invoke
-        task.should contain(@content)
+        expect(task).to contain(@content)
       end
     end
   end
@@ -164,25 +164,25 @@ describe Buildr.method(:download) do
       download('path/downloaded'=>URI.parse('http://localhost/download')).tap do |task|
         task.source.should_receive(:read).and_yield [@content]
         task.invoke
-        task.should contain(@content)
+        expect(task).to contain(@content)
       end
     end
   end
 
   it 'should fail if resource not found' do
     tasks.each do |task|
-      task.source.should_receive(:read).and_raise URI::NotFoundError
-      lambda { task.invoke }.should raise_error(URI::NotFoundError)
+      expect(task.source).to receive(:read).and_raise URI::NotFoundError
+      expect { task.invoke }.to raise_error(URI::NotFoundError)
     end
-    tasks.last.should_not exist
+    expect(tasks.last).not_to exist
   end
 
   it 'should fail on any other error' do
     tasks.each do |task|
-      task.source.should_receive(:read).and_raise RuntimeError
-      lambda { task.invoke }.should raise_error(RuntimeError)
+      expect(task.source).to receive(:read).and_raise RuntimeError
+      expect { task.invoke }.to raise_error(RuntimeError)
     end
-    tasks.last.should_not exist
+    expect(tasks.last).not_to exist
   end
 
   it 'should execute only if file does not already exist' do
@@ -196,19 +196,19 @@ describe Buildr.method(:download) do
   end
 
   it 'should execute without a proxy if none specified' do
-    Net::HTTP.should_receive(:new).with('localhost', 80).twice.and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('localhost', 80).twice.and_return(@http)
     tasks.each(&:invoke)
   end
 
   it 'should pass Buildr proxy options' do
     Buildr.options.proxy.http = 'http://proxy:8080'
-    Net::HTTP.should_receive(:new).with('localhost', 80, 'proxy', 8080, nil, nil).twice.and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('localhost', 80, 'proxy', 8080, nil, nil).twice.and_return(@http)
     tasks.each(&:invoke)
   end
 
   it 'should set HTTP proxy from HTTP_PROXY environment variable' do
     ENV['HTTP_PROXY'] = 'http://proxy:8080'
-    Net::HTTP.should_receive(:new).with('localhost', 80, 'proxy', 8080, nil, nil).twice.and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('localhost', 80, 'proxy', 8080, nil, nil).twice.and_return(@http)
     tasks.each(&:invoke)
   end
 end
@@ -220,21 +220,21 @@ describe Buildr.method(:filter) do
   end
 
   it 'should return a Filter for the source' do
-    filter(source).should be_kind_of(Filter)
+    expect(filter(source)).to be_kind_of(Filter)
   end
 
   it 'should use the source directory' do
-    filter(source).sources.should include(file(source))
+    expect(filter(source).sources).to include(file(source))
   end
 
   it 'should use the source directories' do
     dirs = ['first', 'second']
-    filter('first', 'second').sources.should include(*dirs.map { |dir| file(File.expand_path(dir)) })
+    expect(filter('first', 'second').sources).to include(*dirs.map { |dir| file(File.expand_path(dir)) })
   end
 
   it 'should accept a file task' do
     task = file(source)
-    filter(task).sources.each { |source| source.should be(task) }
+    filter(task).sources.each { |source| expect(source).to be(task) }
   end
 end
 
@@ -249,156 +249,156 @@ describe Buildr::Filter do
   end
 
   it 'should respond to :from and return self' do
-    @filter.from('src').should be(@filter)
+    expect(@filter.from('src')).to be(@filter)
   end
 
   it 'should respond to :from and add source directory' do
-    lambda { @filter.from('src') }.should change { @filter.sources }
+    expect { @filter.from('src') }.to change { @filter.sources }
   end
 
   it 'should respond to :from and add source directories' do
     dirs = ['first', 'second']
     @filter.from(*dirs)
-    @filter.sources.should include(*dirs.map { |dir| file(File.expand_path(dir)) })
+    expect(@filter.sources).to include(*dirs.map { |dir| file(File.expand_path(dir)) })
   end
 
   it 'should return source directories as file task' do
-    @filter.from('src').sources.each { |source| source.should be_kind_of(Rake::FileTask) }
+    @filter.from('src').sources.each { |source| expect(source).to be_kind_of(Rake::FileTask) }
   end
 
   it 'should return source directories as expanded path' do
-    @filter.from('src').sources.each { |source| source.to_s.should eql(File.expand_path('src')) }
+    @filter.from('src').sources.each { |source| expect(source.to_s).to eql(File.expand_path('src')) }
   end
 
   it 'should respond to :into and return self' do
-    @filter.into('target').should be(@filter)
+    expect(@filter.into('target')).to be(@filter)
   end
 
   it 'should respond to :into and set target directory' do
-    lambda { @filter.into('src') }.should change { @filter.target }
-    @filter.into('target').target.should be(file(File.expand_path('target')))
+    expect { @filter.into('src') }.to change { @filter.target }
+    expect(@filter.into('target').target).to be(file(File.expand_path('target')))
   end
 
   it 'should return target directory as file task' do
-    @filter.into('target').target.should be_kind_of(Rake::FileTask)
+    expect(@filter.into('target').target).to be_kind_of(Rake::FileTask)
   end
 
   it 'should return target directory as expanded path' do
-    @filter.into('target').target.to_s.should eql(File.expand_path('target'))
+    expect(@filter.into('target').target.to_s).to eql(File.expand_path('target'))
   end
 
   it 'should respond to :using and return self' do
-    @filter.using().should be(@filter)
+    expect(@filter.using()).to be(@filter)
   end
 
   it 'should respond to :using and set mapping from the argument' do
     mapping = { 'foo'=>'bar' }
-    lambda { @filter.using mapping }.should change { @filter.mapping }.to(mapping)
+    expect { @filter.using mapping }.to change { @filter.mapping }.to(mapping)
   end
 
   it 'should respond to :using and set mapping from the block' do
-    @filter.using { 5 }.mapping.call.should be(5)
+    expect(@filter.using { 5 }.mapping.call).to be(5)
   end
 
   it 'should respond to :include and return self' do
-    @filter.include('file').should be(@filter)
+    expect(@filter.include('file')).to be(@filter)
   end
 
   it 'should respond to :include and use these inclusion patterns' do
     @filter.from('src').into('target').include('file2', 'file3').run
-    Dir['target/*'].sort.should eql(['target/file2', 'target/file3'])
+    expect(Dir['target/*'].sort).to eql(['target/file2', 'target/file3'])
   end
 
   it 'should respond to :include with regular expressions and use these inclusion patterns' do
     @filter.from('src').into('target').include(/file[2|3]/).run
-    Dir['target/*'].sort.should eql(['target/file2', 'target/file3'])
+    expect(Dir['target/*'].sort).to eql(['target/file2', 'target/file3'])
   end
 
   it 'should respond to :include with a Proc and use these inclusion patterns' do
     @filter.from('src').into('target').include(lambda {|file| file[-1, 1].to_i%2 == 0}).run
-    Dir['target/*'].sort.should eql(['target/file2', 'target/file4'])
+    expect(Dir['target/*'].sort).to eql(['target/file2', 'target/file4'])
   end
 
   it 'should respond to :include with a FileTask and use these inclusion patterns' do
     @filter.from('src').into('target').include(file('target/file2'), file('target/file4')).run
-    Dir['target/*'].sort.should eql(['target/file2', 'target/file4'])
+    expect(Dir['target/*'].sort).to eql(['target/file2', 'target/file4'])
   end
 
   it 'should respond to :exclude and return self' do
-    @filter.exclude('file').should be(@filter)
+    expect(@filter.exclude('file')).to be(@filter)
   end
 
   it 'should respond to :exclude and use these exclusion patterns' do
     @filter.from('src').into('target').exclude('file2', 'file3').run
-    Dir['target/*'].sort.should eql(['target/file1', 'target/file4'])
+    expect(Dir['target/*'].sort).to eql(['target/file1', 'target/file4'])
   end
 
   it 'should respond to :exclude with regular expressions and use these exclusion patterns' do
     @filter.from('src').into('target').exclude(/file[2|3]/).run
-    Dir['target/*'].sort.should eql(['target/file1', 'target/file4'])
+    expect(Dir['target/*'].sort).to eql(['target/file1', 'target/file4'])
   end
 
   it 'should respond to :exclude with a Proc and use these exclusion patterns' do
     @filter.from('src').into('target').exclude(lambda {|file| file[-1, 1].to_i%2 == 0}).run
-    Dir['target/*'].sort.should eql(['target/file1', 'target/file3'])
+    expect(Dir['target/*'].sort).to eql(['target/file1', 'target/file3'])
   end
 
   it 'should respond to :exclude with a FileTask and use these exclusion patterns' do
     @filter.from('src').into('target').exclude(file('target/file1'), file('target/file3')).run
-    Dir['target/*'].sort.should eql(['target/file2', 'target/file4'])
+    expect(Dir['target/*'].sort).to eql(['target/file2', 'target/file4'])
   end
 
   it 'should respond to :exclude with a FileTask, use these exclusion patterns and depend on those tasks' do
     file1 = false
     file2 = false
     @filter.from('src').into('target').exclude(file('target/file1').enhance { file1 = true }, file('target/file3').enhance {file2 = true }).run
-    Dir['target/*'].sort.should eql(['target/file2', 'target/file4'])
+    expect(Dir['target/*'].sort).to eql(['target/file2', 'target/file4'])
     @filter.target.invoke
-    file1.should be_true
-    file2.should be_true
+    expect(file1).to be_truthy
+    expect(file2).to be_truthy
   end
 
   it 'should copy files over' do
     @filter.from('src').into('target').run
     Dir['target/*'].sort.each do |file|
-      read(file).should eql("#{File.basename(file)} raw")
+      expect(read(file)).to eql("#{File.basename(file)} raw")
     end
   end
 
   it 'should copy dot files over' do
     write 'src/.config', '# configuration'
     @filter.from('src').into('target').run
-    read('target/.config').should eql('# configuration')
+    expect(read('target/.config')).to eql('# configuration')
   end
 
   it 'should copy empty directories as well' do
     mkpath 'src/empty'
     @filter.from('src').into('target').run
-    File.directory?('target/empty').should be_true
+    expect(File.directory?('target/empty')).to be_truthy
   end
 
   it 'should copy files from multiple source directories' do
     4.upto(6) { |i| write "src2/file#{i}", "file#{i} raw" }
     @filter.from('src', 'src2').into('target').run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} raw")
+      expect(read(file)).to eql("#{File.basename(file)} raw")
     end
-    Dir['target/*'].should include(*(1..6).map { |i| "target/file#{i}" })
+    expect(Dir['target/*']).to include(*(1..6).map { |i| "target/file#{i}" })
   end
 
   it 'should copy files recursively' do
     mkpath 'src/path1' ; write 'src/path1/left'
     mkpath 'src/path2' ; write 'src/path2/right'
     @filter.from('src').into('target').run
-    Dir['target/**/*'].should include(*(1..4).map { |i| "target/file#{i}" })
-    Dir['target/**/*'].should include('target/path1/left', 'target/path2/right')
+    expect(Dir['target/**/*']).to include(*(1..4).map { |i| "target/file#{i}" })
+    expect(Dir['target/**/*']).to include('target/path1/left', 'target/path2/right')
   end
 
   it 'should apply hash mapping using Maven style' do
     1.upto(4) { |i| write "src/file#{i}", "file#{i} with ${key1} and ${key2}" }
     @filter.from('src').into('target').using('key1'=>'value1', 'key2'=>'value2').run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and value2")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and value2")
     end
   end
 
@@ -406,7 +406,7 @@ describe Buildr::Filter do
     1.upto(4) { |i| write "src/file#{i}", "file#{i} with @key1@ and @key2@" }
     @filter.from('src').into('target').using(:ant, 'key1'=>'value1', 'key2'=>'value2').run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and value2")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and value2")
     end
   end
 
@@ -414,7 +414,7 @@ describe Buildr::Filter do
     1.upto(4) { |i| write "src/file#{i}", "file#{i} with \#{key1} and \#{key2}" }
     @filter.from('src').into('target').using(:ruby, 'key1'=>'value1', 'key2'=>'value2').run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and value2")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and value2")
     end
   end
 
@@ -424,7 +424,7 @@ describe Buildr::Filter do
     key2 = 12
     @filter.from('src').into('target').using(binding).run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and 24")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and 24")
     end
   end
 
@@ -432,7 +432,7 @@ describe Buildr::Filter do
     1.upto(4) { |i| write "src/file#{i}", "file#{i} with <%= key1 %> and <%= key2 * 2 %>" }
     @filter.from('src').into('target').using(:erb, 'key1'=>'value1', 'key2'=> 12).run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and 24")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and 24")
     end
   end
 
@@ -441,7 +441,7 @@ describe Buildr::Filter do
     obj = Struct.new(:key1, :key2).new('value1', 12)
     @filter.from('src').into('target').using(:erb, obj).run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and 24")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and 24")
     end
   end
 
@@ -451,92 +451,92 @@ describe Buildr::Filter do
     key2 = 12
     @filter.from('src').into('target').using(:erb){}.run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and 24")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and 24")
     end
   end
 
   it 'should using Maven mapper by default' do
-    @filter.using('key1'=>'value1', 'key2'=>'value2').mapper.should eql(:maven)
+    expect(@filter.using('key1'=>'value1', 'key2'=>'value2').mapper).to eql(:maven)
   end
 
   it 'should apply hash mapping with boolean values' do
     write "src/file", "${key1} and ${key2}"
     @filter.from('src').into('target').using(:key1=>true, :key2=>false).run
-    read("target/file").should eql("true and false")
+    expect(read("target/file")).to eql("true and false")
   end
 
   it 'should apply hash mapping using regular expression' do
     1.upto(4) { |i| write "src/file#{i}", "file#{i} with #key1# and #key2#" }
     @filter.from('src').into('target').using(/#(.*?)#/, 'key1'=>'value1', 'key2'=>'value2').run
     Dir['target/*'].each do |file|
-      read(file).should eql("#{File.basename(file)} with value1 and value2")
+      expect(read(file)).to eql("#{File.basename(file)} with value1 and value2")
     end
   end
 
   it 'should apply proc mapping' do
     @filter.from('src').into('target').using { |file, content| 'proc mapped' }.run
     Dir['target/*'].each do |file|
-      read(file).should eql('proc mapped')
+      expect(read(file)).to eql('proc mapped')
     end
   end
 
   it 'should apply proc mapping with relative file name' do
-    @filter.from('src').into('target').using { |file, content| file.should =~ /^file\d$/ }.run
+    @filter.from('src').into('target').using { |file, content| expect(file).to match(/^file\d$/) }.run
   end
 
   it 'should apply proc mapping with file content' do
-    @filter.from('src').into('target').using { |file, content| content.should =~ /^file\d raw/ }.run
+    @filter.from('src').into('target').using { |file, content| expect(content).to match(/^file\d raw/) }.run
   end
 
   it 'should make target directory' do
-    lambda { @filter.from('src').into('target').run }.should change { File.exist?('target') }.to(true)
+    expect { @filter.from('src').into('target').run }.to change { File.exist?('target') }.to(true)
   end
 
   it 'should touch target directory' do
     mkpath 'target' ; File.utime @early, @early, 'target'
     @filter.from('src').into('target').run
-    File.stat('target').mtime.should be_within(10).of(Time.now)
+    expect(File.stat('target').mtime).to be_within(10).of(Time.now)
   end
 
   it 'should not touch target directory unless running' do
     mkpath 'target' ; File.utime @early, @early, 'target'
     @filter.from('src').into('target').exclude('*').run
-    File.mtime('target').should be_within(10).of(@early)
+    expect(File.mtime('target')).to be_within(10).of(@early)
   end
 
   it 'should run only on new files' do
     # Make source files older so they're not copied twice.
     Dir['src/**/*'].each { |file| File.utime(@early, @early, file) }
     @filter.from('src').into('target').run
-    @filter.from('src').into('target').using { |file, content| file.should eql('file2') }.run
+    @filter.from('src').into('target').using { |file, content| expect(file).to eql('file2') }.run
   end
 
   it 'should return true when run copies any files' do
-    @filter.from('src').into('target').run.should be(true)
+    expect(@filter.from('src').into('target').run).to be(true)
   end
 
   it 'should return false when run does not copy any files' do
     # Make source files older so they're not copied twice.
     Dir['src/**/*'].each { |file| File.utime(@early, @early, file) }
     @filter.from('src').into('target').run
-    @filter.from('src').into('target').run.should be(false)
+    expect(@filter.from('src').into('target').run).to be(false)
   end
 
   it 'should fail if source directory doesn\'t exist' do
-    lambda { Filter.new.from('srced').into('target').run }.should raise_error(RuntimeError, /doesn't exist/)
+    expect { Filter.new.from('srced').into('target').run }.to raise_error(RuntimeError, /doesn't exist/)
   end
 
   it 'should fail is target directory not set' do
-    lambda { Filter.new.from('src').run }.should raise_error(RuntimeError, /No target directory/)
+    expect { Filter.new.from('src').run }.to raise_error(RuntimeError, /No target directory/)
   end
 
   it 'should copy read-only files as writeable' do
     Dir['src/*'].each { |file| File.chmod(0444, file) }
     @filter.from('src').into('target').run
     Dir['target/*'].sort.each do |file|
-      File.readable?(file).should be_true
-      File.writable?(file).should be_true
-      (File.stat(file).mode & 0o200).should == 0o200
+      expect(File.readable?(file)).to be_truthy
+      expect(File.writable?(file)).to be_truthy
+      expect(File.stat(file).mode & 0o200).to eq(0o200)
     end
   end
 
@@ -545,7 +545,7 @@ describe Buildr::Filter do
     Dir['src/*'].each { |file| File.chmod(mode, file) }
     @filter.from('src').into('target').run
     Dir['target/*'].sort.each do |file|
-      (File.stat(file).mode & mode).should == mode
+      expect(File.stat(file).mode & mode).to eq(mode)
     end
   end
 end
@@ -572,23 +572,23 @@ describe Filter::Mapper do
     mapper.using(:moo, 'ooone', 'twoo') do |str|
       i = nil; str.capitalize.gsub(/\w/) { |s| s.send( (i = !i) ? 'upcase' : 'downcase' ) }
     end
-    mapper.transform('Moo cow, mooo cows singing mooooo').should == 'OoOnE cow, TwOo cows singing MoOoOo'
+    expect(mapper.transform('Moo cow, mooo cows singing mooooo')).to eq('OoOnE cow, TwOo cows singing MoOoOo')
   end
 
 end
 
 describe Buildr.method(:options) do
   it 'should return an Options object' do
-    options.should be_kind_of(Options)
+    expect(options).to be_kind_of(Options)
   end
 
   it 'should return an Options object each time' do
-    options.should be(options)
+    expect(options).to be(options)
   end
 
   it 'should return the same Options object when called on Object, Buildr or Project' do
-    options.should be(Buildr.options)
-    define('foo') { options.should be(Buildr.options) }
+    expect(options).to be(Buildr.options)
+    define('foo') { expect(options).to be(Buildr.options) }
   end
 end
 
@@ -602,56 +602,56 @@ describe Buildr::Options, 'proxy.exclude' do
     @no_proxy_args = [@host, 80]
     @proxy_args = @no_proxy_args + ['myproxy', 8080, nil, nil]
     @http = double('http')
-    @http.stub(:request).and_return(Net::HTTPNotModified.new(nil, nil, nil))
+    allow(@http).to receive(:request).and_return(Net::HTTPNotModified.new(nil, nil, nil))
   end
 
   it 'should be an array' do
-    options.proxy.exclude.should be_empty
+    expect(options.proxy.exclude).to be_empty
     options.proxy.exclude = @domain
-    options.proxy.exclude.should include(@domain)
+    expect(options.proxy.exclude).to include(@domain)
   end
 
   it 'should support adding to array' do
     options.proxy.exclude << @domain
-    options.proxy.exclude.should include(@domain)
+    expect(options.proxy.exclude).to include(@domain)
   end
 
   it 'should support resetting array' do
     options.proxy.exclude = @domain
     options.proxy.exclude = nil
-    options.proxy.exclude.should be_empty
+    expect(options.proxy.exclude).to be_empty
   end
 
   it 'should use proxy when not excluded' do
-    Net::HTTP.should_receive(:new).with(*@proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@proxy_args).and_return(@http)
     @uri.read :proxy=>options.proxy
   end
 
   it 'should use proxy unless excluded' do
     options.proxy.exclude = "not.#{@domain}"
-    Net::HTTP.should_receive(:new).with(*@proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@proxy_args).and_return(@http)
     @uri.read :proxy=>options.proxy
   end
 
   it 'should not use proxy if excluded' do
     options.proxy.exclude = @host
-    Net::HTTP.should_receive(:new).with(*@no_proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@no_proxy_args).and_return(@http)
     @uri.read :proxy=>options.proxy
   end
 
   it 'should support multiple host names' do
     options.proxy.exclude = ['optimus', 'prime']
-    Net::HTTP.should_receive(:new).with('optimus', 80).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('optimus', 80).and_return(@http)
     URI('http://optimus').read :proxy=>options.proxy
-    Net::HTTP.should_receive(:new).with('prime', 80).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('prime', 80).and_return(@http)
     URI('http://prime').read :proxy=>options.proxy
-    Net::HTTP.should_receive(:new).with('bumblebee', *@proxy_args[1..-1]).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('bumblebee', *@proxy_args[1..-1]).and_return(@http)
     URI('http://bumblebee').read :proxy=>options.proxy
   end
 
   it 'should support glob pattern on host name' do
     options.proxy.exclude = "*.#{@domain}"
-    Net::HTTP.should_receive(:new).with(*@no_proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@no_proxy_args).and_return(@http)
     @uri.read :proxy=>options.proxy
   end
 end
@@ -663,7 +663,7 @@ describe Hash, '::from_java_properties' do
 name1=value1
 name2=value2
     PROPS
-    hash.should == {'name1'=>'value1', 'name2'=>'value2'}
+    expect(hash).to eq({'name1'=>'value1', 'name2'=>'value2'})
   end
 
   it 'should ignore comments and empty lines' do
@@ -674,7 +674,7 @@ name1=value1
 name2=value2
 
 PROPS
-    hash.should == {'name1'=>'value1', 'name2'=>'value2'}
+    expect(hash).to eq({'name1'=>'value1', 'name2'=>'value2'})
   end
 
   it 'should allow multiple lines' do
@@ -687,7 +687,7 @@ name2=first\
  third
 
 PROPS
-    hash.should == {'name1'=>'start end', 'name2'=>'first second third'}
+    expect(hash).to eq({'name1'=>'start end', 'name2'=>'first second third'})
   end
 
   it 'should handle \t, \r, \n and \f' do
@@ -699,12 +699,12 @@ name2=with\\nand\f
 
 name3=double\\\\hash
 PROPS
-    hash.should == {'name1'=>"with\tand", 'name2'=>"with\nand\f", 'name3'=>'double\hash'}
+    expect(hash).to eq({'name1'=>"with\tand", 'name2'=>"with\nand\f", 'name3'=>'double\hash'})
   end
 
   it 'should ignore whitespace' do
     hash = Hash.from_java_properties('name1 = value1')
-    hash.should == {'name1'=>'value1'}
+    expect(hash).to eq({'name1'=>'value1'})
   end
 end
 
@@ -712,15 +712,15 @@ end
 describe Hash, '#to_java_properties' do
   it 'should return name/value pairs' do
     props = {'name1'=>'value1', 'name2'=>'value2'}.to_java_properties
-    props.split("\n").size.should be(2)
-    props.split("\n").should include('name1=value1')
-    props.split("\n").should include('name2=value2')
+    expect(props.split("\n").size).to be(2)
+    expect(props.split("\n")).to include('name1=value1')
+    expect(props.split("\n")).to include('name2=value2')
   end
 
   it 'should handle \t, \r, \n and \f' do
     props = {'name1'=>"with\tand\r", 'name2'=>"with\nand\f", 'name3'=>'double\hash'}.to_java_properties
-    props.split("\n").should include("name1=with\\tand\\r")
-    props.split("\n").should include("name2=with\\nand\\f")
-    props.split("\n").should include("name3=double\\\\hash")
+    expect(props.split("\n")).to include("name1=with\\tand\\r")
+    expect(props.split("\n")).to include("name2=with\\nand\\f")
+    expect(props.split("\n")).to include("name3=double\\\\hash")
   end
 end

--- a/spec/core/compile_spec.rb
+++ b/spec/core/compile_spec.rb
@@ -59,54 +59,54 @@ describe Buildr::CompileTask do
   include CompilerHelper
 
   it 'should respond to from() and return self' do
-    compile_task.from(sources).should be(compile_task)
+    expect(compile_task.from(sources)).to be(compile_task)
   end
 
   it 'should respond to from() with FileTask having no compiler set and return self' do
-    compile_task_without_compiler.from(file_task).should be(compile_task)
+    expect(compile_task_without_compiler.from(file_task)).to be(compile_task)
   end
 
   it 'should respond to from() and add sources' do
     compile_task.from sources, File.dirname(sources.first)
-    compile_task.sources.should == sources + [File.dirname(sources.first)]
+    expect(compile_task.sources).to eq(sources + [File.dirname(sources.first)])
   end
 
   it 'should respond to with() and return self' do
-    compile_task.with('test.jar').should be(compile_task)
+    expect(compile_task.with('test.jar')).to be(compile_task)
   end
 
   it 'should respond to with() and add dependencies' do
     jars = (1..3).map { |i| "test#{i}.jar" }
     compile_task.with *jars
-    compile_task.dependencies.should == artifacts(jars)
+    expect(compile_task.dependencies).to eq(artifacts(jars))
   end
 
   it 'should respond to into() and return self' do
-    compile_task.into('code').should be(compile_task)
+    expect(compile_task.into('code')).to be(compile_task)
   end
 
   it 'should respond to into() and create file task' do
     compile_task.from(sources).into('code')
-    lambda { file('code').invoke }.should run_task('foo:compile')
+    expect { file('code').invoke }.to run_task('foo:compile')
   end
 
   it 'should respond to using() and return self' do
-    compile_task.using(:source=>'1.4').should eql(compile_task)
+    expect(compile_task.using(:source=>'1.4')).to eql(compile_task)
   end
 
   it 'should respond to using() and set options' do
     compile_task.using(:source=>'1.4', 'target'=>'1.5')
-    compile_task.options.source.should eql('1.4')
-    compile_task.options.target.should eql('1.5')
+    expect(compile_task.options.source).to eql('1.4')
+    expect(compile_task.options.target).to eql('1.5')
   end
 
   it 'should attempt to identify compiler' do
-    Compiler.compilers.first.should_receive(:applies_to?).at_least(:once)
+    expect(Compiler.compilers.first).to receive(:applies_to?).at_least(:once)
     define('foo')
   end
 
   it 'should only support existing compilers' do
-    lambda { define('foo') { compile.using(:unknown) } }.should raise_error(ArgumentError, /unknown compiler/i)
+    expect { define('foo') { compile.using(:unknown) } }.to raise_error(ArgumentError, /unknown compiler/i)
   end
 
   it 'should allow overriding the guessed compiler' do
@@ -118,20 +118,20 @@ describe Buildr::CompileTask do
       compile.using(:scalac)
       new_compiler = compile.compiler
     }
-    old_compiler.should == :javac
-    new_compiler.should == :scalac
+    expect(old_compiler).to eq(:javac)
+    expect(new_compiler).to eq(:scalac)
   end
 end
 
 
 describe Buildr::CompileTask, '#compiler' do
   it 'should be nil if no compiler identifier' do
-    define('foo').compile.compiler.should be_nil
+    expect(define('foo').compile.compiler).to be_nil
   end
 
   it 'should return the selected compiler' do
     define('foo') { compile.using(:javac) }
-    project('foo').compile.compiler.should eql(:javac)
+    expect(project('foo').compile.compiler).to eql(:javac)
   end
 
   it 'should attempt to identify compiler if sources are specified' do
@@ -147,19 +147,19 @@ describe Buildr::CompileTask, '#compiler' do
       compile.sources.clear
     end
     project('foo').compile.invoke
-    Dir['target/classes/*'].should be_empty
+    expect(Dir['target/classes/*']).to be_empty
   end
 end
 
 
 describe Buildr::CompileTask, '#language' do
   it 'should be nil if no compiler identifier' do
-    define('foo').compile.language.should be_nil
+    expect(define('foo').compile.language).to be_nil
   end
 
   it 'should return the appropriate language' do
     define('foo') { compile.using(:javac) }
-    project('foo').compile.language.should eql(:java)
+    expect(project('foo').compile.language).to eql(:java)
   end
 end
 
@@ -168,36 +168,36 @@ describe Buildr::CompileTask, '#sources' do
   include CompilerHelper
 
   it 'should be empty if no sources in default directory' do
-    compile_task.sources.should be_empty
+    expect(compile_task.sources).to be_empty
   end
 
   it 'should point to default directory if it contains sources' do
     write 'src/main/java', ''
-    compile_task.sources.first.should point_to_path('src/main/java')
+    expect(compile_task.sources.first).to point_to_path('src/main/java')
   end
 
   it 'should be an array' do
     compile_task.sources += sources
-    compile_task.sources.should == sources
+    expect(compile_task.sources).to eq(sources)
   end
 
   it 'should allow files' do
     compile_task.from(sources).into('classes').invoke
-    sources.each { |src| file(src.pathmap('classes/thepackage/%n.class')).should exist }
+    sources.each { |src| expect(file(src.pathmap('classes/thepackage/%n.class'))).to exist }
   end
 
   it 'should allow directories' do
     compile_task.from(File.dirname(sources.first)).into('classes').invoke
-    sources.each { |src| file(src.pathmap('classes/thepackage/%n.class')).should exist }
+    sources.each { |src| expect(file(src.pathmap('classes/thepackage/%n.class'))).to exist }
   end
 
   it 'should allow tasks' do
-    lambda { compile_task.from(file(sources.first)).into('classes').invoke }.should run_task('foo:compile')
+    expect { compile_task.from(file(sources.first)).into('classes').invoke }.to run_task('foo:compile')
   end
 
   it 'should act as prerequisites' do
     file('src2') { |task| task('prereq').invoke ; mkpath task.name }
-    lambda { compile_task.from('src2').into('classes').invoke }.should run_task('prereq')
+    expect { compile_task.from('src2').into('classes').invoke }.to run_task('prereq')
   end
 end
 
@@ -206,17 +206,17 @@ describe Buildr::CompileTask, '#dependencies' do
   include CompilerHelper
 
   it 'should be empty' do
-    compile_task.dependencies.should be_empty
+    expect(compile_task.dependencies).to be_empty
   end
 
   it 'should be an array' do
     compile_task.dependencies += jars
-    compile_task.dependencies.should == jars
+    expect(compile_task.dependencies).to eq(jars)
   end
 
   it 'should allow files' do
     compile_task.from(sources).with(jars).into('classes').invoke
-    sources.each { |src| file(src.pathmap('classes/thepackage/%n.class')).should exist }
+    sources.each { |src| expect(file(src.pathmap('classes/thepackage/%n.class'))).to exist }
   end
 
   it 'should allow tasks' do
@@ -231,13 +231,13 @@ describe Buildr::CompileTask, '#dependencies' do
   it 'should allow projects' do
     define('bar', :version=>'1', :group=>'self') { package :jar }
     compile_task.with project('bar')
-    compile_task.dependencies.should == project('bar').packages
+    expect(compile_task.dependencies).to eq(project('bar').packages)
   end
 
   it 'should be accessible as classpath up to version 1.5 since it was deprecated in version 1.3' do
-    Buildr::VERSION.should < '1.5'
-    lambda { compile_task.classpath = jars }.should change(compile_task, :dependencies).to(jars)
-    lambda { compile_task.dependencies = [] }.should change(compile_task, :classpath).to([])
+    expect(Buildr::VERSION).to be < '1.5'
+    expect { compile_task.classpath = jars }.to change(compile_task, :dependencies).to(jars)
+    expect { compile_task.dependencies = [] }.to change(compile_task, :classpath).to([])
   end
 
 end
@@ -248,17 +248,17 @@ describe Buildr::CompileTask, '#target' do
 
   it 'should be a file task' do
     compile_task.from(@sources).into('classes')
-    compile_task.target.should be_kind_of(Rake::FileTask)
+    expect(compile_task.target).to be_kind_of(Rake::FileTask)
   end
 
   it 'should accept a task' do
     task = file('classes')
-    compile_task.into(task).target.should be(task)
+    expect(compile_task.into(task).target).to be(task)
   end
 
   it 'should create dependency in file task when set' do
     compile_task.from(sources).into('classes')
-    lambda { file('classes').invoke }.should run_task('foo:compile')
+    expect { file('classes').invoke }.to run_task('foo:compile')
   end
 end
 
@@ -268,17 +268,17 @@ describe Buildr::CompileTask, '#options' do
 
   it 'should have getter and setter methods' do
     compile_task.options.foo = 'bar'
-    compile_task.options.foo.should eql('bar')
+    expect(compile_task.options.foo).to eql('bar')
   end
 
   it 'should have bracket accessors' do
     compile_task.options[:foo] = 'bar'
-    compile_task.options[:foo].should eql('bar')
+    expect(compile_task.options[:foo]).to eql('bar')
   end
 
   it 'should map from bracket accessor to get/set accessor' do
     compile_task.options[:foo] = 'bar'
-    compile_task.options.foo.should eql('bar')
+    expect(compile_task.options.foo).to eql('bar')
   end
 
   it 'should be independent of parent' do
@@ -288,8 +288,8 @@ describe Buildr::CompileTask, '#options' do
         compile.using(:javac, :source=>'1.5')
       end
     end
-    project('foo').compile.options.source.should eql('1.4')
-    project('foo:bar').compile.options.source.should eql('1.5')
+    expect(project('foo').compile.options.source).to eql('1.4')
+    expect(project('foo:bar').compile.options.source).to eql('1.5')
   end
 end
 
@@ -299,52 +299,52 @@ describe Buildr::CompileTask, '#invoke' do
 
   it 'should compile into target directory' do
     compile_task.from(sources).into('code').invoke
-    Dir['code/thepackage/*.class'].should_not be_empty
+    expect(Dir['code/thepackage/*.class']).not_to be_empty
   end
 
   it 'should compile only once' do
     compile_task.from(sources)
-    lambda { compile_task.target.invoke }.should run_task('foo:compile')
-    lambda { compile_task.invoke }.should_not run_task('foo:compile')
+    expect { compile_task.target.invoke }.to run_task('foo:compile')
+    expect { compile_task.invoke }.not_to run_task('foo:compile')
   end
 
   it 'should compile if there are source files to compile' do
-    lambda { compile_task.from(sources).invoke }.should run_task('foo:compile')
+    expect { compile_task.from(sources).invoke }.to run_task('foo:compile')
   end
 
   it 'should not compile unless there are source files to compile' do
-    lambda { compile_task.invoke }.should_not run_task('foo:compile')
+    expect { compile_task.invoke }.not_to run_task('foo:compile')
   end
 
   it 'should require source file or directory to exist' do
-    lambda { compile_task.from('empty').into('classes').invoke }.should raise_error(RuntimeError, /Don't know how to build/)
+    expect { compile_task.from('empty').into('classes').invoke }.to raise_error(RuntimeError, /Don't know how to build/)
   end
 
   it 'should run all source files as prerequisites' do
     mkpath 'src'
-    file('src').should_receive :invoke_prerequisites
+    expect(file('src')).to receive :invoke_prerequisites
     compile_task.from('src').invoke
   end
 
   it 'should require dependencies to exist' do
-    lambda { compile_task.from(sources).with('no-such.jar').into('classes').invoke }.should \
+    expect { compile_task.from(sources).with('no-such.jar').into('classes').invoke }.to \
       raise_error(RuntimeError, /Don't know how to build/)
   end
 
   it 'should run all dependencies as prerequisites' do
     file(File.expand_path('no-such.jar')) { |task| task('prereq').invoke }
-    lambda { compile_task.from(sources).with('no-such.jar').into('classes').invoke }.should run_tasks(['prereq', 'foo:compile'])
+    expect { compile_task.from(sources).with('no-such.jar').into('classes').invoke }.to run_tasks(['prereq', 'foo:compile'])
   end
 
   it 'should force compilation if no target' do
-    lambda { compile_task.from(sources).invoke }.should run_task('foo:compile')
+    expect { compile_task.from(sources).invoke }.to run_task('foo:compile')
   end
 
   it 'should force compilation if target empty' do
     time = now_at_fs_resolution
     mkpath compile_task.target.to_s
     File.utime(time - 1, time - 1, compile_task.target.to_s)
-    lambda { compile_task.from(sources).invoke }.should run_task('foo:compile')
+    expect { compile_task.from(sources).invoke }.to run_task('foo:compile')
   end
 
   it 'should force compilation if sources newer than compiled' do
@@ -354,7 +354,7 @@ describe Buildr::CompileTask, '#invoke' do
     sources.map { |src| src.pathmap("#{compile_task.target}/thepackage/%n.class") }.
       each { |kls| write kls ; File.utime(time, time, kls) }
     File.utime(time - 1, time - 1, project('foo').compile.target.to_s)
-    lambda { compile_task.from(sources).invoke }.should run_task('foo:compile')
+    expect { compile_task.from(sources).invoke }.to run_task('foo:compile')
   end
 
   it 'should not force compilation if sources older than compiled' do
@@ -362,7 +362,7 @@ describe Buildr::CompileTask, '#invoke' do
     time = now_at_fs_resolution
     sources.map { |src| File.utime(time, time, src); src.pathmap("#{compile_task.target}/thepackage/%n.class") }.
       each { |kls| write kls ; File.utime(time, time, kls) }
-    lambda { compile_task.from(sources).invoke }.should_not run_task('foo:compile')
+    expect { compile_task.from(sources).invoke }.not_to run_task('foo:compile')
   end
 
   it 'should not force compilation if dependencies older than compiled' do
@@ -371,7 +371,7 @@ describe Buildr::CompileTask, '#invoke' do
     jars.each { |jar| File.utime(time - 1 , time - 1, jar) }
     sources.map { |src| File.utime(time, time, src); src.pathmap("#{compile_task.target}/thepackage/%n.class") }.
       each { |kls| write kls ; File.utime(time, time, kls) }
-    lambda { compile_task.from(sources).with(jars).invoke }.should_not run_task('foo:compile')
+    expect { compile_task.from(sources).with(jars).invoke }.not_to run_task('foo:compile')
   end
 
   it 'should force compilation if dependencies newer than compiled' do
@@ -382,28 +382,28 @@ describe Buildr::CompileTask, '#invoke' do
       each { |kls| write kls ; File.utime(time - 1, time - 1, kls) }
     File.utime(time - 1, time - 1, project('foo').compile.target.to_s)
     jars.each { |jar| File.utime(time + 1, time + 1, jar) }
-    lambda { compile_task.from(sources).with(jars).invoke }.should run_task('foo:compile')
+    expect { compile_task.from(sources).with(jars).invoke }.to run_task('foo:compile')
   end
 
   it 'should timestamp target directory if specified' do
     time = now_at_fs_resolution - 10
     mkpath compile_task.target.to_s
     File.utime(time, time, compile_task.target.to_s)
-    compile_task.timestamp.should be_within(1).of(time)
+    expect(compile_task.timestamp).to be_within(1).of(time)
   end
 
   it 'should touch target if anything compiled' do
     mkpath compile_task.target.to_s
     File.utime(now_at_fs_resolution - 10, now_at_fs_resolution - 10, compile_task.target.to_s)
     compile_task.from(sources).invoke
-    File.stat(compile_task.target.to_s).mtime.should be_within(2).of(now_at_fs_resolution)
+    expect(File.stat(compile_task.target.to_s).mtime).to be_within(2).of(now_at_fs_resolution)
   end
 
   it 'should not touch target if nothing compiled' do
     mkpath compile_task.target.to_s
     File.utime(now_at_fs_resolution - 10, now_at_fs_resolution - 10, compile_task.target.to_s)
     compile_task.invoke
-    File.stat(compile_task.target.to_s).mtime.should be_within(2).of(now_at_fs_resolution - 10)
+    expect(File.stat(compile_task.target.to_s).mtime).to be_within(2).of(now_at_fs_resolution - 10)
   end
 
   it 'should not touch target if failed to compile' do
@@ -411,13 +411,13 @@ describe Buildr::CompileTask, '#invoke' do
     File.utime(now_at_fs_resolution - 10, now_at_fs_resolution - 10, compile_task.target.to_s)
     write 'failed.java', 'not a class'
     suppress_stdout { compile_task.from('failed.java').invoke rescue nil }
-    File.stat(compile_task.target.to_s).mtime.should be_within(2).of(now_at_fs_resolution - 10)
+    expect(File.stat(compile_task.target.to_s).mtime).to be_within(2).of(now_at_fs_resolution - 10)
   end
 
   it 'should complain if source directories and no compiler selected' do
     mkpath 'sources'
     define 'bar' do
-      lambda { compile.from('sources').invoke }.should raise_error(RuntimeError, /no compiler selected/i)
+      expect { compile.from('sources').invoke }.to raise_error(RuntimeError, /no compiler selected/i)
     end
   end
 
@@ -429,30 +429,30 @@ describe Buildr::CompileTask, '#invoke' do
     touch 'target/classes/foo/Foo.class'
     File.utime(now_at_fs_resolution - 10, now_at_fs_resolution - 10, compile_task.target.to_s)
     compile_task.invoke
-    File.stat(compile_task.target.to_s).mtime.should be_within(2).of(now_at_fs_resolution - 10)
+    expect(File.stat(compile_task.target.to_s).mtime).to be_within(2).of(now_at_fs_resolution - 10)
   end
 end
 
 
 shared_examples_for 'accessor task' do
   it 'should return a task' do
-    define('foo').send(@task_name).should be_kind_of(Rake::Task)
+    expect(define('foo').send(@task_name)).to be_kind_of(Rake::Task)
   end
 
   it 'should always return the same task' do
     task_name, task = @task_name, nil
     define('foo') { task = self.send(task_name) }
-    project('foo').send(task_name).should be(task)
+    expect(project('foo').send(task_name)).to be(task)
   end
 
   it 'should be unique for the project' do
     define('foo') { define 'bar' }
-    project('foo').send(@task_name).should_not eql(project('foo:bar').send(@task_name))
+    expect(project('foo').send(@task_name)).not_to eql(project('foo:bar').send(@task_name))
   end
 
   it 'should be named after the project' do
     define('foo') { define 'bar' }
-    project('foo:bar').send(@task_name).name.should eql("foo:bar:#{@task_name}")
+    expect(project('foo:bar').send(@task_name).name).to eql("foo:bar:#{@task_name}")
   end
 end
 
@@ -462,52 +462,52 @@ describe Project, '#compile' do
   it_should_behave_like 'accessor task'
 
   it 'should return a compile task' do
-    define('foo').compile.should be_instance_of(CompileTask)
+    expect(define('foo').compile).to be_instance_of(CompileTask)
   end
 
   it 'should accept sources and add to source list' do
     define('foo') { compile('file1', 'file2') }
-    project('foo').compile.sources.should include('file1', 'file2')
+    expect(project('foo').compile.sources).to include('file1', 'file2')
   end
 
   it 'should accept block and enhance task' do
     write 'src/main/java/Test.java', 'class Test {}'
     action = task('action')
     define('foo') { compile { action.invoke } }
-    lambda { project('foo').compile.invoke }.should run_tasks('foo:compile', action)
+    expect { project('foo').compile.invoke }.to run_tasks('foo:compile', action)
   end
 
   it 'should execute resources task' do
     define 'foo'
-    lambda { project('foo').compile.invoke }.should run_task('foo:resources')
+    expect { project('foo').compile.invoke }.to run_task('foo:resources')
   end
 
   it 'should be recursive' do
     write 'bar/src/main/java/Test.java', 'class Test {}'
     define('foo') { define 'bar' }
-    lambda { project('foo').compile.invoke }.should run_task('foo:bar:compile')
+    expect { project('foo').compile.invoke }.to run_task('foo:bar:compile')
   end
 
   it 'should be a local task' do
     write 'bar/src/main/java/Test.java', 'class Test {}'
     define('foo') { define 'bar' }
-    lambda do
+    expect do
       in_original_dir project('foo:bar').base_dir do
         task('compile').invoke
       end
-    end.should run_task('foo:bar:compile').but_not('foo:compile')
+    end.to run_task('foo:bar:compile').but_not('foo:compile')
   end
 
   it 'should run from build task' do
     write 'bar/src/main/java/Test.java', 'class Test {}'
     define('foo') { define 'bar' }
-    lambda { task('build').invoke }.should run_task('foo:bar:compile')
+    expect { task('build').invoke }.to run_task('foo:bar:compile')
   end
 
   it 'should clean after itself' do
     mkpath 'code'
     define('foo') { compile.into('code') }
-    lambda { task('clean').invoke }.should change { File.exist?('code') }.to(false)
+    expect { task('clean').invoke }.to change { File.exist?('code') }.to(false)
   end
 end
 
@@ -517,26 +517,26 @@ describe Project, '#resources' do
   it_should_behave_like 'accessor task'
 
   it 'should return a resources task' do
-    define('foo').resources.should be_instance_of(ResourcesTask)
+    expect(define('foo').resources).to be_instance_of(ResourcesTask)
   end
 
   it 'should provide a filter' do
-    define('foo').resources.filter.should be_instance_of(Filter)
+    expect(define('foo').resources.filter).to be_instance_of(Filter)
   end
 
   it 'should include src/main/resources as source directory' do
     write 'src/main/resources/test'
-    define('foo').resources.sources.first.should point_to_path('src/main/resources')
+    expect(define('foo').resources.sources.first).to point_to_path('src/main/resources')
   end
 
   it 'should include src/main/resources directory only if it exists' do
-    define('foo').resources.sources.should be_empty
+    expect(define('foo').resources.sources).to be_empty
   end
 
   it 'should accept prerequisites' do
     tasks = ['task1', 'task2'].each { |name| task(name) }
     define('foo') { resources 'task1', 'task2' }
-    lambda { project('foo').resources.invoke }.should run_tasks('task1', 'task2')
+    expect { project('foo').resources.invoke }.to run_tasks('task1', 'task2')
   end
 
   it 'should respond to from and add additional sources' do
@@ -544,50 +544,50 @@ describe Project, '#resources' do
     write 'extra/spicy'
     define('foo') { resources.from 'extra' }
     project('foo').resources.invoke
-    FileList['target/resources/*'].sort.should  == ['target/resources/original', 'target/resources/spicy']
+    expect(FileList['target/resources/*'].sort).to  eq(['target/resources/original', 'target/resources/spicy'])
   end
 
   it 'should pass include pattern to filter' do
     3.times { |i| write "src/main/resources/test#{i + 1}" }
     define('foo') { resources.include('test2') }
     project('foo').resources.invoke
-    FileList['target/resources/*'].should  == ['target/resources/test2']
+    expect(FileList['target/resources/*']).to  eq(['target/resources/test2'])
   end
 
   it 'should pass exclude pattern to filter' do
     3.times { |i| write "src/main/resources/test#{i + 1}" }
     define('foo') { resources.exclude('test2') }
     project('foo').resources.invoke
-    FileList['target/resources/*'].sort.should  == ['target/resources/test1', 'target/resources/test3']
+    expect(FileList['target/resources/*'].sort).to  eq(['target/resources/test1', 'target/resources/test3'])
   end
 
   it 'should accept block and enhance task' do
     action = task('action')
     define('foo') { resources { action.invoke } }
-    lambda { project('foo').resources.invoke }.should run_tasks('foo:resources', action)
+    expect { project('foo').resources.invoke }.to run_tasks('foo:resources', action)
   end
 
   it 'should set target directory to target/resources' do
     write 'src/main/resources/foo'
-    define('foo').resources.target.to_s.should point_to_path('target/resources')
+    expect(define('foo').resources.target.to_s).to point_to_path('target/resources')
   end
 
   it 'should use provided target directoy' do
     define('foo') { resources.filter.into('the_resources') }
-    project('foo').resources.target.to_s.should point_to_path('the_resources')
+    expect(project('foo').resources.target.to_s).to point_to_path('the_resources')
   end
 
   it 'should create file task for target directory' do
     write 'src/main/resources/foo'
     define 'foo'
     project('foo').file('target/resources').invoke
-    file('target/resources/foo').should exist
+    expect(file('target/resources/foo')).to exist
   end
 
   it 'should copy resources to target directory' do
     write 'src/main/resources/foo', 'Foo'
     define('foo').compile.invoke
-    file('target/resources/foo').should contain('Foo')
+    expect(file('target/resources/foo')).to contain('Foo')
   end
 
   it 'should copy new resources to target directory' do
@@ -599,7 +599,7 @@ describe Project, '#resources' do
 
     define('foo')
     project('foo').file('target/resources').invoke
-    file('target/resources/foo').should exist
+    expect(file('target/resources/foo')).to exist
   end
 
   it 'should copy updated resources to target directory' do
@@ -612,23 +612,23 @@ describe Project, '#resources' do
     write 'src/main/resources/foo', 'Foo2'
     define('foo')
     project('foo').file('target/resources').invoke
-    file('target/resources/foo').should contain('Foo2')
+    expect(file('target/resources/foo')).to contain('Foo2')
   end
 
   it 'should not create target directory unless there are resources' do
     define('foo').compile.invoke
-    file('target/resources').should_not exist
+    expect(file('target/resources')).not_to exist
   end
 
   it 'should run from target/resources' do
     write 'src/main/resources/test'
     define('foo')
-    lambda { project('foo').resources.target.invoke }.should change { File.exist?('target/resources/test') }.to(true)
+    expect { project('foo').resources.target.invoke }.to change { File.exist?('target/resources/test') }.to(true)
   end
 
   it 'should not be recursive' do
     define('foo') { define 'bar' }
-    lambda { project('foo').resources.invoke }.should_not run_task('foo:bar:resources')
+    expect { project('foo').resources.invoke }.not_to run_task('foo:bar:resources')
   end
 
   it 'should use current profile for filtering' do
@@ -642,7 +642,7 @@ describe Project, '#resources' do
     YAML
     write 'src/main/resources/foo', '${foo}'
     define('foo').compile.invoke
-    file('target/resources/foo').should contain('bar')
+    expect(file('target/resources/foo')).to contain('bar')
   end
 
   it 'should use current profile as default for filtering' do
@@ -656,7 +656,7 @@ describe Project, '#resources' do
       resources.filter.using 'baz' => 'qux'
     end
     project('foo').compile.invoke
-    file('target/resources/foo').should contain('bar qux')
+    expect(file('target/resources/foo')).to contain('bar qux')
   end
 
   it 'should allow clearing default filter mapping' do
@@ -671,6 +671,6 @@ describe Project, '#resources' do
       resources.filter.using 'baz' => 'qux'
     end
     project('foo').compile.invoke
-    file('target/resources/foo').should contain('${foo} qux')
+    expect(file('target/resources/foo')).to contain('${foo} qux')
   end
 end

--- a/spec/core/console_spec.rb
+++ b/spec/core/console_spec.rb
@@ -20,7 +20,7 @@ describe Buildr::Console do
   describe 'console_dimensions' do
 
     it 'should return a value' do
-      Buildr::Console.console_dimensions.should_not be_nil if $stdout.isatty # have to ask again as stdout may be redirected.
+      expect(Buildr::Console.console_dimensions).not_to be_nil if $stdout.isatty # have to ask again as stdout may be redirected.
     end if $stdout.isatty && !ENV["TRAVIS"] && !Buildr::Util.win_os?
   end
 
@@ -32,15 +32,15 @@ describe Buildr::Console do
       end
 
       it 'should emit red code when asked' do
-        Buildr::Console.color('message', :red).should eql("\e[31mmessage\e[0m")
+        expect(Buildr::Console.color('message', :red)).to eql("\e[31mmessage\e[0m")
       end
 
       it 'should emit green code when asked' do
-        Buildr::Console.color('message', :green).should eql("\e[32mmessage\e[0m")
+        expect(Buildr::Console.color('message', :green)).to eql("\e[32mmessage\e[0m")
       end
 
       it 'should emit blue code when asked' do
-        Buildr::Console.color('message', :blue).should eql("\e[34mmessage\e[0m")
+        expect(Buildr::Console.color('message', :blue)).to eql("\e[34mmessage\e[0m")
       end
     end if $stdout.isatty && !Buildr::Util.win_os?
 
@@ -50,15 +50,15 @@ describe Buildr::Console do
       end
 
       it 'should not emit red code when asked' do
-        Buildr::Console.color('message', :red).should eql("message")
+        expect(Buildr::Console.color('message', :red)).to eql("message")
       end
 
       it 'should not emit green code when asked' do
-        Buildr::Console.color('message', :green).should eql("message")
+        expect(Buildr::Console.color('message', :green)).to eql("message")
       end
 
       it 'should not emit blue code when asked' do
-        Buildr::Console.color('message', :blue).should eql("message")
+        expect(Buildr::Console.color('message', :blue)).to eql("message")
       end
     end
   end

--- a/spec/core/doc_spec.rb
+++ b/spec/core/doc_spec.rb
@@ -26,18 +26,18 @@ describe Project, '#doc' do
 
   it 'should return the project\'s Javadoc task' do
     define('foo') { compile.using(:javac) }
-    project('foo').doc.name.should eql('foo:doc')
+    expect(project('foo').doc.name).to eql('foo:doc')
   end
 
   it 'should return a DocTask' do
     define('foo') { compile.using(:javac) }
-    project('foo').doc.should be_kind_of(Doc::DocTask)
+    expect(project('foo').doc).to be_kind_of(Doc::DocTask)
   end
 
   it 'should set target directory to target/doc' do
     define 'foo' do
       compile.using(:javac)
-      doc.target.to_s.should point_to_path('target/doc')
+      expect(doc.target.to_s).to point_to_path('target/doc')
     end
   end
 
@@ -52,7 +52,7 @@ describe Project, '#doc' do
   it 'should respond to into() and return self' do
     define 'foo' do
       compile.using(:javac)
-      doc.into('docs').should be(doc)
+      expect(doc.into('docs')).to be(doc)
     end
   end
 
@@ -71,22 +71,22 @@ describe Project, '#doc' do
       compile.using(:javac)
       task = doc.from('srcs')
     end
-    task.should be(project('foo').doc)
+    expect(task).to be(project('foo').doc)
   end
 
   it 'should respond to from() and add sources' do
     define 'foo' do
       compile.using(:javac)
-      doc.from('srcs').should be(doc)
+      expect(doc.from('srcs')).to be(doc)
     end
   end
 
   it 'should respond to from() and add file task' do
     define 'foo' do
       compile.using(:javac)
-      doc.from('srcs').should be(doc)
+      expect(doc.from('srcs')).to be(doc)
     end
-    project('foo').doc.source_files.first.should point_to_path('srcs')
+    expect(project('foo').doc.source_files.first).to point_to_path('srcs')
   end
 
   it 'should respond to from() and add project\'s sources and dependencies' do
@@ -96,25 +96,25 @@ describe Project, '#doc' do
       define('bar') { compile.using(:javac).with 'group:id:jar:1.0' }
       doc.from project('foo:bar')
     end
-    project('foo').doc.source_files.first.should point_to_path('bar/src/main/java/Test.java')
-    project('foo').doc.classpath.map(&:to_spec).should include('group:id:jar:1.0')
+    expect(project('foo').doc.source_files.first).to point_to_path('bar/src/main/java/Test.java')
+    expect(project('foo').doc.classpath.map(&:to_spec)).to include('group:id:jar:1.0')
   end
 
   it 'should generate docs from project' do
     sources
     define('foo') { compile.using(:javac) }
-    project('foo').doc.source_files.sort.should == sources.sort.map { |f| File.expand_path(f) }
+    expect(project('foo').doc.source_files.sort).to eq(sources.sort.map { |f| File.expand_path(f) })
   end
 
   it 'should include compile dependencies' do
     define('foo') { compile.using(:javac).with 'group:id:jar:1.0' }
-    project('foo').doc.classpath.map(&:to_spec).should include('group:id:jar:1.0')
+    expect(project('foo').doc.classpath.map(&:to_spec)).to include('group:id:jar:1.0')
   end
 
   it 'should respond to include() and return self' do
     define 'foo' do
       compile.using(:javac)
-      doc.include('srcs').should be(doc)
+      expect(doc.include('srcs')).to be(doc)
     end
   end
 
@@ -124,13 +124,13 @@ describe Project, '#doc' do
       compile.using(:javac)
       doc.include included
     end
-    project('foo').doc.source_files.should include(File.expand_path(included))
+    expect(project('foo').doc.source_files).to include(File.expand_path(included))
   end
 
   it 'should respond to exclude() and return self' do
     define 'foo' do
       compile.using(:javac)
-      doc.exclude('srcs').should be(doc)
+      expect(doc.exclude('srcs')).to be(doc)
     end
   end
 
@@ -141,13 +141,13 @@ describe Project, '#doc' do
       doc.exclude excluded
     end
     sources
-    project('foo').doc.source_files.sort.should == sources[1..-1].map { |f| File.expand_path(f) }
+    expect(project('foo').doc.source_files.sort).to eq(sources[1..-1].map { |f| File.expand_path(f) })
   end
 
   it 'should respond to using() and return self' do
     define 'foo' do
       compile.using(:javac)
-      doc.using(:foo=>'Fooing').should be(doc)
+      expect(doc.using(:foo=>'Fooing')).to be(doc)
     end
   end
 
@@ -156,14 +156,14 @@ describe Project, '#doc' do
       compile.using(:javac)
       doc.using :foo=>'Fooing'
     end
-    project('foo').doc.options[:foo].should eql('Fooing')
+    expect(project('foo').doc.options[:foo]).to eql('Fooing')
   end
 
   it 'should produce documentation' do
     sources
     define('foo') { compile.using(:javac) }
     project('foo').doc.invoke
-    (1..3).map { |i| "target/doc/foo/Test#{i}.html" }.each { |f| file(f).should exist }
+    (1..3).map { |i| "target/doc/foo/Test#{i}.html" }.each { |f| expect(file(f)).to exist }
   end
 
   it 'should fail on error' do
@@ -172,14 +172,14 @@ describe Project, '#doc' do
       compile.using(:javac)
       doc.include 'Test.java'
     end
-    lambda { project('foo').doc.invoke }.should raise_error(RuntimeError, /Failed to generate Javadocs/)
+    expect { project('foo').doc.invoke }.to raise_error(RuntimeError, /Failed to generate Javadocs/)
   end
 
   it 'should be local task' do
     define 'foo' do
       define('bar') { compile.using(:javac) }
     end
-    project('foo:bar').doc.should_receive(:invoke_prerequisites)
+    expect(project('foo:bar').doc).to receive(:invoke_prerequisites)
     in_original_dir(project('foo:bar').base_dir) { task('doc').invoke }
   end
 
@@ -188,7 +188,7 @@ describe Project, '#doc' do
       compile.using(:javac)
       define('bar') { compile.using(:javac) }
     end
-    project('foo:bar').doc.should_not_receive(:invoke_prerequisites)
+    expect(project('foo:bar').doc).not_to receive(:invoke_prerequisites)
     project('foo').doc.invoke
   end
 end

--- a/spec/core/extension_spec.rb
+++ b/spec/core/extension_spec.rb
@@ -34,7 +34,7 @@ describe Extension do
   end
 
   it 'should call Extension.first_time during include' do
-    TestExtension.should_receive(:first_time_called).once
+    expect(TestExtension).to receive(:first_time_called).once
     class Buildr::Project
       include TestExtension
     end
@@ -43,8 +43,8 @@ describe Extension do
   it 'should call before_define and after_define in order when project is defined' do
     begin
       TestExtension.callback do |extension|
-        extension.should_receive(:before_define_called).once.ordered
-        extension.should_receive(:after_define_called).once.ordered
+        expect(extension).to receive(:before_define_called).once.ordered
+        expect(extension).to receive(:after_define_called).once.ordered
       end
       class Buildr::Project
         include TestExtension
@@ -60,15 +60,15 @@ describe Extension do
       extensions = 0
       TestExtension.callback do |extension|
         extensions += 1
-        extension.should_receive(:before_define_called).once.ordered
-        extension.should_receive(:after_define_called).once.ordered
+        expect(extension).to receive(:before_define_called).once.ordered
+        expect(extension).to receive(:after_define_called).once.ordered
       end
       class Buildr::Project
         include TestExtension
       end
       define('foo')
       define('bar')
-      extensions.should equal(2)
+      expect(extensions).to equal(2)
     ensure
       TestExtension.callback { |ignore| }
     end
@@ -80,8 +80,8 @@ describe Extension do
       include ExtensionThreeFour
     end
     define('foo')
-    project('foo').before_order.should == [ :one, :two, :three, :four ]
-    project('foo').after_order.should  == [ :four, :three, :two, :one ]
+    expect(project('foo').before_order).to eq([ :one, :two, :three, :four ])
+    expect(project('foo').after_order).to  eq([ :four, :three, :two, :one ])
   end
 
   it 'should call before_define callbacks when extending project' do
@@ -89,31 +89,31 @@ describe Extension do
       extend ExtensionOneTwo
       extend ExtensionThreeFour
     end
-    project('foo').before_order.should == [ :two, :one, :four, :three ]
-    project('foo').after_order.should  == [ :four, :three, :two, :one ]
+    expect(project('foo').before_order).to eq([ :two, :one, :four, :three ])
+    expect(project('foo').after_order).to  eq([ :four, :three, :two, :one ])
   end
 
   it 'should raise error when including if callback dependencies cannot be satisfied' do
     class Buildr::Project
       include ExtensionOneTwo # missing ExtensionThreeFour
     end
-    lambda { define('foo') }.should raise_error
+    expect { define('foo') }.to raise_error
   end
 
   it 'should raise error when extending if callback dependencies cannot be satisfied' do
-    lambda {
+    expect {
       define('foo') do |project|
         extend ExtensionOneTwo # missing ExtensionThreeFour
       end
-    }.should raise_error
+    }.to raise_error
   end
 
   it 'should ignore dependencies when extending project' do
     define('bar') do |project|
       extend ExtensionThreeFour # missing ExtensionOneTwo
     end
-    project('bar').before_order.should == [:four, :three]
-    project('bar').after_order.should == [:four, :three]
+    expect(project('bar').before_order).to eq([:four, :three])
+    expect(project('bar').after_order).to eq([:four, :three])
   end
 end
 

--- a/spec/core/generate_from_eclipse_spec.rb
+++ b/spec/core/generate_from_eclipse_spec.rb
@@ -110,13 +110,13 @@ describe Buildr::Generate do
 
     it 'should create a valid buildfile' do
       define('first')
-      File.exists?(File.join(top, 'single', '.project')).should be_true
-      File.exists?(File.join(top, '.project')).should be_false
-      File.exists?('.project').should be_false
+      expect(File.exists?(File.join(top, 'single', '.project'))).to be_truthy
+      expect(File.exists?(File.join(top, '.project'))).to be_falsey
+      expect(File.exists?('.project')).to be_falsey
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain("GROUP = \"#{top}\"")
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain("GROUP = \"#{top}\"")
+      expect { Buildr.application.run }.not_to raise_error
     end
 
     it "should not add project if the corresponding .project file is not an eclipse project" do
@@ -124,51 +124,51 @@ describe Buildr::Generate do
       FileUtils.rm(buildFile)
       write File.join(top, 'myproject', '.project'), '# Dummy file'
       File.open(File.join(top, 'buildfile'), 'w') { |file| file.write Generate.from_eclipse(File.join(Dir.pwd, top)).join("\n") }
-      file(buildFile).should exist
-      file(buildFile).should contain('define "single"')
-      file(buildFile).should_not contain('define "myproject"')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define "single"')
+      expect(file(buildFile)).not_to contain('define "myproject"')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
       it 'should honour Bundle-Version in MANIFEST.MF' do
 	define('bundle_version')
 	buildFile = File.join(top, 'buildfile')
-	file(buildFile).should exist
-	file(buildFile).should contain('define "single"')
-	file(buildFile).should contain('define "single", :version => "1.1"')
-	lambda { Buildr.application.run }.should_not raise_error
+	expect(file(buildFile)).to exist
+	expect(file(buildFile)).to contain('define "single"')
+	expect(file(buildFile)).to contain('define "single", :version => "1.1"')
+	expect { Buildr.application.run }.not_to raise_error
       end
 
     it "should pass source in build.properties to layout[:source, :main, :java] and layout[:source, :main, :scala]" do
       define('layout_source')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('define')
-      file(buildFile).should contain('define "single"')
-      file(buildFile).should contain('layout[:source, :main, :java]')
-      file(buildFile).should contain('layout[:source, :main, :scala]')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define')
+      expect(file(buildFile)).to contain('define "single"')
+      expect(file(buildFile)).to contain('layout[:source, :main, :java]')
+      expect(file(buildFile)).to contain('layout[:source, :main, :scala]')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
     it "should pass output in build.properties to layout[:target, :main], etc" do
       define('layout_target')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('define')
-      file(buildFile).should contain('define "single"')
-      file(buildFile).should contain('layout[:target, :main]')
-      file(buildFile).should contain('layout[:target, :main, :java]')
-      file(buildFile).should contain('layout[:target, :main, :scala]')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define')
+      expect(file(buildFile)).to contain('define "single"')
+      expect(file(buildFile)).to contain('layout[:target, :main]')
+      expect(file(buildFile)).to contain('layout[:target, :main, :java]')
+      expect(file(buildFile)).to contain('layout[:target, :main, :scala]')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
     it "should package an eclipse plugin" do
       define('layout_target')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('define')
-      file(buildFile).should contain('package(:jar)')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define')
+      expect(file(buildFile)).to contain('package(:jar)')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
   end
@@ -181,9 +181,9 @@ describe Buildr::Generate do
     end
     it "should set the project name to the SymbolicName from the MANIFEST.MF" do
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('define "singleSymbolicName"')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define "singleSymbolicName"')
+      expect { Buildr.application.run }.not_to raise_error
     end
   end
 
@@ -196,9 +196,9 @@ describe Buildr::Generate do
 
     it "should not get confused if SymbolicName in MANIFEST.MF is a singleton:=true" do
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('define "singleSymbolicName"')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define "singleSymbolicName"')
+      expect { Buildr.application.run }.not_to raise_error
     end
   end
 
@@ -212,22 +212,22 @@ describe Buildr::Generate do
     it 'should create a valid buildfile for a nested project' do
       setupExample(top, 'single')
       define('nested/second')
-      File.exists?(File.join(top, 'single', '.project')).should be_true
-      File.exists?(File.join(top, '.project')).should be_false
-      File.exists?('.project').should be_false
+      expect(File.exists?(File.join(top, 'single', '.project'))).to be_truthy
+      expect(File.exists?(File.join(top, '.project'))).to be_falsey
+      expect(File.exists?('.project')).to be_falsey
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should contain("GROUP = \"#{top}\"")
-      file(buildFile).should contain('define "single"')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to contain("GROUP = \"#{top}\"")
+      expect(file(buildFile)).to contain('define "single"')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
     it "should correct the path for a nested plugin" do
       define('base_dir')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('define "single"')
-      file(buildFile).should contain('define "single", :version => "1.1", :base_dir => "nested/single"')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('define "single"')
+      expect(file(buildFile)).to contain('define "single", :version => "1.1", :base_dir => "nested/single"')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
   end
@@ -248,31 +248,31 @@ describe Buildr::Generate do
     it 'should add "compile.with dependencies" in MANIFEST.MF' do
       define('base_dir')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain('compile.with dependencies')
-      file(buildFile).should contain('resources')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain('compile.with dependencies')
+      expect(file(buildFile)).to contain('resources')
+      expect { Buildr.application.run }.not_to raise_error
     end
                                                            #dependencies << projects("first")
 
     it 'should honour Require-Bundle in MANIFEST.MF' do
       define('base_dir')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
-      file(buildFile).should contain(/define "second"/)
-      file(buildFile).should contain(                     /dependencies << projects\("first"\)/)
-      file(buildFile).should contain(/define "second".*do.*dependencies << projects\("first"\).* end/m)
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to exist
+      expect(file(buildFile)).to contain(/define "second"/)
+      expect(file(buildFile)).to contain(                     /dependencies << projects\("first"\)/)
+      expect(file(buildFile)).to contain(/define "second".*do.*dependencies << projects\("first"\).* end/m)
+      expect { Buildr.application.run }.not_to raise_error
     end
 
     # Fragments are only supported with buildr4osi which is not (yet?) part of buildr
     it 'should skip fragments.'  do
       define('base_dir')
       buildFile = File.join(top, 'buildfile')
-      file(buildFile).should exist
+      expect(file(buildFile)).to exist
 #      system("cat #{buildFile}")  # if $VERBOSE
-      file(buildFile).should contain('define "first"')
-      lambda { Buildr.application.run }.should_not raise_error
+      expect(file(buildFile)).to contain('define "first"')
+      expect { Buildr.application.run }.not_to raise_error
     end
 
   end

--- a/spec/core/generate_spec.rb
+++ b/spec/core/generate_spec.rb
@@ -22,12 +22,12 @@ describe Buildr::Generate do
   describe 'Generated buildfile' do
     it 'should be a legal buildfile' do
       File.open('buildfile', 'w') { |file| file.write Generate.from_directory(Dir.pwd).join("\n") }
-      lambda { Buildr.application.run }.should_not raise_error
+      expect { Buildr.application.run }.not_to raise_error
     end
 
     it 'should not contain NEXT_VERSION because it was removed in buildr 1.3.3' do
       buildfile = Generate.from_directory(Dir.pwd)
-      buildfile.each { |line| line.should_not include('NEXT_VERSION')}
+      buildfile.each { |line| expect(line).not_to include('NEXT_VERSION')}
     end
   end
 end

--- a/spec/core/project_spec.rb
+++ b/spec/core/project_spec.rb
@@ -20,91 +20,91 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers')
 describe Project do
   it 'should be findable' do
     foo = define('foo')
-    project('foo').should be(foo)
+    expect(project('foo')).to be(foo)
   end
 
   it 'should not exist unless defined' do
-    lambda { project('foo') }.should raise_error(RuntimeError, /No such project/)
+    expect { project('foo') }.to raise_error(RuntimeError, /No such project/)
   end
 
   it 'should fail to be defined if its name is already used for a task' do
-    lambda { define('test') }.should raise_error(RuntimeError, /Invalid project name/i)
+    expect { define('test') }.to raise_error(RuntimeError, /Invalid project name/i)
     define 'valid' do
-      lambda { define('build') }.should raise_error(RuntimeError, /Invalid project name/i)
+      expect { define('build') }.to raise_error(RuntimeError, /Invalid project name/i)
     end
   end
 
   it 'should exist once defined' do
     define 'foo'
-    lambda { project('foo') }.should_not raise_error
+    expect { project('foo') }.not_to raise_error
   end
 
   it 'should always return same project for same name' do
     foo, bar = define('foo'), define('bar')
-    foo.should_not be(bar)
-    foo.should be(project('foo'))
-    bar.should be(project('bar'))
+    expect(foo).not_to be(bar)
+    expect(foo).to be(project('foo'))
+    expect(bar).to be(project('bar'))
   end
 
   it 'should show up in projects list if defined' do
     define('foo')
-    projects.map(&:name).should include('foo')
+    expect(projects.map(&:name)).to include('foo')
   end
 
   it 'should not show up in projects list unless defined' do
-    projects.map(&:name).should_not include('foo')
+    expect(projects.map(&:name)).not_to include('foo')
   end
 
   it 'should be findable from within a project' do
     define('foo')
-    project('foo').project('foo').should be(project('foo'))
+    expect(project('foo').project('foo')).to be(project('foo'))
   end
 
   it 'should cease to exist when project list cleared' do
     define 'foo'
-    projects.map(&:name).should include('foo')
+    expect(projects.map(&:name)).to include('foo')
     Project.clear
-    projects.map(&:name).should be_empty
+    expect(projects.map(&:name)).to be_empty
   end
 
   it 'should be defined only once' do
-    lambda { define 'foo' }.should_not raise_error
-    lambda { define 'foo' }.should raise_error
+    expect { define 'foo' }.not_to raise_error
+    expect { define 'foo' }.to raise_error /You cannot define the same project/
   end
 
   it 'should be definable in any order' do
     Buildr.define('baz') { define('bar') { project('foo:bar') } }
     Buildr.define('foo') { define('bar') }
-    lambda { project('foo') }.should_not raise_error
+    expect { project('foo') }.not_to raise_error
   end
 
   it 'should detect circular dependency' do
     Buildr.define('baz') { define('bar') { project('foo:bar') } }
     Buildr.define('foo') { define('bar') { project('baz:bar') } }
-    lambda { project('foo') }.should raise_error(RuntimeError, /Circular dependency/)
+    expect { project('foo') }.to raise_error(RuntimeError, /Circular dependency/)
   end
 end
 
 describe Project, ' property' do
   it 'should be set if passed as argument' do
     define 'foo', 'version'=>'1.1'
-    project('foo').version.should eql('1.1')
+    expect(project('foo').version).to eql('1.1')
   end
 
   it 'should be set if assigned in body' do
     define('foo') { self.version = '1.2' }
-    project('foo').version.should eql('1.2')
+    expect(project('foo').version).to eql('1.2')
   end
 
   it 'should take precedence when assigned in body' do
     define('foo', 'version'=>'1.1') { self.version = '1.2' }
-    project('foo').version.should eql('1.2')
+    expect(project('foo').version).to eql('1.2')
   end
 
   it 'should inherit from parent (for some properties)' do
     define('foo', 'version'=>'1.2', :group=>'foobar') { define 'bar' }
-    project('foo:bar').version.should eql('1.2')
-    project('foo:bar').group.should eql('foobar')
+    expect(project('foo:bar').version).to eql('1.2')
+    expect(project('foo:bar').group).to eql('foobar')
   end
 
   it 'should have different value if set in sub-project' do
@@ -113,56 +113,56 @@ describe Project, ' property' do
         self.group = 'barbaz'
       end
     end
-    project('foo:bar').version.should eql('1.3')
-    project('foo:bar').group.should eql('barbaz')
+    expect(project('foo:bar').version).to eql('1.3')
+    expect(project('foo:bar').group).to eql('barbaz')
   end
 end
 
 
 describe Project, ' block' do
   it 'should execute once' do
-    define('foo') { self.name.should eql('foo') }
+    define('foo') { expect(self.name).to eql('foo') }
   end
 
   it 'should execute in describe of project' do
     define('foo') { self.version = '1.3' }
-    project('foo').version.should eql('1.3')
+    expect(project('foo').version).to eql('1.3')
   end
 
   it 'should execute by passing project' do
     define('foo') { |project| project.version = '1.3' }
-    project('foo').version.should eql('1.3')
+    expect(project('foo').version).to eql('1.3')
   end
 
   it 'should execute in namespace of project' do
-    define('foo') { define('bar') { Buildr.application.current_scope.should eql(['foo', 'bar']) } }
+    define('foo') { define('bar') { expect(Buildr.application.current_scope).to eql(['foo', 'bar']) } }
   end
 end
 
 
 describe Project, '#base_dir' do
   it 'should be pwd if not specified' do
-    define('foo').base_dir.should eql(Dir.pwd)
+    expect(define('foo').base_dir).to eql(Dir.pwd)
   end
 
   it 'should come from property, if specified' do
     foo = define('foo', :base_dir=>'tmp')
-    foo.base_dir.should point_to_path('tmp')
+    expect(foo.base_dir).to point_to_path('tmp')
   end
 
   it 'should be expanded path' do
     foo = define('foo', :base_dir=>'tmp')
-    foo.base_dir.should eql(File.expand_path('tmp'))
+    expect(foo.base_dir).to eql(File.expand_path('tmp'))
   end
 
   it 'should be relative to parent project' do
     define('foo') { define('bar') { define 'baz' } }
-    project('foo:bar:baz').base_dir.should point_to_path('bar/baz')
+    expect(project('foo:bar:baz').base_dir).to point_to_path('bar/baz')
   end
 
   it 'should be settable only if not read' do
-    lambda { define('foo', :base_dir=>'tmp') }.should_not raise_error
-    lambda { define('bar', :base_dir=>'tmp') { self.base_dir = 'bar' } }.should raise_error(Exception, /Cannot set/)
+    expect { define('foo', :base_dir=>'tmp') }.not_to raise_error
+    expect { define('bar', :base_dir=>'tmp') { self.base_dir = 'bar' } }.to raise_error(Exception, /Cannot set/)
   end
 end
 
@@ -173,58 +173,58 @@ describe Layout do
   end
 
   it 'should expand empty to itself' do
-    @layout.expand.should eql('')
-    @layout.expand('').should eql('')
+    expect(@layout.expand).to eql('')
+    expect(@layout.expand('')).to eql('')
   end
 
   it 'should expand array of symbols' do
-    @layout.expand(:foo, :bar).should eql('foo/bar')
+    expect(@layout.expand(:foo, :bar)).to eql('foo/bar')
   end
 
   it 'should expand array of names' do
-    @layout.expand('foo', 'bar').should eql('foo/bar')
+    expect(@layout.expand('foo', 'bar')).to eql('foo/bar')
   end
 
   it 'should map symbol to path' do
     @layout[:foo] = 'baz'
-    @layout.expand(:foo, :bar).should eql('baz/bar')
+    expect(@layout.expand(:foo, :bar)).to eql('baz/bar')
   end
 
   it 'should map symbols to path' do
     @layout[:foo, :bar] = 'none'
-    @layout.expand(:foo, :bar).should eql('none')
+    expect(@layout.expand(:foo, :bar)).to eql('none')
   end
 
   it 'should map strings to path' do
     @layout[:foo, "bar"] = 'none'
-    @layout.expand(:foo, :bar).should eql('none')
-    @layout.expand(:foo, 'bar').should eql('none')
+    expect(@layout.expand(:foo, :bar)).to eql('none')
+    expect(@layout.expand(:foo, 'bar')).to eql('none')
   end
 
   it 'should ignore nil elements' do
     @layout[:foo, :bar] = 'none'
-    @layout.expand(:foo, nil, :bar).should eql('none')
-    @layout.expand(nil, :foo).should eql('foo')
+    expect(@layout.expand(:foo, nil, :bar)).to eql('none')
+    expect(@layout.expand(nil, :foo)).to eql('foo')
   end
 
   it 'should return nil if path not mapped' do
-    @layout[:foo].should be_nil
+    expect(@layout[:foo]).to be_nil
   end
 
   it 'should return path from symbol' do
     @layout[:foo] = 'path'
-    @layout[:foo].should eql('path')
+    expect(@layout[:foo]).to eql('path')
   end
 
   it 'should return path from symbol' do
     @layout[:foo, :bar] = 'path'
-    @layout[:foo, :bar].should eql('path')
+    expect(@layout[:foo, :bar]).to eql('path')
   end
 
   it 'should do eager mapping' do
     @layout[:one] = 'none'
     @layout[:one, :two] = '1..2'
-    @layout.expand(:one, :two, :three).should eql('1..2/three')
+    expect(@layout.expand(:one, :two, :three)).to eql('1..2/three')
   end
 
 end
@@ -236,19 +236,19 @@ describe Project, '#layout' do
   end
 
   it 'should exist by default' do
-    define('foo').layout.should respond_to(:expand)
+    expect(define('foo').layout).to respond_to(:expand)
   end
 
   it 'should be clone of default layout' do
     define 'foo' do
-      layout.should_not be(Layout.default)
-      layout.expand(:test, :main).should eql(Layout.default.expand(:test, :main))
+      expect(layout).not_to be(Layout.default)
+      expect(layout.expand(:test, :main)).to eql(Layout.default.expand(:test, :main))
     end
   end
 
   it 'should come from property, if specified' do
     foo = define('foo', :layout=>@layout)
-    foo.layout.should eql(@layout)
+    expect(foo.layout).to eql(@layout)
   end
 
   it 'should inherit from parent project' do
@@ -256,7 +256,7 @@ describe Project, '#layout' do
       layout[:foo] = 'foo'
       define 'bar'
     end
-    project('foo:bar').layout[:foo].should eql('foo')
+    expect(project('foo:bar').layout[:foo]).to eql('foo')
   end
 
   it 'should clone when inheriting from parent project' do
@@ -266,13 +266,13 @@ describe Project, '#layout' do
         layout[:foo] = 'bar'
       end
     end
-    project('foo').layout[:foo].should eql('foo')
-    project('foo:bar').layout[:foo].should eql('bar')
+    expect(project('foo').layout[:foo]).to eql('foo')
+    expect(project('foo:bar').layout[:foo]).to eql('bar')
   end
 
   it 'should be settable only if not read' do
-    lambda { define('foo', :layout=>@layout) }.should_not raise_error
-    lambda { define('bar', :layout=>@layout) { self.layout = @layout.clone } }.should raise_error(Exception, /Cannot set/)
+    expect { define('foo', :layout=>@layout) }.not_to raise_error
+    expect { define('bar', :layout=>@layout) { self.layout = @layout.clone } }.to raise_error(Exception, /Cannot set/)
   end
 
 end
@@ -280,40 +280,40 @@ end
 
 describe Project, '#path_to' do
   it 'should return absolute paths as is' do
-    define('foo').path_to('/tmp').should eql(File.expand_path('/tmp'))
+    expect(define('foo').path_to('/tmp')).to eql(File.expand_path('/tmp'))
   end
 
   it 'should resolve empty path to project\'s base directory' do
-    define('foo').path_to.should eql(project('foo').base_dir)
+    expect(define('foo').path_to).to eql(project('foo').base_dir)
   end
 
   it 'should resolve relative paths' do
-    define('foo').path_to('tmp').should eql(File.expand_path('tmp'))
+    expect(define('foo').path_to('tmp')).to eql(File.expand_path('tmp'))
   end
 
   it 'should accept multiple arguments' do
-    define('foo').path_to('foo', 'bar').should eql(File.expand_path('foo/bar'))
+    expect(define('foo').path_to('foo', 'bar')).to eql(File.expand_path('foo/bar'))
   end
 
   it 'should handle relative paths' do
-    define('foo').path_to('..', 'bar').should eql(File.expand_path('../bar'))
+    expect(define('foo').path_to('..', 'bar')).to eql(File.expand_path('../bar'))
   end
 
   it 'should resolve symbols using layout' do
     define('foo').layout[:foo] = 'bar'
-    project('foo').path_to(:foo).should eql(File.expand_path('bar'))
-    project('foo').path_to(:foo, 'tmp').should eql(File.expand_path('bar/tmp'))
+    expect(project('foo').path_to(:foo)).to eql(File.expand_path('bar'))
+    expect(project('foo').path_to(:foo, 'tmp')).to eql(File.expand_path('bar/tmp'))
   end
 
   it 'should resolve path for sub-project' do
     define('foo') { define 'bar' }
-    project('foo:bar').path_to('foo').should eql(File.expand_path('foo', project('foo:bar').base_dir))
+    expect(project('foo:bar').path_to('foo')).to eql(File.expand_path('foo', project('foo:bar').base_dir))
   end
 
   it 'should be idempotent for relative paths' do
     define 'foo'
     path = project('foo').path_to('bar')
-    project('foo').path_to(path).should eql(path)
+    expect(project('foo').path_to(path)).to eql(path)
   end
 end
 
@@ -323,16 +323,16 @@ describe Project, '#on_define' do
     names = []
     Project.on_define { |project| names << project.name }
     define 'foo' ; define 'bar'
-    names.should eql(['foo', 'bar'])
+    expect(names).to eql(['foo', 'bar'])
   end
 
   it 'should be called with project object' do
-    Project.on_define { |project| project.name.should eql('foo') }
+    Project.on_define { |project| expect(project.name).to eql('foo') }
     define('foo')
   end
 
   it 'should be called with project object and set properties' do
-    Project.on_define { |project| project.version.should eql('2.0') }
+    Project.on_define { |project| expect(project.version).to eql('2.0') }
     define('foo', :version=>'2.0')
   end
 
@@ -340,25 +340,25 @@ describe Project, '#on_define' do
     scopes = []
     Project.on_define { |project| scopes << Buildr.application.current_scope }
     define('foo') { define 'bar' }
-    scopes.should eql([['foo'], ['foo', 'bar']])
+    expect(scopes).to eql([['foo'], ['foo', 'bar']])
   end
 
   it 'should be called before project block' do
     order = []
     Project.on_define { |project| order << 'on_define' }
     define('foo') { order << 'define' }
-    order.should eql(['on_define', 'define'])
+    expect(order).to eql(['on_define', 'define'])
   end
 
   it 'should accept enhancement and call it after project block' do
     order = []
     Project.on_define { |project| project.enhance { order << 'enhance' } }
     define('foo') { order << 'define' }
-    order.should eql(['define', 'enhance'])
+    expect(order).to eql(['define', 'enhance'])
   end
 
   it 'should accept enhancement and call it with project' do
-    Project.on_define { |project| project.enhance { |project| project.name.should eql('foo') } }
+    Project.on_define { |project| project.enhance { |project| expect(project.name).to eql('foo') } }
     define('foo')
   end
 
@@ -366,11 +366,11 @@ describe Project, '#on_define' do
     scopes = []
     Project.on_define { |project| project.enhance { scopes << Buildr.application.current_scope } }
     define('foo') { define 'bar' }
-    scopes.should eql([['foo'], ['foo', 'bar']])
+    expect(scopes).to eql([['foo'], ['foo', 'bar']])
   end
 
   it 'should be removed in version 1.5 since it was deprecated in version 1.3' do
-    Buildr::VERSION.should < '1.5'
+    expect(Buildr::VERSION).to be < '1.5'
   end
 end
 
@@ -386,19 +386,19 @@ describe Rake::Task, ' recursive' do
 
   it 'should invoke same task in child project' do
     task('foo:doda').invoke
-    @order.should include('foo:bar:baz')
-    @order.should include('foo:bar')
-    @order.should include('foo')
+    expect(@order).to include('foo:bar:baz')
+    expect(@order).to include('foo:bar')
+    expect(@order).to include('foo')
   end
 
   it 'should invoke in depth-first order' do
     task('foo:doda').invoke
-    @order.should eql([ 'foo:bar:baz', 'foo:bar', 'foo' ])
+    expect(@order).to eql([ 'foo:bar:baz', 'foo:bar', 'foo' ])
   end
 
   it 'should not invoke task in parent project' do
     task('foo:bar:baz:doda').invoke
-    @order.should eql([ 'foo:bar:baz' ])
+    expect(@order).to eql([ 'foo:bar:baz' ])
   end
 end
 
@@ -406,48 +406,48 @@ end
 describe 'Sub-project' do
   it 'should point at parent project' do
     define('foo') { define 'bar' }
-    project('foo:bar').parent.should be(project('foo'))
+    expect(project('foo:bar').parent).to be(project('foo'))
   end
 
   it 'should be defined only within parent project' do
-    lambda { define('foo:bar') }.should raise_error
+    expect { define('foo:bar') }.to raise_error /You can only define a sub project .* within the definition of its parent project/
   end
 
   it 'should have unique name' do
-    lambda do
+    expect do
       define 'foo' do
         define 'bar'
         define 'bar'
       end
-    end.should raise_error
+    end.to raise_error /You cannot define the same project/
   end
 
   it 'should be findable from root' do
     define('foo') { define 'bar' }
-    projects.map(&:name).should include('foo:bar')
+    expect(projects.map(&:name)).to include('foo:bar')
   end
 
   it 'should be findable from parent project' do
     define('foo') { define 'bar' }
-    project('foo').projects.map(&:name).should include('foo:bar')
+    expect(project('foo').projects.map(&:name)).to include('foo:bar')
   end
 
   it 'should be findable during project definition' do
     define 'foo' do
       bar = define 'bar' do
         baz = define 'baz'
-        project('baz').should eql(baz)
+        expect(project('baz')).to eql(baz)
       end
       # Note: evaluating bar:baz first unearthed a bug that doesn't happen
       # if we evaluate bar, then bar:baz.
-      project('bar:baz').should be(bar.project('baz'))
-      project('bar').should be(bar)
+      expect(project('bar:baz')).to be(bar.project('baz'))
+      expect(project('bar')).to be(bar)
     end
   end
 
   it 'should be findable only if exists' do
     define('foo') { define 'bar' }
-    lambda { project('foo').project('baz') }.should raise_error(RuntimeError, /No such project/)
+    expect { project('foo').project('baz') }.to raise_error(RuntimeError, /No such project/)
   end
 
   it 'should always execute its definition ' do
@@ -457,7 +457,7 @@ describe 'Sub-project' do
       define('bar') { ordered << self.name }
       define('baz') { ordered << self.name }
     end
-    ordered.should eql(['foo', 'foo:bar', 'foo:baz'])
+    expect(ordered).to eql(['foo', 'foo:bar', 'foo:baz'])
   end
 
   it 'should execute in order of dependency' do
@@ -467,16 +467,16 @@ describe 'Sub-project' do
       define('bar') { project('foo:baz') ; ordered << self.name }
       define('baz') { ordered << self.name }
     end
-    ordered.should eql(['foo', 'foo:baz', 'foo:bar'])
+    expect(ordered).to eql(['foo', 'foo:baz', 'foo:bar'])
   end
 
   it 'should warn of circular dependency' do
-    lambda do
+    expect do
       define 'foo' do
         define('bar') { project('foo:baz') }
         define('baz') { project('foo:bar') }
       end
-    end.should raise_error(RuntimeError, /Circular dependency/)
+    end.to raise_error(RuntimeError, /Circular dependency/)
   end
 end
 
@@ -484,43 +484,43 @@ end
 describe 'Top-level project' do
   it 'should have no parent' do
     define('foo')
-    project('foo').parent.should be_nil
+    expect(project('foo').parent).to be_nil
   end
 end
 
 
 describe Buildr, '#project' do
   it 'should raise error if no such project' do
-    lambda { project('foo') }.should raise_error(RuntimeError, /No such project/)
+    expect { project('foo') }.to raise_error(RuntimeError, /No such project/)
   end
 
   it 'should return a project if exists' do
     foo = define('foo')
-    project('foo').should be(foo)
+    expect(project('foo')).to be(foo)
   end
 
   it 'should define a project if a block is given' do
     foo = project('foo') {}
-    project('foo').should be(foo)
+    expect(project('foo')).to be(foo)
   end
 
   it 'should define a project if properties and a block are given' do
     foo = project('foo', :version => '1.2') {}
-    project('foo').should be(foo)
+    expect(project('foo')).to be(foo)
   end
 
   it 'should find a project by its full name' do
     bar, baz = nil
     define('foo') { bar = define('bar') { baz = define('baz')  } }
-    project('foo:bar').should be(bar)
-    project('foo:bar:baz').should be(baz)
+    expect(project('foo:bar')).to be(bar)
+    expect(project('foo:bar:baz')).to be(baz)
   end
 
   it 'should find a project from any context' do
     bar, baz = nil
     define('foo') { bar = define('bar') { baz = define('baz')  } }
-    project('foo:bar').project('foo:bar:baz').should be(baz)
-    project('foo:bar:baz').project('foo:bar').should be(bar)
+    expect(project('foo:bar').project('foo:bar:baz')).to be(baz)
+    expect(project('foo:bar:baz').project('foo:bar')).to be(bar)
   end
 
   it 'should find a project from its parent or sibling project' do
@@ -528,9 +528,9 @@ describe Buildr, '#project' do
       define 'bar'
       define 'baz'
     end
-    project('foo').project('bar').should be(project('foo:bar'))
-    project('foo').project('baz').should be(project('foo:baz'))
-    project('foo:bar').project('baz').should be(project('foo:baz'))
+    expect(project('foo').project('bar')).to be(project('foo:bar'))
+    expect(project('foo').project('baz')).to be(project('foo:baz'))
+    expect(project('foo:bar').project('baz')).to be(project('foo:baz'))
   end
 
   it 'should fine a project from its parent by proximity' do
@@ -538,57 +538,57 @@ describe Buildr, '#project' do
       define('bar') { define 'baz' }
       define 'baz'
     end
-    project('foo').project('baz').should be(project('foo:baz'))
-    project('foo:bar').project('baz').should be(project('foo:bar:baz'))
+    expect(project('foo').project('baz')).to be(project('foo:baz'))
+    expect(project('foo:bar').project('baz')).to be(project('foo:bar:baz'))
   end
 
   it 'should invoke project before returning it' do
-    define('foo').should_receive(:invoke).once
+    expect(define('foo')).to receive(:invoke).once
     project('foo')
   end
 
   it 'should fail if called without a project name' do
-    lambda { project }.should raise_error(ArgumentError)
+    expect { project }.to raise_error(ArgumentError)
   end
 
   it 'should return self if called on a project without a name' do
-    define('foo') { project.should be(self) }
+    define('foo') { expect(project).to be(self) }
   end
 
   it 'should evaluate parent project before returning' do
     # Note: gets around our define that also invokes the project.
     Buildr.define('foo') { define('bar'); define('baz') }
-    project('foo:bar').should eql(projects[1])
+    expect(project('foo:bar')).to eql(projects[1])
   end
 end
 
 
 describe Buildr, '#projects' do
   it 'should only return defined projects' do
-    projects.should eql([])
+    expect(projects).to eql([])
     define 'foo'
-    projects.should eql([project('foo')])
+    expect(projects).to eql([project('foo')])
   end
 
   it 'should return all defined projects' do
     define 'foo'
     define('bar') { define 'baz' }
-    projects.should include(project('foo'))
-    projects.should include(project('bar'))
-    projects.should include(project('bar:baz'))
+    expect(projects).to include(project('foo'))
+    expect(projects).to include(project('bar'))
+    expect(projects).to include(project('bar:baz'))
   end
 
   it 'should return only named projects' do
     define 'foo' ; define 'bar' ; define 'baz'
-    projects('foo', 'bar').should include(project('foo'))
-    projects('foo', 'bar').should include(project('bar'))
-    projects('foo', 'bar').should_not include(project('baz'))
+    expect(projects('foo', 'bar')).to include(project('foo'))
+    expect(projects('foo', 'bar')).to include(project('bar'))
+    expect(projects('foo', 'bar')).not_to include(project('baz'))
   end
 
   it 'should complain if named project does not exist' do
     define 'foo'
-    projects('foo').should include(project('foo'))
-    lambda { projects('bar') }.should raise_error(RuntimeError, /No such project/)
+    expect(projects('foo')).to include(project('foo'))
+    expect { projects('bar') }.to raise_error(RuntimeError, /No such project/)
   end
 
   it 'should find a project from its parent or sibling project' do
@@ -596,9 +596,9 @@ describe Buildr, '#projects' do
       define 'bar'
       define 'baz'
     end
-    project('foo').projects('bar').should eql(projects('foo:bar'))
-    project('foo').projects('baz').should eql(projects('foo:baz'))
-    project('foo:bar').projects('baz').should eql(projects('foo:baz'))
+    expect(project('foo').projects('bar')).to eql(projects('foo:bar'))
+    expect(project('foo').projects('baz')).to eql(projects('foo:baz'))
+    expect(project('foo:bar').projects('baz')).to eql(projects('foo:baz'))
   end
 
   it 'should fine a project from its parent by proximity' do
@@ -606,14 +606,14 @@ describe Buildr, '#projects' do
       define('bar') { define 'baz' }
       define 'baz'
     end
-    project('foo').projects('baz').should eql(projects('foo:baz'))
-    project('foo:bar').projects('baz').should eql(projects('foo:bar:baz'))
+    expect(project('foo').projects('baz')).to eql(projects('foo:baz'))
+    expect(project('foo:bar').projects('baz')).to eql(projects('foo:bar:baz'))
   end
 
   it 'should evaluate all projects before returning' do
     # Note: gets around our define that also invokes the project.
     Buildr.define('foo') { define('bar'); define('baz') }
-    projects.should eql(projects('foo', 'foo:bar', 'foo:baz'))
+    expect(projects).to eql(projects('foo', 'foo:bar', 'foo:baz'))
   end
 end
 
@@ -626,18 +626,18 @@ describe Rake::Task, ' local directory' do
 
   it 'should execute project in local directory' do
     define 'foo'
-    @task.should_receive(:from).with('foo')
+    expect(@task).to receive(:from).with('foo')
     @task.invoke
   end
 
   it 'should execute sub-project in local directory' do
-    @task.should_receive(:from).with('foo:bar')
+    expect(@task).to receive(:from).with('foo:bar')
     define('foo') { define 'bar' }
     in_original_dir(project('foo:bar').base_dir) { @task.invoke }
   end
 
   it 'should do nothing if no project in local directory' do
-    @task.should_not_receive(:from)
+    expect(@task).not_to receive(:from)
     define('foo') { define 'bar' }
     in_original_dir('../not_foo') { @task.invoke }
   end
@@ -645,7 +645,7 @@ describe Rake::Task, ' local directory' do
   it 'should find closest project that matches current directory' do
     mkpath 'bar/src/main'
     define('foo') { define 'bar' }
-    @task.should_receive(:from).with('foo:bar')
+    expect(@task).to receive(:from).with('foo:bar')
     in_original_dir('bar/src/main') { @task.invoke }
   end
 end
@@ -654,40 +654,40 @@ end
 describe Project, '#task' do
   it 'should create a regular task' do
     define('foo') { task('bar') }
-    Buildr.application.lookup('foo:bar').should_not be_nil
+    expect(Buildr.application.lookup('foo:bar')).not_to be_nil
   end
 
   it 'should return a task defined in the project' do
     define('foo') { task('bar') }
-    project('foo').task('bar').should be_instance_of(Rake::Task)
+    expect(project('foo').task('bar')).to be_instance_of(Rake::Task)
   end
 
   it 'should not create task outside project definition' do
     define 'foo'
-    lambda { project('foo').task('bar') }.should raise_error(RuntimeError, /no task foo:bar/)
+    expect { project('foo').task('bar') }.to raise_error(RuntimeError, /no task foo:bar/)
   end
 
   it 'should include project name as prefix' do
     define('foo') { task('bar') }
-    project('foo').task('bar').name.should eql('foo:bar')
+    expect(project('foo').task('bar').name).to eql('foo:bar')
   end
 
   it 'should ignore namespace if starting with colon' do
     define 'foo' do
-      task(':bar').name.should == 'bar'
+      expect(task(':bar').name).to eq('bar')
     end
-    Rake::Task.task_defined?('bar').should be_true
+    expect(Rake::Task.task_defined?('bar')).to be_truthy
   end
 
   it 'should accept single dependency' do
     define('foo') { task('bar'=>'baz') }
-    project('foo').task('bar').prerequisites.should include('baz')
+    expect(project('foo').task('bar').prerequisites).to include('baz')
   end
 
   it 'should accept multiple dependencies' do
     define('foo') { task('bar'=>['baz1', 'baz2']) }
-    project('foo').task('bar').prerequisites.should include('baz1')
-    project('foo').task('bar').prerequisites.should include('baz2')
+    expect(project('foo').task('bar').prerequisites).to include('baz1')
+    expect(project('foo').task('bar').prerequisites).to include('baz2')
   end
 
   it 'should execute task exactly once' do
@@ -695,33 +695,33 @@ describe Project, '#task' do
       task 'baz'
       task 'bar'=>'baz'
     end
-    lambda { project('foo').task('bar').invoke }.should run_tasks(['foo:baz', 'foo:bar'])
+    expect { project('foo').task('bar').invoke }.to run_tasks(['foo:baz', 'foo:bar'])
   end
 
   it 'should create a file task' do
     define('foo') { file('bar') }
-    Buildr.application.lookup(File.expand_path('bar')).should_not be_nil
+    expect(Buildr.application.lookup(File.expand_path('bar'))).not_to be_nil
   end
 
   it 'should create file task with absolute path' do
     define('foo') { file('/tmp') }
-    Buildr.application.lookup(File.expand_path('/tmp')).should_not be_nil
+    expect(Buildr.application.lookup(File.expand_path('/tmp'))).not_to be_nil
   end
 
   it 'should create file task relative to project base directory' do
     define('foo', :base_dir=>'tmp') { file('bar') }
-    Buildr.application.lookup(File.expand_path('tmp/bar')).should_not be_nil
+    expect(Buildr.application.lookup(File.expand_path('tmp/bar'))).not_to be_nil
   end
 
   it 'should accept single dependency' do
     define('foo') { file('bar'=>'baz') }
-    project('foo').file('bar').prerequisites.should include('baz')
+    expect(project('foo').file('bar').prerequisites).to include('baz')
   end
 
   it 'should accept multiple dependencies' do
     define('foo') { file('bar'=>['baz1', 'baz2']) }
-    project('foo').file('bar').prerequisites.should include('baz1')
-    project('foo').file('bar').prerequisites.should include('baz2')
+    expect(project('foo').file('bar').prerequisites).to include('baz1')
+    expect(project('foo').file('bar').prerequisites).to include('baz2')
   end
 
   it 'should accept hash arguments' do
@@ -729,18 +729,18 @@ describe Project, '#task' do
       task 'bar'=>'bar_dep'
       file 'baz'=>'baz_dep'
     end
-    project('foo').task('bar').prerequisites.should include('bar_dep')
-    project('foo').file('baz').prerequisites.should include('baz_dep')
+    expect(project('foo').task('bar').prerequisites).to include('bar_dep')
+    expect(project('foo').file('baz').prerequisites).to include('baz_dep')
   end
 
   it 'should return a file task defined in the project' do
     define('foo') { file('bar') }
-    project('foo').file('bar').should be_instance_of(Rake::FileTask)
+    expect(project('foo').file('bar')).to be_instance_of(Rake::FileTask)
   end
 
   it 'should create file task relative to project definition' do
     define('foo') { define 'bar' }
-    project('foo:bar').file('baz').name.should point_to_path('bar/baz')
+    expect(project('foo:bar').file('baz').name).to point_to_path('bar/baz')
   end
 
   it 'should execute task exactly once' do
@@ -748,7 +748,7 @@ describe Project, '#task' do
       task 'baz'
       file 'bar'=>'baz'
     end
-    lambda { project('foo').file('bar').invoke }.should run_tasks(['foo:baz', project('foo').path_to('bar')])
+    expect { project('foo').file('bar').invoke }.to run_tasks(['foo:baz', project('foo').path_to('bar')])
   end
 end
 

--- a/spec/core/run_spec.rb
+++ b/spec/core/run_spec.rb
@@ -19,12 +19,12 @@ describe Project, :run do
 
   it 'should return the project\'s run task' do
     define('foo')
-    project('foo').run.name.should eql('foo:run')
+    expect(project('foo').run.name).to eql('foo:run')
   end
 
   it 'should return a RunTask' do
     define('foo')
-    project('foo').run.should be_kind_of(Run::RunTask)
+    expect(project('foo').run).to be_kind_of(Run::RunTask)
   end
 
   it 'should include compile dependencies' do
@@ -32,7 +32,7 @@ describe Project, :run do
       compile.using(:javac).with 'group:compile:jar:1.0'
       test.compile.using(:javac).with 'group:test:jar:1.0'
     end
-    project('foo').run.classpath.should include(artifact('group:compile:jar:1.0'))
+    expect(project('foo').run.classpath).to include(artifact('group:compile:jar:1.0'))
   end
 
   it 'should not include test dependencies' do
@@ -40,12 +40,12 @@ describe Project, :run do
       compile.using(:javac).with 'group:compile:jar:1.0'
       test.compile.using(:javac).with 'group:test:jar:1.0'
     end
-    project('foo').run.classpath.should_not include(artifact('group:test:jar:1.0'))
+    expect(project('foo').run.classpath).not_to include(artifact('group:test:jar:1.0'))
   end
 
   it 'should respond to using() and return self' do
     define 'foo' do
-      run.using(:foo=>'Fooing').should be(run)
+      expect(run.using(:foo=>'Fooing')).to be(run)
     end
   end
 
@@ -53,14 +53,14 @@ describe Project, :run do
     define 'foo' do
       run.using :foo=>'Fooing'
     end
-    project('foo').run.options[:foo].should eql('Fooing')
+    expect(project('foo').run.options[:foo]).to eql('Fooing')
   end
 
   it 'should select runner using run.using' do
     define 'foo' do
       run.using :java
     end
-    project('foo').run.runner.should be_a(Run::JavaRunner)
+    expect(project('foo').run.runner).to be_a(Run::JavaRunner)
   end
 
   it 'should select runner based on compile language' do
@@ -68,27 +68,27 @@ describe Project, :run do
     define 'foo' do
       # compile language detected as :java
     end
-    project('foo').run.runner.should be_a(Run::JavaRunner)
+    expect(project('foo').run.runner).to be_a(Run::JavaRunner)
   end
 
   it "should run with the project resources" do
     write 'src/main/java/Test.java', 'class Test {}'
     write 'src/main/resources/test.properties', ''
     define 'foo'
-    project('foo').run.classpath.should include project('foo').resources.target
+    expect(project('foo').run.classpath).to include project('foo').resources.target
   end
 
   it 'should depend on project''s compile task' do
     define 'foo'
-    project('foo').run.prerequisites.should include(project('foo').compile)
+    expect(project('foo').run.prerequisites).to include(project('foo').compile)
   end
 
   it 'should be local task' do
     define 'foo' do
       define('bar')
     end
-    project('foo:bar').run.should_receive(:invoke_prerequisites)
-    project('foo:bar').run.should_receive(:run)
+    expect(project('foo:bar').run).to receive(:invoke_prerequisites)
+    expect(project('foo:bar').run).to receive(:run)
     in_original_dir(project('foo:bar').base_dir) { task('run').invoke }
   end
 
@@ -96,9 +96,9 @@ describe Project, :run do
     define 'foo' do
       define('bar') { run.using :java, :main => 'foo' }
     end
-    project('foo:bar').run.should_not_receive(:invoke_prerequisites)
-    project('foo:bar').run.should_not_receive(:run)
-    project('foo').run.should_receive(:run)
+    expect(project('foo:bar').run).not_to receive(:invoke_prerequisites)
+    expect(project('foo:bar').run).not_to receive(:run)
+    expect(project('foo').run).to receive(:run)
     project('foo').run.invoke
   end
 

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -19,12 +19,12 @@ describe Project, '.shell' do
 
   it 'should return the project\'s shell task' do
     define('foo')
-    project('foo').shell.name.should eql('foo:shell')
+    expect(project('foo').shell.name).to eql('foo:shell')
   end
 
   it 'should return a ShellTask' do
     define('foo')
-    project('foo').shell.should be_kind_of(Shell::ShellTask)
+    expect(project('foo').shell).to be_kind_of(Shell::ShellTask)
   end
 
   it 'should include compile and test.compile dependencies' do
@@ -32,13 +32,13 @@ describe Project, '.shell' do
       compile.using(:javac).with 'group:compile:jar:1.0'
       test.compile.using(:javac).with 'group:test:jar:1.0'
     end
-    project('foo').shell.classpath.should include(artifact('group:compile:jar:1.0'))
-    project('foo').shell.classpath.should include(artifact('group:test:jar:1.0'))
+    expect(project('foo').shell.classpath).to include(artifact('group:compile:jar:1.0'))
+    expect(project('foo').shell.classpath).to include(artifact('group:test:jar:1.0'))
   end
 
   it 'should respond to using() and return self' do
     define 'foo' do
-      shell.using(:foo=>'Fooing').should be(shell)
+      expect(shell.using(:foo=>'Fooing')).to be(shell)
     end
   end
 
@@ -46,14 +46,14 @@ describe Project, '.shell' do
     define 'foo' do
       shell.using :foo=>'Fooing'
     end
-    project('foo').shell.options[:foo].should eql('Fooing')
+    expect(project('foo').shell.options[:foo]).to eql('Fooing')
   end
 
   it 'should select provider using shell.using' do
     define 'foo' do
       shell.using :bsh
     end
-    project('foo').shell.provider.should be_a(Shell::BeanShell)
+    expect(project('foo').shell.provider).to be_a(Shell::BeanShell)
   end
 
   it 'should select runner based on compile language' do
@@ -61,12 +61,12 @@ describe Project, '.shell' do
     define 'foo' do
       # compile language detected as :java
     end
-    project('foo').shell.provider.should be_a(Shell::BeanShell)
+    expect(project('foo').shell.provider).to be_a(Shell::BeanShell)
   end
 
   it 'should depend on project''s compile task' do
     define 'foo'
-    project('foo').shell.prerequisites.should include(project('foo').compile)
+    expect(project('foo').shell.prerequisites).to include(project('foo').compile)
   end
 
   it 'should be local task' do
@@ -76,8 +76,8 @@ describe Project, '.shell' do
       end
     end
     task = project('foo:bar').shell
-    task.should_receive(:invoke_prerequisites)
-    task.should_receive(:run)
+    expect(task).to receive(:invoke_prerequisites)
+    expect(task).to receive(:run)
     in_original_dir(project('foo:bar').base_dir) { task('shell').invoke }
   end
 
@@ -86,9 +86,9 @@ describe Project, '.shell' do
       shell.using :bsh
       define('bar') { shell.using :bsh }
     end
-    project('foo:bar').shell.should_not_receive(:invoke_prerequisites)
-    project('foo:bar').shell.should_not_receive(:run)
-    project('foo').shell.should_receive(:run)
+    expect(project('foo:bar').shell).not_to receive(:invoke_prerequisites)
+    expect(project('foo:bar').shell).not_to receive(:run)
+    expect(project('foo').shell).to receive(:run)
     project('foo').shell.invoke
   end
 
@@ -97,7 +97,7 @@ describe Project, '.shell' do
       shell.using :bsh
     end
     shell = project('foo').shell
-    shell.provider.should_receive(:launch).with(shell)
+    expect(shell.provider).to receive(:launch).with(shell)
     project('foo').shell.invoke
   end
 end
@@ -105,8 +105,8 @@ end
 shared_examples_for "shell provider" do
 
   it 'should have launch method accepting shell task' do
-    @instance.method(:launch).should_not be_nil
-    @instance.method(:launch).arity.should === 1
+    expect(@instance.method(:launch)).not_to be_nil
+    expect(@instance.method(:launch).arity).to be === 1
   end
 
 end
@@ -124,20 +124,22 @@ Shell.providers.each do |provider|
 
     it 'should call Java::Commands.java with :java_args' do
       @project.shell.using :java_args => ["-Xx"]
-      Java::Commands.should_receive(:java).with do |*args|
-        args.last.should be_a(Hash)
-        args.last.keys.should include(:java_args)
-        args.last[:java_args].should include('-Xx')
+      expect(Java::Commands).to receive(:java) do |*args|
+        expect(args.last).to be_a(Hash)
+        expect(args.last.keys).to include(:java_args)
+        expect(args.last[:java_args]).to include('-Xx')
+        
       end
       project('foo').shell.invoke
     end
 
     it 'should call Java::Commands.java with :properties' do
       @project.shell.using :properties => {:foo => "bar"}
-      Java::Commands.should_receive(:java).with do |*args|
-        args.last.should be_a(Hash)
-        args.last.keys.should include(:properties)
-        args.last[:properties][:foo].should == "bar"
+      expect(Java::Commands).to receive(:java) do |*args|
+        expect(args.last).to be_a(Hash)
+        expect(args.last.keys).to include(:properties)
+        expect(args.last[:properties][:foo]).to eq("bar")
+        
       end
       project('foo').shell.invoke
     end

--- a/spec/core/test_spec.rb
+++ b/spec/core/test_spec.rb
@@ -33,33 +33,33 @@ describe Buildr::TestTask do
   end
 
   it 'should respond to :compile and return compile task' do
-    test_task.compile.should be_kind_of(Buildr::CompileTask)
+    expect(test_task.compile).to be_kind_of(Buildr::CompileTask)
   end
 
   it 'should respond to :compile and add sources to compile' do
     test_task.compile 'sources'
-    test_task.compile.sources.should include('sources')
+    expect(test_task.compile.sources).to include('sources')
   end
 
   it 'should respond to :compile and add action for test:compile' do
     write 'src/test/java/Test.java', 'class Test {}'
     test_task.compile { task('action').invoke }
-    lambda { test_task.compile.invoke }.should run_tasks('action')
+    expect { test_task.compile.invoke }.to run_tasks('action')
   end
 
   it 'should execute compile tasks first' do
     write 'src/main/java/Nothing.java', 'class Nothing {}'
     write 'src/test/java/Test.java', 'class Test {}'
     define 'foo'
-    lambda { project('foo').test.compile.invoke }.should run_tasks(['foo:compile', 'foo:test:compile'])
+    expect { project('foo').test.compile.invoke }.to run_tasks(['foo:compile', 'foo:test:compile'])
   end
 
   it 'should respond to :resources and return resources task' do
-    test_task.resources.should be_kind_of(Buildr::ResourcesTask)
+    expect(test_task.resources).to be_kind_of(Buildr::ResourcesTask)
   end
 
   it 'should respond to :resources and add prerequisites to test:resources' do
-    file('prereq').should_receive :invoke_prerequisites
+    expect(file('prereq')).to receive :invoke_prerequisites
     test_task.resources 'prereq'
     test_task.compile.invoke
   end
@@ -67,127 +67,127 @@ describe Buildr::TestTask do
   it 'should respond to :resources and add action for test:resources' do
     task 'action'
     test_task.resources { task('action').invoke }
-    lambda { test_task.resources.invoke }.should run_tasks('action')
+    expect { test_task.resources.invoke }.to run_tasks('action')
   end
 
   it 'should respond to :setup and return setup task' do
-    test_task.setup.name.should =~ /test:setup$/
+    expect(test_task.setup.name).to match(/test:setup$/)
   end
 
   it 'should respond to :setup and add prerequisites to test:setup' do
     test_task.setup 'prereq'
-    test_task.setup.prerequisites.should include('prereq')
+    expect(test_task.setup.prerequisites).to include('prereq')
   end
 
   it 'should respond to :setup and add action for test:setup' do
     task 'action'
     test_task.setup { task('action').invoke }
-    lambda { test_task.setup.invoke }.should run_tasks('action')
+    expect { test_task.setup.invoke }.to run_tasks('action')
   end
 
   it 'should respond to :teardown and return teardown task' do
-    test_task.teardown.name.should =~ /test:teardown$/
+    expect(test_task.teardown.name).to match(/test:teardown$/)
   end
 
   it 'should respond to :teardown and add prerequisites to test:teardown' do
     test_task.teardown 'prereq'
-    test_task.teardown.prerequisites.should include('prereq')
+    expect(test_task.teardown.prerequisites).to include('prereq')
   end
 
   it 'should respond to :teardown and add action for test:teardown' do
     task 'action'
     test_task.teardown { task('action').invoke }
-    lambda { test_task.teardown.invoke }.should run_tasks('action')
+    expect { test_task.teardown.invoke }.to run_tasks('action')
   end
 
   it 'should respond to :with and return self' do
-    test_task.with.should be(test_task)
+    expect(test_task.with).to be(test_task)
   end
 
   it 'should respond to :with and add artifacfs to compile task dependencies' do
     test_task.with 'test.jar', 'acme:example:jar:1.0'
-    test_task.compile.dependencies.should include(File.expand_path('test.jar'))
-    test_task.compile.dependencies.should include(artifact('acme:example:jar:1.0'))
+    expect(test_task.compile.dependencies).to include(File.expand_path('test.jar'))
+    expect(test_task.compile.dependencies).to include(artifact('acme:example:jar:1.0'))
   end
 
   it 'should respond to deprecated classpath' do
     test_task.classpath = artifact('acme:example:jar:1.0')
-    test_task.classpath.should be(artifact('acme:example:jar:1.0'))
+    expect(test_task.classpath).to be(artifact('acme:example:jar:1.0'))
   end
 
   it 'should respond to dependencies' do
     test_task.dependencies = artifact('acme:example:jar:1.0')
-    test_task.dependencies.should be(artifact('acme:example:jar:1.0'))
+    expect(test_task.dependencies).to be(artifact('acme:example:jar:1.0'))
   end
 
   it 'should respond to :with and add artifacfs to task dependencies' do
     test_task.with 'test.jar', 'acme:example:jar:1.0'
-    test_task.dependencies.should include(File.expand_path('test.jar'))
-    test_task.dependencies.should include(artifact('acme:example:jar:1.0'))
+    expect(test_task.dependencies).to include(File.expand_path('test.jar'))
+    expect(test_task.dependencies).to include(artifact('acme:example:jar:1.0'))
   end
 
   it 'should response to :options and return test framework options' do
     test_task.using :foo=>'bar'
-    test_task.options[:foo].should eql('bar')
+    expect(test_task.options[:foo]).to eql('bar')
   end
 
   it 'should respond to :using and return self' do
-    test_task.using.should be(test_task)
+    expect(test_task.using).to be(test_task)
   end
 
   it 'should respond to :using and set value options' do
     test_task.using('foo'=>'FOO', 'bar'=>'BAR')
-    test_task.options[:foo].should eql('FOO')
-    test_task.options[:bar].should eql('BAR')
+    expect(test_task.options[:foo]).to eql('FOO')
+    expect(test_task.options[:bar]).to eql('BAR')
   end
 
   it 'should respond to :using with deprecated parameter style and set value options to true, up to version 1.5 since this usage was deprecated in version 1.3' do
-    Buildr::VERSION.should < '1.5'
+    expect(Buildr::VERSION).to be < '1.5'
     test_task.using('foo', 'bar')
-    test_task.options[:foo].should eql(true)
-    test_task.options[:bar].should eql(true)
+    expect(test_task.options[:foo]).to eql(true)
+    expect(test_task.options[:bar]).to eql(true)
   end
 
   it 'should start without pre-selected test framework' do
-    test_task.framework.should be_nil
+    expect(test_task.framework).to be_nil
   end
 
   it 'should respond to :using and select test framework' do
     test_task.using(:testng)
-    test_task.framework.should eql(:testng)
+    expect(test_task.framework).to eql(:testng)
   end
 
   it 'should infer test framework from compiled language' do
-    lambda { test_task.compile.using(:javac) }.should change { test_task.framework }.to(:junit)
+    expect { test_task.compile.using(:javac) }.to change { test_task.framework }.to(:junit)
   end
 
   it 'should respond to :include and return self' do
-    test_task.include.should be(test_task)
+    expect(test_task.include).to be(test_task)
   end
 
   it 'should respond to :include and add inclusion patterns' do
     test_task.include 'Foo', 'Bar'
-    test_task.send(:include?, 'Foo').should be_true
-    test_task.send(:include?, 'Bar').should be_true
+    expect(test_task.send(:include?, 'Foo')).to be_truthy
+    expect(test_task.send(:include?, 'Bar')).to be_truthy
   end
 
   it 'should respond to :exclude and return self' do
-    test_task.exclude.should be(test_task)
+    expect(test_task.exclude).to be(test_task)
   end
 
   it 'should respond to :exclude and add exclusion patterns' do
     test_task.exclude 'FooTest', 'BarTest'
-    test_task.send(:include?, 'FooTest').should be_false
-    test_task.send(:include?, 'BarTest').should be_false
-    test_task.send(:include?, 'BazTest').should be_true
+    expect(test_task.send(:include?, 'FooTest')).to be_falsey
+    expect(test_task.send(:include?, 'BarTest')).to be_falsey
+    expect(test_task.send(:include?, 'BazTest')).to be_truthy
   end
 
   it 'should execute setup task before running tests' do
     mock = double('actions')
     test_task.setup { mock.setup }
     test_task.enhance { mock.tests }
-    mock.should_receive(:setup).ordered
-    mock.should_receive(:tests).ordered
+    expect(mock).to receive(:setup).ordered
+    expect(mock).to receive(:tests).ordered
     test_task.invoke
   end
 
@@ -195,51 +195,51 @@ describe Buildr::TestTask do
     mock = double('actions')
     test_task.teardown { mock.teardown }
     test_task.enhance { mock.tests }
-    mock.should_receive(:tests).ordered
-    mock.should_receive(:teardown).ordered
+    expect(mock).to receive(:tests).ordered
+    expect(mock).to receive(:teardown).ordered
     test_task.invoke
   end
 
   it 'should not execute teardown if setup failed' do
     test_task.setup { fail }
-    lambda { test_task.invoke rescue nil }.should_not run_task(test_task.teardown)
+    expect { test_task.invoke rescue nil }.not_to run_task(test_task.teardown)
   end
 
   it 'should use the main compile dependencies' do
     define('foo') { compile.using(:javac).with 'group:id:jar:1.0' }
-    project('foo').test.dependencies.should include(artifact('group:id:jar:1.0'))
+    expect(project('foo').test.dependencies).to include(artifact('group:id:jar:1.0'))
   end
 
   it 'should include the main compile target in its dependencies' do
     define('foo') { compile.using(:javac) }
-    project('foo').test.dependencies.should include(project('foo').compile.target)
+    expect(project('foo').test.dependencies).to include(project('foo').compile.target)
   end
 
   it 'should include the main compile target in its dependencies, even when using non standard directories' do
     write 'src/java/Nothing.java', 'class Nothing {}'
     define('foo') { compile path_to('src/java') }
-    project('foo').test.dependencies.should include(project('foo').compile.target)
+    expect(project('foo').test.dependencies).to include(project('foo').compile.target)
   end
 
   it 'should include the main resources target in its dependencies' do
     write 'src/main/resources/config.xml'
-    define('foo').test.dependencies.should include(project('foo').resources.target)
+    expect(define('foo').test.dependencies).to include(project('foo').resources.target)
   end
 
   it 'should use the test compile dependencies' do
     define('foo') { test.compile.using(:javac).with 'group:id:jar:1.0' }
-    project('foo').test.dependencies.should include(artifact('group:id:jar:1.0'))
+    expect(project('foo').test.dependencies).to include(artifact('group:id:jar:1.0'))
   end
 
   it 'should include the test compile target in its dependencies' do
     define('foo') { test.compile.using(:javac) }
-    project('foo').test.dependencies.should include(project('foo').test.compile.target)
+    expect(project('foo').test.dependencies).to include(project('foo').test.compile.target)
   end
 
   it 'should include the test compile target in its dependencies, even when using non standard directories' do
     write 'src/test/Test.java', 'class Test {}'
     define('foo') { test.compile path_to('src/test') }
-    project('foo').test.dependencies.should include(project('foo').test.compile.target)
+    expect(project('foo').test.dependencies).to include(project('foo').test.compile.target)
   end
 
   it 'should add test compile target ahead of regular compile target' do
@@ -247,12 +247,12 @@ describe Buildr::TestTask do
     write 'src/test/java/Test.java'
     define 'foo'
     depends = project('foo').test.dependencies
-    depends.index(project('foo').test.compile.target).should < depends.index(project('foo').compile.target)
+    expect(depends.index(project('foo').test.compile.target)).to be < depends.index(project('foo').compile.target)
   end
 
   it 'should include the test resources target in its dependencies' do
     write 'src/test/resources/config.xml'
-    define('foo').test.dependencies.should include(project('foo').test.resources.target)
+    expect(define('foo').test.dependencies).to include(project('foo').test.resources.target)
   end
 
   it 'should add test resource target ahead of regular resource target' do
@@ -260,23 +260,23 @@ describe Buildr::TestTask do
     write 'src/test/resources/config.xml'
     define 'foo'
     depends = project('foo').test.dependencies
-    depends.index(project('foo').test.resources.target).should < depends.index(project('foo').resources.target)
+    expect(depends.index(project('foo').test.resources.target)).to be < depends.index(project('foo').resources.target)
   end
 
   it 'should not have a last successful run timestamp before the tests are run' do
-    test_task.timestamp.should == Rake::EARLY
+    expect(test_task.timestamp).to eq(Rake::EARLY)
   end
 
   it 'should clean after itself (test files)' do
     define('foo') { test.compile.using(:javac) }
     mkpath project('foo').test.compile.target.to_s
-    lambda { task('clean').invoke }.should change { File.exist?(project('foo').test.compile.target.to_s) }.to(false)
+    expect { task('clean').invoke }.to change { File.exist?(project('foo').test.compile.target.to_s) }.to(false)
   end
 
   it 'should clean after itself (reports)' do
     define 'foo'
     mkpath project('foo').test.report_to.to_s
-    lambda { task('clean').invoke }.should change { File.exist?(project('foo').test.report_to.to_s) }.to(false)
+    expect { task('clean').invoke }.to change { File.exist?(project('foo').test.report_to.to_s) }.to(false)
   end
 
   it 'should only run tests explicitly specified if options.test is :only' do
@@ -284,34 +284,34 @@ describe Buildr::TestTask do
     write 'bar/src/main/java/Bar.java', 'public class Bar {}'
     define('bar', :version=>'1.0', :base_dir=>'bar') { package :jar }
     define('foo') { compile.with project('bar') }
-    lambda { task('foo:test').invoke rescue nil }.should_not run_tasks('bar:test')
+    expect { task('foo:test').invoke rescue nil }.not_to run_tasks('bar:test')
   end
 end
 
 
 describe Buildr::TestTask, 'with no tests' do
   it 'should pass' do
-    lambda { define('foo').test.invoke }.should_not raise_error
+    expect { define('foo').test.invoke }.not_to raise_error
   end
 
   it 'should report no failed tests' do
-    lambda { verbose(true) { define('foo').test.invoke } }.should_not show_error(/fail/i)
+    expect { verbose(true) { define('foo').test.invoke } }.not_to show_error(/fail/i)
   end
 
   it 'should return no failed tests' do
     define('foo') { test.using(:junit) }
     project('foo').test.invoke
-    project('foo').test.failed_tests.should be_empty
+    expect(project('foo').test.failed_tests).to be_empty
   end
 
   it 'should return no passing tests' do
     define('foo') { test.using(:junit) }
     project('foo').test.invoke
-    project('foo').test.passed_tests.should be_empty
+    expect(project('foo').test.passed_tests).to be_empty
   end
 
   it 'should execute teardown task' do
-    lambda { define('foo').test.invoke }.should run_task('foo:test:teardown')
+    expect { define('foo').test.invoke }.to run_task('foo:test:teardown')
   end
 end
 
@@ -331,30 +331,30 @@ describe Buildr::TestTask, 'with passing tests' do
   end
 
   it 'should pass' do
-    lambda { test_task.invoke }.should_not raise_error
+    expect { test_task.invoke }.not_to raise_error
   end
 
   it 'should report no failed tests' do
-    lambda { verbose(true) { test_task.invoke } }.should_not show_error(/fail/i)
+    expect { verbose(true) { test_task.invoke } }.not_to show_error(/fail/i)
   end
 
   it 'should return passed tests' do
     test_task.invoke
-    test_task.passed_tests.should == ['PassingTest1', 'PassingTest2']
+    expect(test_task.passed_tests).to eq(['PassingTest1', 'PassingTest2'])
   end
 
   it 'should return no failed tests' do
     test_task.invoke
-    test_task.failed_tests.should be_empty
+    expect(test_task.failed_tests).to be_empty
   end
 
   it 'should execute teardown task' do
-    lambda { test_task.invoke }.should run_task('foo:test:teardown')
+    expect { test_task.invoke }.to run_task('foo:test:teardown')
   end
 
   it 'should update the last successful run timestamp' do
     before = Time.now ; test_task.invoke ; after = Time.now
-    (before-1..after+1).should cover(test_task.timestamp)
+    expect(before-1..after+1).to cover(test_task.timestamp)
   end
 end
 
@@ -376,91 +376,91 @@ describe Buildr::TestTask, 'with failed test' do
   end
 
   it 'should fail' do
-    lambda { test_task.invoke }.should raise_error(RuntimeError, /Tests failed/)
+    expect { test_task.invoke }.to raise_error(RuntimeError, /Tests failed/)
   end
 
   it 'should report failed tests' do
-    lambda { verbose(true) { test_task.invoke rescue nil } }.should show_error(/FailingTest/)
+    expect { verbose(true) { test_task.invoke rescue nil } }.to show_error(/FailingTest/)
   end
 
   it 'should record failed tests' do
     test_task.invoke rescue nil
-    File.read(project('foo').path_to('target', "#{test_task.framework}-failed")).should == 'FailingTest'
+    expect(File.read(project('foo').path_to('target', "#{test_task.framework}-failed"))).to eq('FailingTest')
   end
 
   it 'should return failed tests' do
     test_task.invoke rescue nil
-    test_task.failed_tests.should == ['FailingTest']
+    expect(test_task.failed_tests).to eq(['FailingTest'])
   end
 
   it 'should return passing tests as well' do
     test_task.invoke rescue nil
-    test_task.passed_tests.should == ['PassingTest']
+    expect(test_task.passed_tests).to eq(['PassingTest'])
   end
 
   it 'should know what tests failed last time' do
     test_task.invoke rescue nil
-    project('foo').test.last_failures.should == ['FailingTest']
+    expect(project('foo').test.last_failures).to eq(['FailingTest'])
   end
 
   it 'should not fail if fail_on_failure is false' do
     test_task.using(:fail_on_failure=>false).invoke
-    lambda { test_task.invoke }.should_not raise_error
+    expect { test_task.invoke }.not_to raise_error
   end
 
   it 'should report failed tests even if fail_on_failure is false' do
     test_task.using(:fail_on_failure=>false)
-    lambda { verbose(true) { test_task.invoke } }.should show_error(/FailingTest/)
+    expect { verbose(true) { test_task.invoke } }.to show_error(/FailingTest/)
   end
 
   it 'should return failed tests even if fail_on_failure is false' do
     test_task.using(:fail_on_failure=>false).invoke
-    test_task.failed_tests.should == ['FailingTest']
+    expect(test_task.failed_tests).to eq(['FailingTest'])
   end
 
   it 'should execute teardown task' do
-    lambda { test_task.invoke rescue nil }.should run_task('foo:test:teardown')
+    expect { test_task.invoke rescue nil }.to run_task('foo:test:teardown')
   end
 
   it 'should not update the last successful run timestamp' do
     a_second_ago = Time.now - 1
     touch_last_successful_test_run test_task, a_second_ago
     test_task.invoke rescue nil
-    test_task.timestamp.should <= a_second_ago
+    expect(test_task.timestamp).to be <= a_second_ago
   end
 end
 
 
 describe Buildr::Project, '#test' do
   it 'should return the project\'s test task' do
-    define('foo') { test.should be(task('test')) }
+    define('foo') { expect(test).to be(task('test')) }
   end
 
   it 'should accept prerequisites for task' do
     define('foo') { test 'prereq' }
-    project('foo').test.prerequisites.should include('prereq')
+    expect(project('foo').test.prerequisites).to include('prereq')
   end
 
   it 'should accept actions for task' do
     task 'action'
     define('foo') { test { task('action').invoke } }
-    lambda { project('foo').test.invoke }.should run_tasks('action')
+    expect { project('foo').test.invoke }.to run_tasks('action')
   end
 
   it 'should set fail_on_failure true by default' do
-    define('foo').test.options[:fail_on_failure].should be_true
+    expect(define('foo').test.options[:fail_on_failure]).to be_truthy
   end
 
   it 'should set fork mode by default' do
-    define('foo').test.options[:fork].should == :once
+    expect(define('foo').test.options[:fork]).to eq(:once)
   end
 
   it 'should set properties to empty hash by default' do
-    define('foo').test.options[:properties].should == {}
+    expect(define('foo').test.options[:properties]).to eq({})
   end
 
   it 'should set environment variables to empty hash by default' do
-    define('foo').test.options[:environment].should == {}
+    expect(define('foo').test.options[:environment]).to eq({})
   end
 
   it 'should inherit options from parent project' do
@@ -468,10 +468,10 @@ describe Buildr::Project, '#test' do
       test.using :fail_on_failure=>false, :fork=>:each, :properties=>{ :foo=>'bar' }, :environment=>{ 'config'=>'config.yaml' }
       define 'bar' do
         test.using :junit
-        test.options[:fail_on_failure].should be_false
-        test.options[:fork].should == :each
-        test.options[:properties][:foo].should == 'bar'
-        test.options[:environment]['config'].should == 'config.yaml'
+        expect(test.options[:fail_on_failure]).to be_falsey
+        expect(test.options[:fork]).to eq(:each)
+        expect(test.options[:properties][:foo]).to eq('bar')
+        expect(test.options[:environment]['config']).to eq('config.yaml')
       end
     end
   end
@@ -482,10 +482,10 @@ describe Buildr::Project, '#test' do
         test.using :fail_on_failure=>false, :fork=>:each, :properties=>{ :foo=>'bar' }, :environment=>{ 'config'=>'config.yaml' }
         test.using :junit
       end.invoke
-      test.options[:fail_on_failure].should be_true
-      test.options[:fork].should == :once
-      test.options[:properties].should == {}
-      test.options[:environment].should == {}
+      expect(test.options[:fail_on_failure]).to be_truthy
+      expect(test.options[:fork]).to eq(:once)
+      expect(test.options[:properties]).to eq({})
+      expect(test.options[:environment]).to eq({})
     end
   end
 
@@ -498,10 +498,10 @@ describe Buildr::Project, '#test' do
         test.options[:environment]['config'] = 'config.yaml'
         test.using :junit
       end.invoke
-      test.options[:fail_on_failure].should be_true
-      test.options[:fork].should == :once
-      test.options[:properties].should == {}
-      test.options[:environment].should == {}
+      expect(test.options[:fail_on_failure]).to be_truthy
+      expect(test.options[:fork]).to eq(:once)
+      expect(test.options[:properties]).to eq({})
+      expect(test.options[:environment]).to eq({})
     end
   end
 
@@ -509,7 +509,7 @@ describe Buildr::Project, '#test' do
     define 'foo' do
         test.options[:properties][:foo] = 'bar'
     end
-    project('foo').test.options[:properties][:foo].should == 'bar'
+    expect(project('foo').test.options[:properties][:foo]).to eq('bar')
   end
 
   it 'should accept to set a test property in a subproject' do
@@ -518,7 +518,7 @@ describe Buildr::Project, '#test' do
         test.options[:properties][:bar] = 'baz'
       end
     end
-    project('foo:bar').test.options[:properties][:bar].should == 'baz'
+    expect(project('foo:bar').test.options[:properties][:bar]).to eq('baz')
   end
 
   it 'should not change options of unrelated projects when using #options' do
@@ -526,7 +526,7 @@ describe Buildr::Project, '#test' do
       test.options[:properties][:foo] = 'bar'
     end
     define 'bar' do
-      test.options[:properties].should == {}
+      expect(test.options[:properties]).to eq({})
     end
   end
 
@@ -534,7 +534,7 @@ describe Buildr::Project, '#test' do
     write 'src/main/java/Foo.java'
     write 'src/test/java/FooTest.java'
     define('foo')
-    lambda { task('foo:build').invoke }.should run_task('foo:test')
+    expect { task('foo:build').invoke }.to run_task('foo:test')
   end
 end
 
@@ -543,21 +543,21 @@ describe Buildr::Project, '#test.compile' do
   it 'should identify compiler from project' do
     write 'src/test/java/com/example/Test.java'
     define('foo') do
-      test.compile.compiler.should eql(:javac)
+      expect(test.compile.compiler).to eql(:javac)
     end
   end
 
   it 'should include identified sources' do
     write 'src/test/java/Test.java'
     define('foo') do
-      test.compile.sources.should include(_('src/test/java'))
+      expect(test.compile.sources).to include(_('src/test/java'))
     end
   end
 
   it 'should compile to target/test/<code>' do
     define 'foo', :target=>'targeted' do
       test.compile.using(:javac)
-      test.compile.target.should eql(file('targeted/test/classes'))
+      expect(test.compile.target).to eql(file('targeted/test/classes'))
     end
   end
 
@@ -566,7 +566,7 @@ describe Buildr::Project, '#test.compile' do
       compile.using(:javac).with 'group:id:jar:1.0'
       test.compile.using(:javac)
     end
-    project('foo').test.compile.dependencies.should include(artifact('group:id:jar:1.0'))
+    expect(project('foo').test.compile.dependencies).to include(artifact('group:id:jar:1.0'))
   end
 
   it 'should include the main compiled target in its dependencies' do
@@ -574,7 +574,7 @@ describe Buildr::Project, '#test.compile' do
       compile.using(:javac).into 'bytecode'
       test.compile.using(:javac)
     end
-    project('foo').test.compile.dependencies.should include(file('bytecode'))
+    expect(project('foo').test.compile.dependencies).to include(file('bytecode'))
   end
 
   it 'should include the test framework dependencies' do
@@ -582,46 +582,46 @@ describe Buildr::Project, '#test.compile' do
       test.compile.using(:javac)
       test.using(:junit)
     end
-    project('foo').test.compile.dependencies.should include(*artifacts(JUnit.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(JUnit.dependencies))
   end
 
   it 'should clean after itself' do
     write 'src/test/java/Nothing.java', 'class Nothing {}'
     define('foo') { test.compile.into 'bytecode' }
     project('foo').test.compile.invoke
-    lambda { project('foo').clean.invoke }.should change { File.exist?('bytecode') }.to(false)
+    expect { project('foo').clean.invoke }.to change { File.exist?('bytecode') }.to(false)
   end
 end
 
 
 describe Buildr::Project, '#test.resources' do
   it 'should ignore resources unless they exist' do
-    define('foo').test.resources.sources.should be_empty
-    project('foo').test.resources.target.should be_nil
+    expect(define('foo').test.resources.sources).to be_empty
+    expect(project('foo').test.resources.target).to be_nil
   end
 
   it 'should pick resources from src/test/resources if found' do
     mkpath 'src/test/resources'
-    define('foo') { test.resources.sources.should include(file('src/test/resources')) }
+    define('foo') { expect(test.resources.sources).to include(file('src/test/resources')) }
   end
 
   it 'should copy to the resources target directory' do
     write 'src/test/resources/config.xml', '</xml>'
     define('foo', :target=>'targeted').test.invoke
-    file('targeted/test/resources/config.xml').should contain('</xml>')
+    expect(file('targeted/test/resources/config.xml')).to contain('</xml>')
   end
 
   it 'should create target directory even if no files to copy' do
     define('foo') do
       test.resources.filter.into('resources')
     end
-    lambda { file(File.expand_path('resources')).invoke }.should change { File.exist?('resources') }.to(true)
+    expect { file(File.expand_path('resources')).invoke }.to change { File.exist?('resources') }.to(true)
   end
 
   it 'should execute alongside compile task' do
     task 'action'
     define('foo') { test.resources { task('action').invoke } }
-    lambda { project('foo').test.compile.invoke }.should run_tasks('action')
+    expect { project('foo').test.compile.invoke }.to run_tasks('action')
   end
 end
 
@@ -640,22 +640,22 @@ describe Buildr::TestTask, '#invoke' do
   end
 
   it 'should require dependencies to exist' do
-    lambda { test_task.with('no-such.jar').invoke }.should \
+    expect { test_task.with('no-such.jar').invoke }.to \
       raise_error(RuntimeError, /Don't know how to build/)
   end
 
   it 'should run all dependencies as prerequisites' do
     file(File.expand_path('no-such.jar')) { task('prereq').invoke }
-    lambda { test_task.with('no-such.jar').invoke }.should run_tasks(['prereq', 'foo:test'])
+    expect { test_task.with('no-such.jar').invoke }.to run_tasks(['prereq', 'foo:test'])
   end
 
   it 'should run tests if they have never run' do
-    lambda { test_task.invoke }.should run_task('foo:test')
+    expect { test_task.invoke }.to run_task('foo:test')
   end
 
   it 'should not run tests if test option is off' do
     Buildr.options.test = false
-    lambda { test_task.invoke }.should_not run_task('foo:test')
+    expect { test_task.invoke }.not_to run_task('foo:test')
   end
 
   describe 'when there was a successful test run already' do
@@ -671,58 +671,58 @@ describe Buildr::TestTask, '#invoke' do
     end
 
     it 'should not run tests if nothing changed' do
-      lambda { test_task.invoke; sleep 1 }.should_not run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.not_to run_task('foo:test')
     end
 
     it 'should run tests if options.test is :all' do
       Buildr.options.test = :all
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should run tests if main compile target changed' do
       touch project('foo').compile.target.to_s
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should run tests if test compile target changed' do
       touch test_task.compile.target.to_s
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should run tests if main resources changed' do
       touch project('foo').resources.target.to_s
-      lambda { test_task.invoke }.should run_task('foo:test')
+      expect { test_task.invoke }.to run_task('foo:test')
     end
 
     it 'should run tests if test resources changed' do
       touch test_task.resources.target.to_s
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should run tests if compile-dependent project changed' do
       write 'bar/src/main/java/Bar.java', 'public class Bar {}'
       define('bar', :version=>'1.0', :base_dir=>'bar') { package :jar }
       project('foo').compile.with project('bar')
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should run tests if test-dependent project changed' do
       write 'bar/src/main/java/Bar.java', 'public class Bar {}'
       define('bar', :version=>'1.0', :base_dir=>'bar') { package :jar }
       test_task.with project('bar')
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should run tests if buildfile changed' do
       touch 'buildfile'
-      test_task.should_receive(:run_tests)
-      lambda { test_task.invoke; sleep 1 }.should run_task('foo:test')
+      expect(test_task).to receive(:run_tests)
+      expect { test_task.invoke; sleep 1 }.to run_task('foo:test')
     end
 
     it 'should not run tests if buildfile changed but IGNORE_BUILDFILE is true' do
       begin
         ENV["IGNORE_BUILDFILE"] = "true"
-        test_task.should_not_receive(:run_tests)
+        expect(test_task).not_to receive(:run_tests)
         test_task.invoke
       ensure
         ENV["IGNORE_BUILDFILE"] = nil
@@ -734,16 +734,16 @@ end
 describe Rake::Task, 'test' do
   it 'should be recursive' do
     define('foo') { define 'bar' }
-    lambda { task('test').invoke }.should run_tasks('foo:test', 'foo:bar:test')
+    expect { task('test').invoke }.to run_tasks('foo:test', 'foo:bar:test')
   end
 
   it 'should be local task' do
     define('foo') { define 'bar' }
-    lambda do
+    expect do
       in_original_dir project('foo:bar').base_dir do
         task('test').invoke
       end
-    end.should run_task('foo:bar:test').but_not('foo:test')
+    end.to run_task('foo:bar:test').but_not('foo:test')
   end
 
   it 'should stop at first failure' do
@@ -751,14 +751,14 @@ describe Rake::Task, 'test' do
       define('foo') { test { fail } }
       define('bar') { test { fail } }
     end
-    lambda { task('test').invoke rescue nil }.should run_tasks('myproject:bar:test').but_not('myproject:foo:test')
+    expect { task('test').invoke rescue nil }.to run_tasks('myproject:bar:test').but_not('myproject:foo:test')
   end
 
   it 'should ignore failure if options.test is :all' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     options.test = :all
-    lambda { task('test').invoke rescue nil }.should run_tasks('foo:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.to run_tasks('foo:test', 'bar:test')
   end
 
   it 'should ignore failure in subprojects if options.test is :all' do
@@ -769,7 +769,7 @@ describe Rake::Task, 'test' do
     }
     define('bar') { test { fail } }
     options.test = :all
-    lambda { task('test').invoke rescue nil }.should run_tasks('foo:p1:test', 'foo:p2:test', 'foo:p3:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.to run_tasks('foo:p1:test', 'foo:p2:test', 'foo:p3:test', 'bar:test')
   end
 
   it 'should ignore failure in subprojects if environment variable test is \'all\'' do
@@ -780,56 +780,56 @@ describe Rake::Task, 'test' do
     }
     define('bar') { test { fail } }
     ENV['test'] = 'all'
-    lambda { task('test').invoke rescue nil }.should run_tasks('foo:p1:test', 'foo:p2:test', 'foo:p3:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.to run_tasks('foo:p1:test', 'foo:p2:test', 'foo:p3:test', 'bar:test')
   end
 
   it 'should ignore failure if options.test is :all and target is build task ' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     options.test = :all
-    lambda { task('build').invoke rescue nil }.should run_tasks('foo:test', 'bar:test')
+    expect { task('build').invoke rescue nil }.to run_tasks('foo:test', 'bar:test')
   end
 
   it 'should ignore failure if environment variable test is \'all\'' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     ENV['test'] = 'all'
-    lambda { task('test').invoke rescue nil }.should run_tasks('foo:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.to run_tasks('foo:test', 'bar:test')
   end
 
   it 'should ignore failure if environment variable TEST is \'all\'' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     ENV['TEST'] = 'all'
-    lambda { task('test').invoke rescue nil }.should run_tasks('foo:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.to run_tasks('foo:test', 'bar:test')
   end
 
   it 'should execute no tests if options.test is false' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     options.test = false
-    lambda { task('test').invoke rescue nil }.should_not run_tasks('foo:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.not_to run_tasks('foo:test', 'bar:test')
   end
 
   it 'should execute no tests if environment variable test is \'no\'' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     ENV['test'] = 'no'
-    lambda { task('test').invoke rescue nil }.should_not run_tasks('foo:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.not_to run_tasks('foo:test', 'bar:test')
   end
 
   it 'should execute no tests if environment variable TEST is \'no\'' do
     define('foo') { test { fail } }
     define('bar') { test { fail } }
     ENV['TEST'] = 'no'
-    lambda { task('test').invoke rescue nil }.should_not run_tasks('foo:test', 'bar:test')
+    expect { task('test').invoke rescue nil }.not_to run_tasks('foo:test', 'bar:test')
   end
 
   it "should not compile tests if environment variable test is 'no'" do
     write "src/test/java/HelloTest.java", "public class HelloTest { public void testTest() {}}"
     define('foo') { test { fail } }
     ENV['test'] = 'no'
-    lambda { task('test').invoke rescue nil }.should_not run_tasks('foo:test:compile')
+    expect { task('test').invoke rescue nil }.not_to run_tasks('foo:test:compile')
   end
 end
 
@@ -838,7 +838,7 @@ describe 'test rule' do
 
   it 'should execute test task on local project' do
     define('foo') { define 'bar' }
-    lambda { task('test:something').invoke }.should run_task('foo:test')
+    expect { task('test:something').invoke }.to run_task('foo:test')
   end
 
   it 'should reset tasks to specific pattern' do
@@ -852,8 +852,8 @@ describe 'test rule' do
     end
     task('test:something').invoke
     ['foo', 'foo:bar'].map { |name| project(name) }.each do |project|
-      project.test.tests.should include('something')
-      project.test.tests.should_not include('nothing')
+      expect(project.test.tests).to include('something')
+      expect(project.test.tests).not_to include('nothing')
     end
   end
 
@@ -863,7 +863,7 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['prefix-something-suffix']) }
     end
     task('test:something').invoke
-    project('foo').test.tests.should include('prefix-something-suffix')
+    expect(project('foo').test.tests).to include('prefix-something-suffix')
   end
 
   it 'should not apply *name* pattern if asterisks used' do
@@ -872,8 +872,8 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['prefix-something', 'prefix-something-suffix']) }
     end
     task('test:*something').invoke
-    project('foo').test.tests.should include('prefix-something')
-    project('foo').test.tests.should_not include('prefix-something-suffix')
+    expect(project('foo').test.tests).to include('prefix-something')
+    expect(project('foo').test.tests).not_to include('prefix-something-suffix')
   end
 
   it 'should accept multiple tasks separated by commas' do
@@ -882,9 +882,9 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['foo', 'bar', 'baz']) }
     end
     task('test:foo,bar').invoke
-    project('foo').test.tests.should include('foo')
-    project('foo').test.tests.should include('bar')
-    project('foo').test.tests.should_not include('baz')
+    expect(project('foo').test.tests).to include('foo')
+    expect(project('foo').test.tests).to include('bar')
+    expect(project('foo').test.tests).not_to include('baz')
   end
 
   it 'should execute only the named tests' do
@@ -903,7 +903,7 @@ describe 'test rule' do
     end
     touch_last_successful_test_run project('foo').test
     task('test:something').invoke
-    project('foo').test.tests.should include('something')
+    expect(project('foo').test.tests).to include('something')
   end
 
   it 'should not execute excluded tests' do
@@ -912,8 +912,8 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['something', 'nothing']) }
     end
     task('test:*,-nothing').invoke
-    project('foo').test.tests.should include('something')
-    project('foo').test.tests.should_not include('nothing')
+    expect(project('foo').test.tests).to include('something')
+    expect(project('foo').test.tests).not_to include('nothing')
   end
 
   it 'should not execute tests in excluded package' do
@@ -925,8 +925,8 @@ describe 'test rule' do
       test.using(:junit)
     end
     task('test:-com.example.bar').invoke
-    project('foo').test.tests.should include('com.example.foo.TestSomething')
-    project('foo').test.tests.should_not include('com.example.bar.TestFails')
+    expect(project('foo').test.tests).to include('com.example.foo.TestSomething')
+    expect(project('foo').test.tests).not_to include('com.example.bar.TestFails')
   end
 
   it 'should not execute excluded tests with wildcards' do
@@ -935,8 +935,8 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['something', 'nothing']) }
     end
     task('test:something,-s*,-n*').invoke
-    project('foo').test.tests.should_not include('something')
-    project('foo').test.tests.should_not include('nothing')
+    expect(project('foo').test.tests).not_to include('something')
+    expect(project('foo').test.tests).not_to include('nothing')
   end
 
   it 'should execute all tests except excluded tests' do
@@ -945,8 +945,8 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['something', 'anything', 'nothing']) }
     end
     task('test:-nothing').invoke
-    project('foo').test.tests.should include('something', 'anything')
-    project('foo').test.tests.should_not include('nothing')
+    expect(project('foo').test.tests).to include('something', 'anything')
+    expect(project('foo').test.tests).not_to include('nothing')
   end
 
   it 'should ignore exclusions in buildfile' do
@@ -956,8 +956,8 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['something', 'anything', 'nothing']) }
     end
     task('test:-nothing').invoke
-    project('foo').test.tests.should include('something', 'anything')
-    project('foo').test.tests.should_not include('nothing')
+    expect(project('foo').test.tests).to include('something', 'anything')
+    expect(project('foo').test.tests).not_to include('nothing')
   end
 
   it 'should ignore inclusions in buildfile' do
@@ -967,8 +967,8 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['something', 'nothing']) }
     end
     task('test:nothing').invoke
-    project('foo').test.tests.should include('nothing')
-    project('foo').test.tests.should_not include('something')
+    expect(project('foo').test.tests).to include('nothing')
+    expect(project('foo').test.tests).not_to include('something')
   end
 
   it 'should not execute a test if it''s both included and excluded' do
@@ -977,7 +977,7 @@ describe 'test rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['nothing']) }
     end
     task('test:nothing,-nothing').invoke
-    project('foo').test.tests.should_not include('nothing')
+    expect(project('foo').test.tests).not_to include('nothing')
   end
 
   it 'should not update the last successful test run timestamp' do
@@ -988,7 +988,7 @@ describe 'test rule' do
     a_second_ago = Time.now - 1
     touch_last_successful_test_run project('foo').test, a_second_ago
     task('test:something').invoke
-    project('foo').test.timestamp.should <= a_second_ago
+    expect(project('foo').test.timestamp).to be <= a_second_ago
   end
 end
 
@@ -1000,8 +1000,8 @@ describe 'test failed' do
       define 'foo' do
         test.using(:junit)
         test.instance_eval do
-          @framework.stub(:tests).and_return(['FailingTest', 'PassingTest'])
-          @framework.stub(:run).and_return(['PassingTest'])
+          allow(@framework).to receive(:tests).and_return(['FailingTest', 'PassingTest'])
+          allow(@framework).to receive(:run).and_return(['PassingTest'])
         end
       end
       project('foo').test
@@ -1018,8 +1018,8 @@ describe 'test failed' do
     end
     write project('foo').path_to(:target, "junit-failed"), "FailingTest"
     task('test:failed').invoke rescue nil
-    project('foo').test.tests.should include('FailingTest')
-    project('foo').test.tests.should_not include('PassingTest')
+    expect(project('foo').test.tests).to include('FailingTest')
+    expect(project('foo').test.tests).not_to include('PassingTest')
   end
 
   it 'should run failed tests, respecting excluded tests' do
@@ -1032,8 +1032,8 @@ describe 'test failed' do
     end
     write project('foo').path_to(:target, "junit-failed"), "FailingTest\nExcludedTest"
     task('test:failed').invoke rescue nil
-    project('foo').test.tests.should include('FailingTest')
-    project('foo').test.tests.should_not include('ExcludedTest')
+    expect(project('foo').test.tests).to include('FailingTest')
+    expect(project('foo').test.tests).not_to include('ExcludedTest')
   end
 
   it 'should run only the tests that failed the last time, even when failed tests have dependencies' do
@@ -1056,9 +1056,9 @@ describe 'test failed' do
     end
     write project('parent:bar').path_to(:target, "junit-failed"), "FailingTest"
     task('test:failed').invoke rescue nil
-    project('parent:foo').test.tests.should_not include('PassingTest')
-    project('parent:bar').test.tests.should include('FailingTest')
-    project('parent:bar').test.tests.should_not include('PassingTest')
+    expect(project('parent:foo').test.tests).not_to include('PassingTest')
+    expect(project('parent:bar').test.tests).to include('FailingTest')
+    expect(project('parent:bar').test.tests).not_to include('PassingTest')
   end
 
 end
@@ -1066,32 +1066,32 @@ end
 
 describe Buildr::Options, 'test' do
   it 'should be true by default' do
-    Buildr.options.test.should be_true
+    expect(Buildr.options.test).to be_truthy
   end
 
   ['skip', 'no', 'off', 'false'].each do |value|
     it "should be false if test environment variable is '#{value}'" do
-      lambda { ENV['test'] = value }.should change { Buildr.options.test }.to(false)
+      expect { ENV['test'] = value }.to change { Buildr.options.test }.to(false)
     end
   end
 
   ['skip', 'no', 'off', 'false'].each do |value|
     it "should be false if TEST environment variable is '#{value}'" do
-      lambda { ENV['TEST'] = value }.should change { Buildr.options.test }.to(false)
+      expect { ENV['TEST'] = value }.to change { Buildr.options.test }.to(false)
     end
   end
 
   it 'should be :all if test environment variable is all' do
-    lambda { ENV['test'] = 'all' }.should change { Buildr.options.test }.to(:all)
+    expect { ENV['test'] = 'all' }.to change { Buildr.options.test }.to(:all)
   end
 
   it 'should be :all if TEST environment variable is all' do
-    lambda { ENV['TEST'] = 'all' }.should change { Buildr.options.test }.to(:all)
+    expect { ENV['TEST'] = 'all' }.to change { Buildr.options.test }.to(:all)
   end
 
   it 'should be true and warn for any other value' do
     ENV['TEST'] = 'funky'
-    lambda { Buildr.options.test.should be(true) }.should show_warning(/expecting the environment variable/i)
+    expect { expect(Buildr.options.test).to be(true) }.to show_warning(/expecting the environment variable/i)
   end
 end
 
@@ -1100,44 +1100,44 @@ describe Buildr, 'integration' do
   it 'should return the same task from all contexts' do
     task = task('integration')
     define 'foo' do
-      integration.should be(task)
+      expect(integration).to be(task)
       define 'bar' do
-        integration.should be(task)
+        expect(integration).to be(task)
       end
     end
-    integration.should be(task)
+    expect(integration).to be(task)
   end
 
   it 'should respond to :setup and return setup task' do
     setup = integration.setup
-    define('foo') { integration.setup.should be(setup) }
+    define('foo') { expect(integration.setup).to be(setup) }
   end
 
   it 'should respond to :setup and add prerequisites to integration:setup' do
     define('foo') { integration.setup 'prereq' }
-    integration.setup.prerequisites.should include('prereq')
+    expect(integration.setup.prerequisites).to include('prereq')
   end
 
   it 'should respond to :setup and add action for integration:setup' do
     action = task('action')
     define('foo') { integration.setup { action.invoke } }
-    lambda { integration.setup.invoke }.should run_tasks(action)
+    expect { integration.setup.invoke }.to run_tasks(action)
   end
 
   it 'should respond to :teardown and return teardown task' do
     teardown = integration.teardown
-    define('foo') { integration.teardown.should be(teardown) }
+    define('foo') { expect(integration.teardown).to be(teardown) }
   end
 
   it 'should respond to :teardown and add prerequisites to integration:teardown' do
     define('foo') { integration.teardown 'prereq' }
-    integration.teardown.prerequisites.should include('prereq')
+    expect(integration.teardown.prerequisites).to include('prereq')
   end
 
   it 'should respond to :teardown and add action for integration:teardown' do
     action = task('action')
     define('foo') { integration.teardown { action.invoke } }
-    lambda { integration.teardown.invoke }.should run_tasks(action)
+    expect { integration.teardown.invoke }.to run_tasks(action)
   end
 end
 
@@ -1146,7 +1146,7 @@ describe Rake::Task, 'integration' do
   it 'should be a local task' do
     define('foo') { test.using :integration }
     define('bar', :base_dir=>'other') { test.using :integration }
-    lambda { task('integration').invoke }.should run_task('foo:test').but_not('bar:test')
+    expect { task('integration').invoke }.to run_task('foo:test').but_not('bar:test')
   end
 
   it 'should be a recursive task' do
@@ -1154,14 +1154,14 @@ describe Rake::Task, 'integration' do
       test.using :integration
       define('bar') { test.using :integration }
     end
-    lambda { task('integration').invoke }.should run_tasks('foo:test', 'foo:bar:test')
+    expect { task('integration').invoke }.to run_tasks('foo:test', 'foo:bar:test')
   end
 
   it 'should find nested integration tests' do
     define 'foo' do
       define('bar') { test.using :integration }
     end
-    lambda { task('integration').invoke }.should run_tasks('foo:bar:test').but_not('foo:test')
+    expect { task('integration').invoke }.to run_tasks('foo:bar:test').but_not('foo:test')
   end
 
   it 'should ignore nested regular tasks' do
@@ -1169,7 +1169,7 @@ describe Rake::Task, 'integration' do
       test.using :integration
       define('bar') { test.using :integration=>false }
     end
-    lambda { task('integration').invoke }.should run_tasks('foo:test').but_not('foo:bar:test')
+    expect { task('integration').invoke }.to run_tasks('foo:test').but_not('foo:bar:test')
   end
 
   it 'should agree not to run the same tasks as test' do
@@ -1179,34 +1179,34 @@ describe Rake::Task, 'integration' do
         define('baz') { test.using :integration=>false }
       end
     end
-    lambda { task('test').invoke }.should run_tasks('foo:test', 'foo:bar:baz:test').but_not('foo:bar:test')
-    lambda { task('integration').invoke }.should run_tasks('foo:bar:test').but_not('foo:test', 'foo:bar:baz:test')
+    expect { task('test').invoke }.to run_tasks('foo:test', 'foo:bar:baz:test').but_not('foo:bar:test')
+    expect { task('integration').invoke }.to run_tasks('foo:bar:test').but_not('foo:test', 'foo:bar:baz:test')
   end
 
   it 'should run setup task before any project integration tests' do
     define('foo') { test.using :integration }
     define('bar') { test.using :integration }
-    lambda { task('integration').invoke }.should run_tasks([integration.setup, 'bar:test'], [integration.setup, 'foo:test'])
+    expect { task('integration').invoke }.to run_tasks([integration.setup, 'bar:test'], [integration.setup, 'foo:test'])
   end
 
   it 'should run teardown task after all project integrations tests' do
     define('foo') { test.using :integration }
     define('bar') { test.using :integration }
-    lambda { task('integration').invoke }.should run_tasks(['bar:test', integration.teardown], ['foo:test', integration.teardown])
+    expect { task('integration').invoke }.to run_tasks(['bar:test', integration.teardown], ['foo:test', integration.teardown])
   end
 
   it 'should run test cases marked for integration' do
     write 'src/test/java/FailingTest.java',
       'public class FailingTest extends junit.framework.TestCase { public void testNothing() { assertTrue(false); } }'
     define('foo') { test.using :integration }
-    lambda { task('test').invoke }.should_not raise_error
-    lambda { task('integration').invoke }.should raise_error(RuntimeError, /tests failed/i)
+    expect { task('test').invoke }.not_to raise_error
+    expect { task('integration').invoke }.to raise_error(RuntimeError, /tests failed/i)
   end
 
   it 'should run setup and teardown tasks marked for integration' do
     define('foo') { test.using :integration }
-    lambda { task('test').invoke }.should run_tasks().but_not('foo:test:setup', 'foo:test:teardown')
-    lambda { task('integration').invoke }.should run_tasks('foo:test:setup', 'foo:test:teardown')
+    expect { task('test').invoke }.to run_tasks().but_not('foo:test:setup', 'foo:test:teardown')
+    expect { task('integration').invoke }.to run_tasks('foo:test:setup', 'foo:test:teardown')
   end
 
   it 'should run test actions marked for integration' do
@@ -1214,9 +1214,9 @@ describe Rake::Task, 'integration' do
     define 'foo' do
       test.using :integration, :junit
     end
-    lambda { task('test').invoke }.should_not change { project('foo').test.passed_tests }
-    lambda { task('integration').invoke }.should change { project('foo').test.passed_tests }
-    project('foo').test.passed_tests.should be_empty
+    expect { task('test').invoke }.not_to change { project('foo').test.passed_tests }
+    expect { task('integration').invoke }.to change { project('foo').test.passed_tests }
+    expect(project('foo').test.passed_tests).to be_empty
   end
 
   it 'should not fail if test=all' do
@@ -1224,7 +1224,7 @@ describe Rake::Task, 'integration' do
       'public class FailingTest extends junit.framework.TestCase { public void testNothing() { assertTrue(false); } }'
     define('foo') { test.using :integration }
     options.test = :all
-    lambda { task('integration').invoke }.should_not raise_error
+    expect { task('integration').invoke }.not_to raise_error
   end
 
   it 'should execute by local package task' do
@@ -1232,7 +1232,7 @@ describe Rake::Task, 'integration' do
       test.using :integration
       package :jar
     end
-    lambda { task('package').invoke }.should run_tasks(['foo:package', 'foo:test'])
+    expect { task('package').invoke }.to run_tasks(['foo:package', 'foo:test'])
   end
 
   it 'should execute by local package task along with unit tests' do
@@ -1241,7 +1241,7 @@ describe Rake::Task, 'integration' do
       package :jar
       define('bar') { test.using :integration=>false }
     end
-    lambda { task('package').invoke }.should run_tasks(['foo:package', 'foo:test'],
+    expect { task('package').invoke }.to run_tasks(['foo:package', 'foo:test'],
       ['foo:bar:test', 'foo:bar:package'])
   end
 
@@ -1251,7 +1251,7 @@ describe Rake::Task, 'integration' do
       package :jar
     end
     options.test = false
-    lambda { task('package').invoke }.should run_task('foo:package').but_not('foo:test')
+    expect { task('package').invoke }.to run_task('foo:package').but_not('foo:test')
   end
 end
 
@@ -1262,7 +1262,7 @@ describe 'integration rule' do
       test.using :junit, :integration
       define 'bar'
     end
-    lambda { task('integration:something').invoke }.should run_task('foo:test')
+    expect { task('integration:something').invoke }.to run_task('foo:test')
   end
 
   it 'should reset tasks to specific pattern' do
@@ -1276,8 +1276,8 @@ describe 'integration rule' do
     end
     task('integration:something').invoke
     ['foo', 'foo:bar'].map { |name| project(name) }.each do |project|
-      project.test.tests.should include('something')
-      project.test.tests.should_not include('nothing')
+      expect(project.test.tests).to include('something')
+      expect(project.test.tests).not_to include('nothing')
     end
   end
 
@@ -1287,7 +1287,7 @@ describe 'integration rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['prefix-something-suffix']) }
     end
     task('integration:something').invoke
-    project('foo').test.tests.should include('prefix-something-suffix')
+    expect(project('foo').test.tests).to include('prefix-something-suffix')
   end
 
   it 'should not apply *name* pattern if asterisks used' do
@@ -1296,8 +1296,8 @@ describe 'integration rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['prefix-something', 'prefix-something-suffix']) }
     end
     task('integration:*something').invoke
-    project('foo').test.tests.should include('prefix-something')
-    project('foo').test.tests.should_not include('prefix-something-suffix')
+    expect(project('foo').test.tests).to include('prefix-something')
+    expect(project('foo').test.tests).not_to include('prefix-something-suffix')
   end
 
   it 'should accept multiple tasks separated by commas' do
@@ -1306,9 +1306,9 @@ describe 'integration rule' do
       test.instance_eval { @framework.stub(:tests).and_return(['foo', 'bar', 'baz']) }
     end
     task('integration:foo,bar').invoke
-    project('foo').test.tests.should include('foo')
-    project('foo').test.tests.should include('bar')
-    project('foo').test.tests.should_not include('baz')
+    expect(project('foo').test.tests).to include('foo')
+    expect(project('foo').test.tests).to include('bar')
+    expect(project('foo').test.tests).not_to include('baz')
   end
 
   it 'should execute only the named tests' do

--- a/spec/core/transport_spec.rb
+++ b/spec/core/transport_spec.rb
@@ -27,32 +27,32 @@ describe URI, '#download' do
 
   it 'should download file if found' do
     @uri.download @target
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should fail if file not found' do
-    lambda { (@uri + 'missing').download @target }.should raise_error(URI::NotFoundError)
-    file(@target).should_not exist
+    expect { (@uri + 'missing').download @target }.to raise_error(URI::NotFoundError)
+    expect(file(@target)).not_to exist
   end
 
   it 'should work the same way from static method with URI' do
     URI.download @uri, @target
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should work the same way from static method with String' do
     URI.download @uri.to_s, @target
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should download to a task' do
     @uri.download file(@target)
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should download to a file' do
     File.open(@target, 'w') { |file| @uri.download file }
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 end
 
@@ -69,51 +69,51 @@ describe URI, '#upload' do
     File.chmod(0666, @source)
     s = File.stat(@source).mode
     @uri.upload @source
-    File.stat(@target).mode.should eql(s)
+    expect(File.stat(@target).mode).to eql(s)
   end
 
   it 'should upload file if found' do
     @uri.upload @source
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should fail if file not found' do
-    lambda { @uri.upload @source.ext('missing') }.should raise_error(URI::NotFoundError)
-    file(@target).should_not exist
+    expect { @uri.upload @source.ext('missing') }.to raise_error(URI::NotFoundError)
+    expect(file(@target)).not_to exist
   end
 
   it 'should work the same way from static method with URI' do
     URI.upload @uri, @source
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should work the same way from static method with String' do
     URI.upload @uri.to_s, @source
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should upload from a task' do
     @uri.upload file(@source)
-    file(@target).should contain(@content)
+    expect(file(@target)).to contain(@content)
   end
 
   it 'should create MD5 hash' do
     @uri.upload file(@source)
-    file(@target.ext('.md5')).should contain(Digest::MD5.hexdigest(@content))
+    expect(file(@target.ext('.md5'))).to contain(Digest::MD5.hexdigest(@content))
   end
 
   it 'should create SHA1 hash' do
     @uri.upload file(@source)
-    file(@target.ext('.sha1')).should contain(Digest::SHA1.hexdigest(@content))
+    expect(file(@target.ext('.sha1'))).to contain(Digest::SHA1.hexdigest(@content))
   end
 
   it 'should upload an entire directory' do
     mkpath 'dir' ; write 'dir/test', 'in directory'
     mkpath 'dir/nested' ; write 'dir/nested/test', 'in nested directory'
     @uri.upload 'dir'
-    file(@target).should contain('test', 'nested/test')
-    file(@target + '/test').should contain('in directory')
-    file(@target + '/nested/test').should contain('in nested directory')
+    expect(file(@target)).to contain('test', 'nested/test')
+    expect(file(@target + '/test')).to contain('in directory')
+    expect(file(@target + '/nested/test')).to contain('in nested directory')
   end
 end
 
@@ -121,29 +121,29 @@ end
 describe URI::FILE do
 
   it 'should accept file:something as file:///something' do
-    URI('file:something').should eql(URI('file:///something'))
+    expect(URI('file:something')).to eql(URI('file:///something'))
   end
 
   it 'should accept file:/ as file:///' do
-    URI('file:/').should eql(URI('file:///'))
+    expect(URI('file:/')).to eql(URI('file:///'))
   end
 
   it 'should accept file:/something as file:///something' do
-    URI('file:/something').should eql(URI('file:///something'))
+    expect(URI('file:/something')).to eql(URI('file:///something'))
   end
 
   it 'should accept file://something as file://something/' do
-    URI('file://something').should eql(URI('file://something/'))
+    expect(URI('file://something')).to eql(URI('file://something/'))
   end
 
   it 'should accept file:///something' do
-    URI('file:///something').should be_kind_of(URI::FILE)
-    URI('file:///something').to_s.should eql('file:///something')
-    URI('file:///something').path.should eql('/something')
+    expect(URI('file:///something')).to be_kind_of(URI::FILE)
+    expect(URI('file:///something').to_s).to eql('file:///something')
+    expect(URI('file:///something').path).to eql('/something')
   end
 
   it 'should treat host as path when host name is a Windows drive' do
-    URI('file://c:/something').should eql(URI('file:///c:/something'))
+    expect(URI('file://c:/something')).to eql(URI('file:///c:/something'))
   end
 end
 
@@ -161,20 +161,20 @@ describe URI::FILE, '#read' do
   end
 
   it 'should read the file' do
-    @uri.read.should eql(@content)
+    expect(@uri.read).to eql(@content)
   end
 
   it 'should read the file and yield to block' do
-    @uri.read { |content| content.should eql(@content) }
+    @uri.read { |content| expect(content).to eql(@content) }
   end
 
   it 'should raise NotFoundError if file doesn\'t exist' do
-    lambda { (@uri + 'notme').read }.should raise_error(URI::NotFoundError)
+    expect { (@uri + 'notme').read }.to raise_error(URI::NotFoundError)
   end
 
   it 'should raise NotFoundError if file is actually a directory' do
     mkpath 'dir'
-    lambda { (@uri + 'dir').read }.should raise_error(URI::NotFoundError)
+    expect { (@uri + 'dir').read }.to raise_error(URI::NotFoundError)
   end
 end
 
@@ -192,7 +192,7 @@ describe URI::FILE, '#write' do
 
   it 'should write the file from a string' do
     @uri.write @content
-    read(@filename).should eql(@content)
+    expect(read(@filename)).to eql(@content)
   end
 
   it 'should write the file from a reader' do
@@ -202,18 +202,18 @@ describe URI::FILE, '#write' do
     end
     reader.instance_variable_set :@array, [@content]
     @uri.write reader
-    read(@filename).should eql(@content)
+    expect(read(@filename)).to eql(@content)
   end
 
   it 'should write the file from a block' do
     array = [@content]
     @uri.write { array.pop }
-    read(@filename).should eql(@content)
+    expect(read(@filename)).to eql(@content)
   end
 
   it 'should not create file if read fails' do
     @uri.write { fail } rescue nil
-    file(@filename).should_not exist
+    expect(file(@filename)).not_to exist
   end
 end
 
@@ -233,120 +233,120 @@ describe URI::HTTP, '#read' do
     @no_proxy_args = [@host_domain, 80]
     @proxy_args = @no_proxy_args + ['myproxy', 8080, 'john', 'smith']
     @http = double('http')
-    @http.stub(:request).and_yield(Net::HTTPNotModified.new(nil, nil, nil))
+    allow(@http).to receive(:request).and_yield(Net::HTTPNotModified.new(nil, nil, nil))
   end
 
   it 'should not use proxy unless proxy is set' do
-    Net::HTTP.should_receive(:new).with(*@no_proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@no_proxy_args).and_return(@http)
     @uri.read
   end
 
   it 'should use HTTPS if applicable' do
-    Net::HTTP.should_receive(:new).with(@host_domain, 443).and_return(@http)
-    @http.should_receive(:use_ssl=).with(true)
+    expect(Net::HTTP).to receive(:new).with(@host_domain, 443).and_return(@http)
+    expect(@http).to receive(:use_ssl=).with(true)
     URI(@uri.to_s.sub(/http/, 'https')).read
   end
 
   it 'should use proxy from environment variable HTTP_PROXY when using http' do
     ENV['HTTP_PROXY'] = @proxy
-    Net::HTTP.should_receive(:new).with(*@proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@proxy_args).and_return(@http)
     @uri.read
   end
 
   it 'should use proxy from environment variable HTTPS_PROXY when using https' do
     ENV['HTTPS_PROXY'] = @proxy
-    Net::HTTP.should_receive(:new).with(@host_domain, 443, 'myproxy', 8080, 'john', 'smith').and_return(@http)
-    @http.should_receive(:use_ssl=).with(true)
+    expect(Net::HTTP).to receive(:new).with(@host_domain, 443, 'myproxy', 8080, 'john', 'smith').and_return(@http)
+    expect(@http).to receive(:use_ssl=).with(true)
     URI(@uri.to_s.sub(/http/, 'https')).read
   end
 
   it 'should not use proxy for hosts from environment variable NO_PROXY' do
     ENV['HTTP_PROXY'] = @proxy
     ENV['NO_PROXY'] = @host_domain
-    Net::HTTP.should_receive(:new).with(*@no_proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@no_proxy_args).and_return(@http)
     @uri.read
   end
 
   it 'should use proxy for hosts other than those specified by NO_PROXY' do
     ENV['HTTP_PROXY'] = @proxy
     ENV['NO_PROXY'] = 'whatever'
-    Net::HTTP.should_receive(:new).with(*@proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@proxy_args).and_return(@http)
     @uri.read
   end
 
   it 'should support comma separated list in environment variable NO_PROXY' do
     ENV['HTTP_PROXY'] = @proxy
     ENV['NO_PROXY'] = 'optimus,prime'
-    Net::HTTP.should_receive(:new).with('optimus', 80).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('optimus', 80).and_return(@http)
     URI('http://optimus').read
-    Net::HTTP.should_receive(:new).with('prime', 80).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('prime', 80).and_return(@http)
     URI('http://prime').read
-    Net::HTTP.should_receive(:new).with('bumblebee', *@proxy_args[1..-1]).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('bumblebee', *@proxy_args[1..-1]).and_return(@http)
     URI('http://bumblebee').read
   end
 
   it 'should support glob pattern in NO_PROXY' do
     ENV['HTTP_PROXY'] = @proxy
     ENV['NO_PROXY'] = "*.#{@domain}"
-    Net::HTTP.should_receive(:new).once.with(*@no_proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).once.with(*@no_proxy_args).and_return(@http)
     @uri.read
   end
 
   it 'should support specific port in NO_PROXY' do
     ENV['HTTP_PROXY'] = @proxy
     ENV['NO_PROXY'] = "#{@host_domain}:80"
-    Net::HTTP.should_receive(:new).with(*@no_proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@no_proxy_args).and_return(@http)
     @uri.read
     ENV['NO_PROXY'] = "#{@host_domain}:800"
-    Net::HTTP.should_receive(:new).with(*@proxy_args).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with(*@proxy_args).and_return(@http)
     @uri.read
   end
 
   it 'should not die if content size is zero' do
     ok = Net::HTTPOK.new(nil, nil, nil)
-    ok.stub(:read_body)
-    @http.stub(:request).and_yield(ok)
-    Net::HTTP.should_receive(:new).and_return(@http)
-    $stdout.should_receive(:isatty).and_return(false)
+    allow(ok).to receive(:read_body)
+    allow(@http).to receive(:request).and_yield(ok)
+    expect(Net::HTTP).to receive(:new).and_return(@http)
+    expect($stdout).to receive(:isatty).and_return(false)
     @uri.read :progress=>true
   end
 
   it 'should use HTTP Basic authentication' do
-    Net::HTTP.should_receive(:new).and_return(@http)
+    expect(Net::HTTP).to receive(:new).and_return(@http)
     request = double('request')
-    Net::HTTP::Get.should_receive(:new).and_return(request)
-    request.should_receive(:basic_auth).with('john', 'secret')
+    expect(Net::HTTP::Get).to receive(:new).and_return(request)
+    expect(request).to receive(:basic_auth).with('john', 'secret')
     URI("http://john:secret@#{@host_domain}").read
   end
 
   it 'should preseve authentication information during a redirect' do
-    Net::HTTP.should_receive(:new).twice.and_return(@http)
+    expect(Net::HTTP).to receive(:new).twice.and_return(@http)
 
     # The first request will produce a redirect
     redirect = Net::HTTPRedirection.new(nil, nil, nil)
     redirect['Location'] = "http://#{@host_domain}/asdf"
 
     request1 = double('request1')
-    Net::HTTP::Get.should_receive(:new).once.with('/', default_http_headers).and_return(request1)
-    request1.should_receive(:basic_auth).with('john', 'secret')
-    @http.should_receive(:request).with(request1).and_yield(redirect)
+    expect(Net::HTTP::Get).to receive(:new).once.with('/', default_http_headers).and_return(request1)
+    expect(request1).to receive(:basic_auth).with('john', 'secret')
+    expect(@http).to receive(:request).with(request1).and_yield(redirect)
 
     # The second request will be ok
     ok = Net::HTTPOK.new(nil, nil, nil)
-    ok.stub(:read_body)
+    allow(ok).to receive(:read_body)
 
     request2 = double('request2')
-    Net::HTTP::Get.should_receive(:new).once.with("/asdf", default_http_headers).and_return(request2)
-    request2.should_receive(:basic_auth).with('john', 'secret')
-    @http.should_receive(:request).with(request2).and_yield(ok)
+    expect(Net::HTTP::Get).to receive(:new).once.with("/asdf", default_http_headers).and_return(request2)
+    expect(request2).to receive(:basic_auth).with('john', 'secret')
+    expect(@http).to receive(:request).with(request2).and_yield(ok)
 
     URI("http://john:secret@#{@host_domain}").read
   end
 
   it 'should include the query part when performing HTTP GET' do
     # should this test be generalized or shared with any other URI subtypes?
-    Net::HTTP.stub(:new).and_return(@http)
-    Net::HTTP::Get.should_receive(:new).with(/#{Regexp.escape(@query)}$/, default_http_headers)
+    allow(Net::HTTP).to receive(:new).and_return(@http)
+    expect(Net::HTTP::Get).to receive(:new).with(/#{Regexp.escape(@query)}$/, default_http_headers)
     @uri.read
   end
 
@@ -358,71 +358,71 @@ describe URI::HTTP, '#write' do
     @content = 'Readme. Please!'
     @uri = URI('http://john:secret@host.domain/foo/bar/baz.jar')
     @http = double('Net::HTTP')
-    @http.stub(:request).and_return(Net::HTTPOK.new(nil, nil, nil))
-    Net::HTTP.stub(:new).and_return(@http)
+    allow(@http).to receive(:request).and_return(Net::HTTPOK.new(nil, nil, nil))
+    allow(Net::HTTP).to receive(:new).and_return(@http)
   end
 
   it 'should open connection to HTTP server' do
-    Net::HTTP.should_receive(:new).with('host.domain', 80).and_return(@http)
+    expect(Net::HTTP).to receive(:new).with('host.domain', 80).and_return(@http)
     @uri.write @content
   end
 
   it 'should use HTTP basic authentication' do
-    @http.should_receive(:request) do |request|
-      request['authorization'].should == ('Basic ' + ['john:secret'].pack('m').delete("\r\n"))
+    expect(@http).to receive(:request) do |request|
+      expect(request['authorization']).to eq('Basic ' + ['john:secret'].pack('m').delete("\r\n"))
       Net::HTTPOK.new(nil, nil, nil)
     end
     @uri.write @content
   end
 
   it 'should use HTTPS if applicable' do
-    Net::HTTP.should_receive(:new).with('host.domain', 443).and_return(@http)
-    @http.should_receive(:use_ssl=).with(true)
+    expect(Net::HTTP).to receive(:new).with('host.domain', 443).and_return(@http)
+    expect(@http).to receive(:use_ssl=).with(true)
     URI(@uri.to_s.sub(/http/, 'https')).write @content
   end
 
   it 'should upload file with PUT request' do
-    @http.should_receive(:request) do |request|
-      request.should be_kind_of(Net::HTTP::Put)
+    expect(@http).to receive(:request) do |request|
+      expect(request).to be_kind_of(Net::HTTP::Put)
       Net::HTTPOK.new(nil, nil, nil)
     end
     @uri.write @content
   end
 
   it 'should set Content-Length header' do
-    @http.should_receive(:request) do |request|
-      request.content_length.should == @content.size
+    expect(@http).to receive(:request) do |request|
+      expect(request.content_length).to eq(@content.size)
       Net::HTTPOK.new(nil, nil, nil)
     end
     @uri.write @content
   end
 
   it 'should set Content-MD5 header' do
-    @http.should_receive(:request) do |request|
-      request['Content-MD5'].should == Digest::MD5.hexdigest(@content)
+    expect(@http).to receive(:request) do |request|
+      expect(request['Content-MD5']).to eq(Digest::MD5.hexdigest(@content))
       Net::HTTPOK.new(nil, nil, nil)
     end
     @uri.write @content
   end
 
   it 'should send entire content' do
-    @http.should_receive(:request) do |request|
+    expect(@http).to receive(:request) do |request|
       body_stream = request.body_stream
-      body_stream.read(1024).should == @content
-      body_stream.read(1024).should be_nil
+      expect(body_stream.read(1024)).to eq(@content)
+      expect(body_stream.read(1024)).to be_nil
       Net::HTTPOK.new(nil, nil, nil)
     end
     @uri.write @content
   end
 
   it 'should fail on 4xx response' do
-    @http.should_receive(:request).and_return(Net::HTTPBadRequest.new(nil, nil, nil))
-    lambda { @uri.write @content }.should raise_error(RuntimeError, /failed to upload/i)
+    expect(@http).to receive(:request).and_return(Net::HTTPBadRequest.new(nil, nil, nil))
+    expect { @uri.write @content }.to raise_error(RuntimeError, /failed to upload/i)
   end
 
   it 'should fail on 5xx response' do
-    @http.should_receive(:request).and_return(Net::HTTPServiceUnavailable.new(nil, nil, nil))
-    lambda { @uri.write @content }.should raise_error(RuntimeError, /failed to upload/i)
+    expect(@http).to receive(:request).and_return(Net::HTTPServiceUnavailable.new(nil, nil, nil))
+    expect { @uri.write @content }.to raise_error(RuntimeError, /failed to upload/i)
   end
 
 end
@@ -436,15 +436,13 @@ describe URI::SFTP, '#read' do
     @ssh_session = double('Net::SSH::Session')
     @sftp_session = double('Net::SFTP::Session')
     @file_factory = double('Net::SFTP::Operations::FileFactory')
-    Net::SSH.stub(:start).with('localhost', 'john', :password=>'secret', :port=>22).and_return(@ssh_session) do
-      Net::SFTP::Session.should_receive(:new).with(@ssh_session).and_yield(@sftp_session).and_return(@sftp_session)
-      @sftp_session.should_receive(:connect!).and_return(@sftp_session)
-      @sftp_session.should_receive(:loop)
-      @sftp_session.should_receive(:file).with.and_return(@file_factory)
-      @file_factory.stub(:open)
-      @ssh_session.should_receive(:close)
-      @ssh_session
-    end
+    allow(Net::SSH).to receive(:start).with('localhost', 'john', :password=>'secret', :port=>22).and_return(@ssh_session)
+    expect(Net::SFTP::Session).to receive(:new).with(@ssh_session).and_yield(@sftp_session).and_return(@sftp_session)
+    expect(@sftp_session).to receive(:connect!).and_return(@sftp_session)
+    expect(@sftp_session).to receive(:loop)
+    expect(@sftp_session).to receive(:file).and_return(@file_factory)
+    allow(@file_factory).to receive(:open)
+    expect(@ssh_session).to receive(:close)
   end
 
   it 'should open connection to SFTP server' do
@@ -452,26 +450,26 @@ describe URI::SFTP, '#read' do
   end
 
   it 'should open file for reading' do
-    @file_factory.should_receive(:open).with('/root/path/readme', 'r')
+    expect(@file_factory).to receive(:open).with('/root/path/readme', 'r')
     @uri.read
   end
 
   it 'should read contents of file and return it' do
     file = double('Net::SFTP::Operations::File')
-    file.should_receive(:read).with(URI::RW_CHUNK_SIZE).once.and_return(@content)
-    @file_factory.should_receive(:open).with('/root/path/readme', 'r').and_yield(file)
-    @uri.read.should eql(@content)
+    expect(file).to receive(:read).with(URI::RW_CHUNK_SIZE).once.and_return(@content)
+    expect(@file_factory).to receive(:open).with('/root/path/readme', 'r').and_yield(file)
+    expect(@uri.read).to eql(@content)
   end
 
   it 'should read contents of file and pass it to block' do
     file = double('Net::SFTP::Operations::File')
-    file.should_receive(:read).with(URI::RW_CHUNK_SIZE).once.and_return(@content)
-    @file_factory.should_receive(:open).with('/root/path/readme', 'r').and_yield(file)
+    expect(file).to receive(:read).with(URI::RW_CHUNK_SIZE).once.and_return(@content)
+    expect(@file_factory).to receive(:open).with('/root/path/readme', 'r').and_yield(file)
     content = ''
     @uri.read do |chunk|
       content << chunk
     end
-    content.should eql(@content)
+    expect(content).to eql(@content)
   end
 end
 
@@ -484,18 +482,16 @@ describe URI::SFTP, '#write' do
     @ssh_session = double('Net::SSH::Session')
     @sftp_session = double('Net::SFTP::Session')
     @file_factory = double('Net::SFTP::Operations::FileFactory')
-    Net::SSH.stub(:start).with('localhost', 'john', :password=>'secret', :port=>22).and_return(@ssh_session) do
-      Net::SFTP::Session.should_receive(:new).with(@ssh_session).and_yield(@sftp_session).and_return(@sftp_session)
-      @sftp_session.should_receive(:connect!).and_return(@sftp_session)
-      @sftp_session.should_receive(:loop)
-      @sftp_session.stub(:opendir!).and_return { fail }
-      @sftp_session.stub(:close)
-      @sftp_session.stub(:mkdir!)
-      @sftp_session.should_receive(:file).with.and_return(@file_factory)
-      @file_factory.stub(:open)
-      @ssh_session.should_receive(:close)
-      @ssh_session
-    end
+    allow(Net::SSH).to receive(:start).with('localhost', 'john', :password=>'secret', :port=>22).and_return(@ssh_session)
+    expect(Net::SFTP::Session).to receive(:new).with(@ssh_session).and_yield(@sftp_session).and_return(@sftp_session)
+    expect(@sftp_session).to receive(:connect!).and_return(@sftp_session)
+    expect(@sftp_session).to receive(:loop)
+    allow(@sftp_session).to receive(:opendir!) { fail }
+    allow(@sftp_session).to receive(:close)
+    allow(@sftp_session).to receive(:mkdir!)
+    expect(@sftp_session).to receive(:file).and_return(@file_factory)
+    allow(@file_factory).to receive(:open)
+    expect(@ssh_session).to receive(:close)
   end
 
   it 'should open connection to SFTP server' do
@@ -504,39 +500,39 @@ describe URI::SFTP, '#write' do
 
   it 'should check that path exists on server' do
     paths = ['/root', '/root/path']
-    @sftp_session.should_receive(:opendir!).with(anything()).twice { |path| paths.shift.should == path }
+    expect(@sftp_session).to receive(:opendir!).with(anything()).twice { |path| expect(paths.shift).to eq(path) }
     @uri.write @content
   end
 
   it 'should close all opened directories' do
-    @sftp_session.should_receive(:opendir!).with(anything()).twice do |path|
-      @sftp_session.should_receive(:close).with(handle = Object.new)
+    expect(@sftp_session).to receive(:opendir!).with(anything()).twice do |path|
+      expect(@sftp_session).to receive(:close).with(handle = Object.new)
       handle
     end
     @uri.write @content
   end
 
   it 'should create missing paths on server' do
-    @sftp_session.should_receive(:opendir!) { |path| fail unless path == '/root' }
-    @sftp_session.should_receive(:mkdir!).once.with('/root/path', {})
+    expect(@sftp_session).to receive(:opendir!) { |path| fail unless path == '/root' }
+    expect(@sftp_session).to receive(:mkdir!).once.with('/root/path', {})
     @uri.write @content
   end
 
   it 'should create missing directories recursively' do
     paths = ['/root', '/root/path']
-    @sftp_session.should_receive(:mkdir!).with(anything(), {}).twice { |path, options| paths.shift.should == path }
+    expect(@sftp_session).to receive(:mkdir!).with(anything(), {}).twice { |path, options| expect(paths.shift).to eq(path) }
     @uri.write @content
   end
 
   it 'should open file for writing' do
-    @file_factory.should_receive(:open).with('/root/path/readme', 'w')
+    expect(@file_factory).to receive(:open).with('/root/path/readme', 'w')
     @uri.write @content
   end
 
   it 'should write contents to file' do
     file = double('Net::SFTP::Operations::File')
-    file.should_receive(:write).with(@content)
-    @file_factory.should_receive(:open).with('/root/path/readme', 'w').and_yield(file)
+    expect(file).to receive(:write).with(@content)
+    expect(@file_factory).to receive(:open).with('/root/path/readme', 'w').and_yield(file)
     @uri.write @content
   end
 

--- a/spec/core/util_spec.rb
+++ b/spec/core/util_spec.rb
@@ -21,13 +21,13 @@ describe Buildr do
     it "should replace filename extensions" do
       replace = lambda { |filename, ext| Util.replace_extension(filename, ext) }
 
-      replace["foo.zip", "txt"].should eql("foo.txt")
-      replace["foo.", "txt"].should eql("foo.txt")
-      replace["foo", "txt"].should eql("foo.txt")
+      expect(replace["foo.zip", "txt"]).to eql("foo.txt")
+      expect(replace["foo.", "txt"]).to eql("foo.txt")
+      expect(replace["foo", "txt"]).to eql("foo.txt")
 
-      replace["bar/foo.zip", "txt"].should eql("bar/foo.txt")
-      replace["bar/foo.", "txt"].should eql("bar/foo.txt")
-      replace["bar/foo", "txt"].should eql("bar/foo.txt")
+      expect(replace["bar/foo.zip", "txt"]).to eql("bar/foo.txt")
+      expect(replace["bar/foo.", "txt"]).to eql("bar/foo.txt")
+      expect(replace["bar/foo", "txt"]).to eql("bar/foo.txt")
     end
   end
 end
@@ -35,11 +35,11 @@ end
 describe Hash do
   describe "#only" do
     it "should find value for one key" do
-      {:a => 1, :b => 2, :c => 3}.only(:a).should == {:a => 1}
+      expect({:a => 1, :b => 2, :c => 3}.only(:a)).to eq({:a => 1})
     end
 
     it "should find values for multiple keys" do
-      {:a => 1, :b => 2, :c => 3}.only(:b, :c).should == {:b => 2, :c => 3}
+      expect({:a => 1, :b => 2, :c => 3}.only(:b, :c)).to eq({:b => 2, :c => 3})
     end
   end
 end
@@ -50,35 +50,35 @@ describe OpenObject do
   end
 
   it "should be kind of Hash" do
-    Hash.should === @obj
+    expect(Hash).to be === @obj
   end
 
   it "should accept block that supplies default value" do
     obj = OpenObject.new { |hash, key| hash[key] = "New #{key}" }
-    obj[:foo].should == "New foo"
-    obj.keys.should == [:foo]
+    expect(obj[:foo]).to eq("New foo")
+    expect(obj.keys).to eq([:foo])
   end
 
   it "should combine initial values from hash argument and from block" do
     obj = OpenObject.new(:a => 6, :b => 2) { |h, k| h[k] = k.to_s * 2 }
-    obj[:a].should == 6
-    obj[:c].should == 'cc'
+    expect(obj[:a]).to eq(6)
+    expect(obj[:c]).to eq('cc')
   end
 
   it "should allow reading a value by calling its name method" do
-    @obj.b.should == 2
+    expect(@obj.b).to eq(2)
   end
 
   it "should allow setting a value by calling its name= method" do
-    lambda { @obj.f = 32 }.should change { @obj.f }.to(32)
+    expect { @obj.f = 32 }.to change { @obj.f }.to(32)
   end
 
   it "should allow changing a value by calling its name= method" do
-    lambda { @obj.c = 17 }.should change { @obj.c }.to(17)
+    expect { @obj.c = 17 }.to change { @obj.c }.to(17)
   end
 
   it "should implement only method like a hash" do
-    @obj.only(:a).should == { :a => 1 }
+    expect(@obj.only(:a)).to eq({ :a => 1 })
   end
 end
 
@@ -94,7 +94,7 @@ describe File do
         sleep 1
         File.utime(nil, nil, 'tmp')
 
-        File.mtime('tmp').should > creation_time
+        expect(File.mtime('tmp')).to be > creation_time
       ensure
         Dir.rmdir 'tmp'
       end
@@ -108,7 +108,7 @@ describe File do
         sleep 1
         File.utime(nil, nil, 'tmp')
 
-        File.mtime('tmp').should > creation_time
+        expect(File.mtime('tmp')).to be > creation_time
       ensure
         File.delete 'tmp'
       end
@@ -120,7 +120,7 @@ describe File do
         time = Time.at((Time.now - 10).to_i)
         File.utime(time, time, 'tmp')
 
-        File.mtime('tmp').should == time
+        expect(File.mtime('tmp')).to eq(time)
       ensure
         File.delete 'tmp'
       end
@@ -132,7 +132,7 @@ describe File do
         time = Time.at((Time.now + 10).to_i)
         File.utime(time, time, 'tmp')
 
-        File.mtime('tmp').should == time
+        expect(File.mtime('tmp')).to eq(time)
       ensure
         File.delete 'tmp'
       end

--- a/spec/groovy/bdd_spec.rb
+++ b/spec/groovy/bdd_spec.rb
@@ -32,30 +32,30 @@ describe Buildr::Groovy::EasyB do
   it 'should apply to a project having EasyB sources' do
     define('one', :base_dir => 'one') do
       write _('src/spec/groovy/SomeSpecification.groovy'), 'true;'
-      Buildr::Groovy::EasyB.applies_to?(self).should be_true
+      expect(Buildr::Groovy::EasyB.applies_to?(self)).to be_truthy
     end
     define('two', :base_dir => 'two') do
       write _('src/test/groovy/SomeSpecification.groovy'), 'true;'
-      Buildr::Groovy::EasyB.applies_to?(self).should be_false
+      expect(Buildr::Groovy::EasyB.applies_to?(self)).to be_falsey
     end
     define('three', :base_dir => 'three') do
       write _('src/spec/groovy/SomeStory.groovy'), 'true;'
-      Buildr::Groovy::EasyB.applies_to?(self).should be_true
+      expect(Buildr::Groovy::EasyB.applies_to?(self)).to be_truthy
     end
     define('four', :base_dir => 'four') do
       write _('src/test/groovy/SomeStory.groovy'), 'true;'
-      Buildr::Groovy::EasyB.applies_to?(self).should be_false
+      expect(Buildr::Groovy::EasyB.applies_to?(self)).to be_falsey
     end
   end
 
   it 'should be selected by :easyb name' do
-    foo { test.framework.should eql(:easyb) }
+    foo { expect(test.framework).to eql(:easyb) }
   end
 
   it 'should select a java compiler if java sources are found' do
     foo do
       write _('src/spec/java/SomeSpecification.java'), 'public class SomeSpecification {}'
-      test.compile.language.should eql(:java)
+      expect(test.compile.language).to eql(:java)
     end
   end
 
@@ -64,7 +64,7 @@ describe Buildr::Groovy::EasyB do
       spec = _('src/spec/groovy/SomeSpecification.groovy')
       write spec, 'true'
       test.invoke
-      test.tests.should include(spec)
+      expect(test.tests).to include(spec)
     end
   end
 
@@ -73,7 +73,7 @@ describe Buildr::Groovy::EasyB do
       spec = _('src/spec/groovy/SomeStory.groovy')
       write spec, 'true'
       test.invoke
-      test.tests.should include(spec)
+      expect(test.tests).to include(spec)
     end
   end
 

--- a/spec/groovy/compiler_spec.rb
+++ b/spec/groovy/compiler_spec.rb
@@ -22,8 +22,8 @@ describe 'groovyc compiler' do
     write 'src/main/groovy/some/Hello.groovy', 'println "Hello Groovy"'
     write 'src/test/groovy/some/Hello.groovy', 'println "Hello Groovy"'
     define('foo') do
-      compile.compiler.should eql(:groovyc)
-      test.compile.compiler.should eql(:groovyc)
+      expect(compile.compiler).to eql(:groovyc)
+      expect(test.compile.compiler).to eql(:groovyc)
     end
   end
 
@@ -31,8 +31,8 @@ describe 'groovyc compiler' do
     write 'src/main/java/some/Hello.groovy', 'println "Hello Groovy"'
     write 'src/test/java/some/Hello.groovy', 'println "Hello Groovy"'
     define('foo') do
-      compile.compiler.should eql(:groovyc)
-      test.compile.compiler.should eql(:groovyc)
+      expect(compile.compiler).to eql(:groovyc)
+      expect(test.compile.compiler).to eql(:groovyc)
     end
   end
 
@@ -42,8 +42,8 @@ describe 'groovyc compiler' do
     write 'src/test/java/some/Empty.java', 'package some; public interface Empty {}'
     write 'src/test/groovy/some/Hello.groovy', 'println "Hello Groovy"'
     define('foo') do
-      compile.compiler.should eql(:groovyc)
-      test.compile.compiler.should eql(:groovyc)
+      expect(compile.compiler).to eql(:groovyc)
+      expect(test.compile.compiler).to eql(:groovyc)
     end
   end
 
@@ -54,8 +54,8 @@ describe 'groovyc compiler' do
     custom[:source, :main, :groovy] = 'groovy'
     custom[:source, :test, :groovy] = 'testing'
     define 'foo', :layout=>custom do
-      compile.compiler.should eql(:groovyc)
-      test.compile.compiler.should eql(:groovyc)
+      expect(compile.compiler).to eql(:groovyc)
+      expect(test.compile.compiler).to eql(:groovyc)
     end
   end
 
@@ -63,39 +63,39 @@ describe 'groovyc compiler' do
     write 'src/com/example/Code.groovy', 'println "monkey code"'
     write 'testing/com/example/Test.groovy', 'println "some test"'
     define 'foo' do
-      lambda { compile.from 'src' }.should change { compile.compiler }.to(:groovyc)
-      lambda { test.compile.from 'testing' }.should change { test.compile.compiler }.to(:groovyc)
+      expect { compile.from 'src' }.to change { compile.compiler }.to(:groovyc)
+      expect { test.compile.from 'testing' }.to change { test.compile.compiler }.to(:groovyc)
     end
   end
 
   it 'should report the multi-language as :groovy, :java' do
-    define('foo').compile.using(:groovyc).language.should == :groovy
+    expect(define('foo').compile.using(:groovyc).language).to eq(:groovy)
   end
 
   it 'should set the target directory to target/classes' do
     define 'foo' do
-      lambda { compile.using(:groovyc) }.should change { compile.target.to_s }.to(File.expand_path('target/classes'))
+      expect { compile.using(:groovyc) }.to change { compile.target.to_s }.to(File.expand_path('target/classes'))
     end
   end
 
   it 'should not override existing target directory' do
     define 'foo' do
       compile.into('classes')
-      lambda { compile.using(:groovyc) }.should_not change { compile.target }
+      expect { compile.using(:groovyc) }.not_to change { compile.target }
     end
   end
 
   it 'should not change existing list of sources' do
     define 'foo' do
       compile.from('sources')
-      lambda { compile.using(:groovyc) }.should_not change { compile.sources }
+      expect { compile.using(:groovyc) }.not_to change { compile.sources }
     end
   end
 
   it 'should compile groovy sources' do
     write 'src/main/groovy/some/Example.groovy', 'package some; class Example { static main(args) { println "Hello" } }'
     define('foo').compile.invoke
-    file('target/classes/some/Example.class').should exist
+    expect(file('target/classes/some/Example.class')).to exist
   end
 
   it 'should compile test groovy sources that rely on junit' do
@@ -105,8 +105,8 @@ describe 'groovyc compiler' do
       test.using :junit
     end
     foo.test.compile.invoke
-    file('target/classes/some/Example.class').should exist
-    file('target/test/classes/some/ExampleTest.class').should exist
+    expect(file('target/classes/some/Example.class')).to exist
+    expect(file('target/test/classes/some/ExampleTest.class')).to exist
   end
 
   it 'should include as classpath dependency' do
@@ -116,8 +116,8 @@ describe 'groovyc compiler' do
       compile.from('src/bar/groovy').into('target/bar')
       package(:jar)
     end
-    lambda { define('foo').compile.with(project('bar').package(:jar)).invoke }.should run_task('foo:compile')
-    file('target/classes/some/Example.class').should exist
+    expect { define('foo').compile.with(project('bar').package(:jar)).invoke }.to run_task('foo:compile')
+    expect(file('target/classes/some/Example.class')).to exist
   end
 
   it 'should cross compile java sources' do
@@ -125,7 +125,7 @@ describe 'groovyc compiler' do
     write 'src/main/java/some/Baz.java', 'package some; public class Baz extends Bar { }'
     write 'src/main/groovy/some/Bar.groovy', 'package some; class Bar implements Foo { def void hello() { } }'
     define('foo').compile.invoke
-    %w{Foo Bar Baz}.each { |f| file("target/classes/some/#{f}.class").should exist }
+    %w{Foo Bar Baz}.each { |f| expect(file("target/classes/some/#{f}.class")).to exist }
   end
 
   it 'should cross compile test java sources' do
@@ -133,15 +133,15 @@ describe 'groovyc compiler' do
     write 'src/test/java/some/Baz.java', 'package some; public class Baz extends Bar { }'
     write 'src/test/groovy/some/Bar.groovy', 'package some; class Bar implements Foo { def void hello() { } }'
     define('foo').test.compile.invoke
-    %w{Foo Bar Baz}.each { |f| file("target/test/classes/some/#{f}.class").should exist }
+    %w{Foo Bar Baz}.each { |f| expect(file("target/test/classes/some/#{f}.class")).to exist }
   end
 
   it 'should package classes into a jar file' do
     write 'src/main/groovy/some/Example.groovy', 'package some; class Example { }'
     define('foo', :version => '1.0').package.invoke
-    file('target/foo-1.0.jar').should exist
+    expect(file('target/foo-1.0.jar')).to exist
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
-      jar.exist?('some/Example.class').should be_true
+      expect(jar.exist?('some/Example.class')).to be_truthy
     end
   end
 
@@ -167,78 +167,78 @@ describe 'groovyc compiler options' do
 
   it 'should set warning option to false by default' do
     groovyc do
-      compile.options.warnings.should be_false
-      @compiler.javac_options[:nowarn].should be_true
+      expect(compile.options.warnings).to be_falsey
+      expect(@compiler.javac_options[:nowarn]).to be_truthy
     end
   end
 
   it 'should set warning option to true when running with --verbose option' do
     verbose true
     groovyc do
-      compile.options.warnings.should be_true
-      @compiler.javac_options[:nowarn].should be_false
+      expect(compile.options.warnings).to be_truthy
+      expect(@compiler.javac_options[:nowarn]).to be_falsey
     end
   end
 
   it 'should not set verbose option by default' do
-    groovyc.options.verbose.should be_false
+    expect(groovyc.options.verbose).to be_falsey
   end
 
   it 'should set verbose option when running with --trace=groovyc option' do
     Buildr.application.options.trace_categories = [:groovyc]
-    groovyc.options.verbose.should be_true
+    expect(groovyc.options.verbose).to be_truthy
   end
 
   it 'should set debug option to false based on Buildr.options' do
     Buildr.options.debug = false
-    groovyc.options.debug.should be_false
+    expect(groovyc.options.debug).to be_falsey
   end
 
   it 'should set debug option to false based on debug environment variable' do
     ENV['debug'] = 'no'
-    groovyc.options.debug.should be_false
+    expect(groovyc.options.debug).to be_falsey
   end
 
   it 'should set debug option to false based on DEBUG environment variable' do
     ENV['DEBUG'] = 'no'
-    groovyc.options.debug.should be_false
+    expect(groovyc.options.debug).to be_falsey
   end
 
   it 'should set deprecation option to false by default' do
-    groovyc.options.deprecation.should be_false
+    expect(groovyc.options.deprecation).to be_falsey
   end
 
   it 'should use deprecation argument when deprecation is true' do
     groovyc do
       compile.using(:deprecation=>true)
-      compile.options.deprecation.should be_true
-      @compiler.javac_options[:deprecation].should be_true
+      expect(compile.options.deprecation).to be_truthy
+      expect(@compiler.javac_options[:deprecation]).to be_truthy
     end
   end
 
   it 'should not use deprecation argument when deprecation is false' do
     groovyc do
       compile.using(:deprecation=>false)
-      compile.options.deprecation.should be_false
-      @compiler.javac_options[:deprecation].should_not be_true
+      expect(compile.options.deprecation).to be_falsey
+      expect(@compiler.javac_options[:deprecation]).not_to be_truthy
     end
   end
 
   it 'should set optimise option to false by default' do
-    groovyc.options.optimise.should be_false
+    expect(groovyc.options.optimise).to be_falsey
   end
 
   it 'should use optimize argument when deprecation is true' do
     groovyc do
       compile.using(:optimise=>true)
-      @compiler.javac_options[:optimize].should be_true
+      expect(@compiler.javac_options[:optimize]).to be_truthy
     end
   end
 
   it 'should not use optimize argument when deprecation is false' do
     groovyc do
       compile.using(:optimise=>false)
-      @compiler.javac_options[:optimize].should be_false
+      expect(@compiler.javac_options[:optimize]).to be_falsey
     end
   end
 

--- a/spec/groovy/doc_spec.rb
+++ b/spec/groovy/doc_spec.rb
@@ -27,8 +27,8 @@ describe "Groovydoc" do
       end
     end
 
-    project('foo').doc.options[:windowtitle].should eql('foo')
-    project('foo:bar').doc.options[:windowtitle].should eql('foo:bar')
+    expect(project('foo').doc.options[:windowtitle]).to eql('foo')
+    expect(project('foo:bar').doc.options[:windowtitle]).to eql('foo:bar')
   end
 
   it 'should pick :windowtitle from project description by default, if available' do
@@ -36,7 +36,7 @@ describe "Groovydoc" do
     define 'foo' do
       doc.using :groovydoc
     end
-    project('foo').doc.options[:windowtitle].should eql('My App')
+    expect(project('foo').doc.options[:windowtitle]).to eql('My App')
   end
 
   it 'should not override explicit :windowtitle option' do
@@ -44,14 +44,14 @@ describe "Groovydoc" do
       doc.using :groovydoc
       doc.using :windowtitle => 'explicit'
     end
-    project('foo').doc.options[:windowtitle].should eql('explicit')
+    expect(project('foo').doc.options[:windowtitle]).to eql('explicit')
   end
 
   it 'should identify itself from groovy source directories' do
     write 'src/main/groovy/some/A.java', 'package some; public class A {}'
     write 'src/main/groovy/some/B.groovy', 'package some; public class B {}'
     define('foo') do
-      doc.engine.should be_a(Buildr::Doc::Groovydoc)
+      expect(doc.engine).to be_a(Buildr::Doc::Groovydoc)
     end
   end
 
@@ -60,6 +60,6 @@ describe "Groovydoc" do
     write 'src/main/groovy/some/B.groovy', 'package some; public class B {}'
     define('foo')
     project('foo').doc.invoke
-    file('target/doc/index.html').should exist
+    expect(file('target/doc/index.html')).to exist
   end
 end

--- a/spec/ide/eclipse_spec.rb
+++ b/spec/ide/eclipse_spec.rb
@@ -100,20 +100,20 @@ describe Buildr::Eclipse do
 
       it 'should not have natures' do
         define('foo')
-        project_natures.should be_empty
+        expect(project_natures).to be_empty
       end
 
       it 'should not have build commands' do
         define('foo')
-        build_commands.should be_empty
+        expect(build_commands).to be_empty
       end
 
       it 'should generate a .project file' do
         define('foo')
         task('eclipse').invoke
         File.open('.project') do |f|
-          REXML::Document.new(f).root.
-            elements.collect("name") { |e| e.text }.should == ['foo']
+          expect(REXML::Document.new(f).root.
+            elements.collect("name") { |e| e.text }).to eq(['foo'])
         end
       end
 
@@ -121,15 +121,15 @@ describe Buildr::Eclipse do
         define('foo') { eclipse.name = 'bar' }
         task('eclipse').invoke
         File.open('.project') do |f|
-          REXML::Document.new(f).root.
-            elements.collect("name") { |e| e.text }.should == ['bar']
+          expect(REXML::Document.new(f).root.
+            elements.collect("name") { |e| e.text }).to eq(['bar'])
         end
       end
 
       it 'should not generate a .classpath file' do
         define('foo')
         task('eclipse').invoke
-        File.exists?('.classpath').should be_false
+        expect(File.exists?('.classpath')).to be_falsey
       end
     end
 
@@ -144,8 +144,8 @@ describe Buildr::Eclipse do
           define('bar')
         end
         task('eclipse').invoke
-        File.exists?('.project').should be_false
-        File.exists?(File.join('bar','.project')).should be_true
+        expect(File.exists?('.project')).to be_falsey
+        expect(File.exists?(File.join('bar','.project'))).to be_truthy
       end
     end
 
@@ -157,12 +157,12 @@ describe Buildr::Eclipse do
 
       it 'should have Java nature' do
         define('foo')
-        project_natures.should include(JAVA_NATURE)
+        expect(project_natures).to include(JAVA_NATURE)
       end
 
       it 'should have Java build command' do
         define('foo')
-        build_commands.should include(JAVA_BUILDER)
+        expect(build_commands).to include(JAVA_BUILDER)
       end
     end
 
@@ -176,8 +176,8 @@ describe Buildr::Eclipse do
         }
         task('eclipse').invoke
         File.open(File.join('foo', '.project')) do |f|
-          REXML::Document.new(f).root.
-            elements.collect("name") { |e| e.text }.should == ['myproject-foo']
+          expect(REXML::Document.new(f).root.
+            elements.collect("name") { |e| e.text }).to eq(['myproject-foo'])
         end
       end
 
@@ -189,8 +189,8 @@ describe Buildr::Eclipse do
         }
         task('eclipse').invoke
         File.open(File.join('foo', '.project')) do |f|
-          REXML::Document.new(f).root.
-            elements.collect("name") { |e| e.text }.should == ['bar']
+          expect(REXML::Document.new(f).root.
+            elements.collect("name") { |e| e.text }).to eq(['bar'])
         end
       end
 
@@ -203,8 +203,8 @@ describe Buildr::Eclipse do
         }
         task('eclipse').invoke
         File.open(File.join('foo', '.project')) do |f|
-          REXML::Document.new(f).root.
-            elements.collect("name") { |e| e.text }.should == ['foo']
+          expect(REXML::Document.new(f).root.
+            elements.collect("name") { |e| e.text }).to eq(['foo'])
         end
       end
     end
@@ -218,14 +218,14 @@ describe Buildr::Eclipse do
       end
 
       it 'should have Scala nature before Java nature' do
-        project_natures.should include(SCALA_NATURE)
-        project_natures.should include(JAVA_NATURE)
-        project_natures.index(SCALA_NATURE).should < project_natures.index(JAVA_NATURE)
+        expect(project_natures).to include(SCALA_NATURE)
+        expect(project_natures).to include(JAVA_NATURE)
+        expect(project_natures.index(SCALA_NATURE)).to be < project_natures.index(JAVA_NATURE)
       end
 
       it 'should have Scala build command and no Java build command' do
-        build_commands.should include(SCALA_BUILDER)
-        build_commands.should_not include(JAVA_BUILDER)
+        expect(build_commands).to include(SCALA_BUILDER)
+        expect(build_commands).not_to include(JAVA_BUILDER)
       end
     end
 
@@ -238,14 +238,14 @@ describe Buildr::Eclipse do
       end
 
       it 'should have Scala nature before Java nature' do
-        project_natures.should include(SCALA_NATURE)
-        project_natures.should include(JAVA_NATURE)
-        project_natures.index(SCALA_NATURE).should < project_natures.index(JAVA_NATURE)
+        expect(project_natures).to include(SCALA_NATURE)
+        expect(project_natures).to include(JAVA_NATURE)
+        expect(project_natures.index(SCALA_NATURE)).to be < project_natures.index(JAVA_NATURE)
       end
 
       it 'should have Scala build command and no Java build command' do
-        build_commands.should include(SCALA_BUILDER)
-        build_commands.should_not include(JAVA_BUILDER)
+        expect(build_commands).to include(SCALA_BUILDER)
+        expect(build_commands).not_to include(JAVA_BUILDER)
       end
     end
 
@@ -260,14 +260,14 @@ describe Buildr::Eclipse do
       end
 
       it 'should have Scala nature before Java nature' do
-        project_natures.should include(SCALA_NATURE)
-        project_natures.should include(JAVA_NATURE)
-        project_natures.index(SCALA_NATURE).should < project_natures.index(JAVA_NATURE)
+        expect(project_natures).to include(SCALA_NATURE)
+        expect(project_natures).to include(JAVA_NATURE)
+        expect(project_natures.index(SCALA_NATURE)).to be < project_natures.index(JAVA_NATURE)
       end
 
       it 'should have Scala build command and no Java build command' do
-        build_commands.should include(SCALA_BUILDER)
-        build_commands.should_not include(JAVA_BUILDER)
+        expect(build_commands).to include(SCALA_BUILDER)
+        expect(build_commands).not_to include(JAVA_BUILDER)
       end
     end
 
@@ -281,16 +281,16 @@ describe Buildr::Eclipse do
 
       it 'should have plugin nature before Java nature' do
         define('foo')
-        project_natures.should include(PLUGIN_NATURE)
-        project_natures.should include(JAVA_NATURE)
-        project_natures.index(PLUGIN_NATURE).should < project_natures.index(JAVA_NATURE)
+        expect(project_natures).to include(PLUGIN_NATURE)
+        expect(project_natures).to include(JAVA_NATURE)
+        expect(project_natures.index(PLUGIN_NATURE)).to be < project_natures.index(JAVA_NATURE)
       end
 
       it 'should have plugin build commands and the Java build command' do
         define('foo')
-        build_commands.should include(PLUGIN_BUILDERS[0])
-        build_commands.should include(PLUGIN_BUILDERS[1])
-        build_commands.should include(JAVA_BUILDER)
+        expect(build_commands).to include(PLUGIN_BUILDERS[0])
+        expect(build_commands).to include(PLUGIN_BUILDERS[1])
+        expect(build_commands).to include(JAVA_BUILDER)
       end
     end
 
@@ -304,16 +304,16 @@ describe Buildr::Eclipse do
 
       it 'should have plugin nature before Java nature' do
         define('foo')
-        project_natures.should include(PLUGIN_NATURE)
-        project_natures.should include(JAVA_NATURE)
-        project_natures.index(PLUGIN_NATURE).should < project_natures.index(JAVA_NATURE)
+        expect(project_natures).to include(PLUGIN_NATURE)
+        expect(project_natures).to include(JAVA_NATURE)
+        expect(project_natures.index(PLUGIN_NATURE)).to be < project_natures.index(JAVA_NATURE)
       end
 
       it 'should have plugin build commands and the Java build command' do
         define('foo')
-        build_commands.should include(PLUGIN_BUILDERS[0])
-        build_commands.should include(PLUGIN_BUILDERS[1])
-        build_commands.should include(JAVA_BUILDER)
+        expect(build_commands).to include(PLUGIN_BUILDERS[0])
+        expect(build_commands).to include(PLUGIN_BUILDERS[1])
+        expect(build_commands).to include(JAVA_BUILDER)
       end
     end
 
@@ -337,7 +337,7 @@ Implementation-Vendor: "Acme Corp."
 Bundle-SymbolicName: acme.plugin.example
 MANIFEST
         define('foo')
-        project_natures.should include(PLUGIN_NATURE)
+        expect(project_natures).to include(PLUGIN_NATURE)
       end
 
       it 'should not have plugin nature if MANIFEST.MF exists but doesn\'t contain "Bundle-SymbolicName:"' do
@@ -352,7 +352,7 @@ Implementation-Version: "build57"
 Implementation-Vendor: "Acme Corp."
 MANIFEST
         define('foo')
-        project_natures.should_not include(PLUGIN_NATURE)
+        expect(project_natures).not_to include(PLUGIN_NATURE)
       end
     end
   end
@@ -368,9 +368,9 @@ MANIFEST
 
       it 'should have SCALA_CONTAINER before JAVA_CONTAINER' do
         define('foo')
-        classpath_containers.should include(SCALA_CONTAINER)
-        classpath_containers.should include(JAVA_CONTAINER)
-        classpath_containers.index(SCALA_CONTAINER).should < classpath_containers.index(JAVA_CONTAINER)
+        expect(classpath_containers).to include(SCALA_CONTAINER)
+        expect(classpath_containers).to include(JAVA_CONTAINER)
+        expect(classpath_containers.index(SCALA_CONTAINER)).to be < classpath_containers.index(JAVA_CONTAINER)
       end
     end
 
@@ -387,8 +387,8 @@ MANIFEST
           define('foo')
           classpath_sources('excluding').each do |excluding_attribute|
             excluding = excluding_attribute.split('|')
-            excluding.should include('**/.svn/')
-            excluding.should include('**/CVS/')
+            expect(excluding).to include('**/.svn/')
+            expect(excluding).to include('**/CVS/')
           end
         end
       end
@@ -398,23 +398,23 @@ MANIFEST
 
         it 'should accept to come from the default directory' do
           define('foo')
-          classpath_sources.should include('src/main/java')
+          expect(classpath_sources).to include('src/main/java')
         end
 
         it 'should accept to come from a user-defined directory' do
           define('foo') { compile path_to('src/java') }
-          classpath_sources.should include('src/java')
+          expect(classpath_sources).to include('src/java')
         end
 
         it 'should accept a file task as a main source folder' do
           define('foo') { compile apt }
-          classpath_sources.should include('target/generated/apt')
+          expect(classpath_sources).to include('target/generated/apt')
         end
 
         it 'should go to the default target directory' do
           define('foo')
-          classpath_specific_output('src/main/java').should be(nil)
-          classpath_default_output.should == 'target/classes'
+          expect(classpath_specific_output('src/main/java')).to be(nil)
+          expect(classpath_default_output).to eq('target/classes')
         end
       end
 
@@ -423,23 +423,23 @@ MANIFEST
 
         it 'should accept to come from the default directory' do
           define('foo')
-          classpath_sources.should include('src/test/java')
+          expect(classpath_sources).to include('src/test/java')
         end
 
         it 'should accept to come from a user-defined directory' do
           define('foo') { test.compile path_to('src/test') }
-          classpath_sources.should include('src/test')
+          expect(classpath_sources).to include('src/test')
         end
 
         it 'should go to the default target directory' do
           define('foo')
-          classpath_specific_output('src/test/java').should == 'target/test/classes'
+          expect(classpath_specific_output('src/test/java')).to eq('target/test/classes')
         end
 
         it 'should accept to be the only code in the project' do
           rm 'src/main/java/Main.java'
           define('foo')
-          classpath_sources.should include('src/test/java')
+          expect(classpath_sources).to include('src/test/java')
         end
       end
 
@@ -452,18 +452,18 @@ MANIFEST
 
         it 'should accept to come from the default directory' do
           define('foo')
-          classpath_sources.should include('src/main/resources')
+          expect(classpath_sources).to include('src/main/resources')
         end
 
         it 'should share a classpath entry if it comes from a directory with code' do
           write 'src/main/java/config.properties'
           define('foo') { resources.from('src/main/java').exclude('**/*.java') }
-          classpath_sources.select { |path| path == 'src/main/java'}.length.should == 1
+          expect(classpath_sources.select { |path| path == 'src/main/java'}.length).to eq(1)
         end
 
         it 'should go to the default target directory' do
           define('foo')
-          classpath_specific_output('src/main/resources').should == 'target/resources'
+          expect(classpath_specific_output('src/main/resources')).to eq('target/resources')
         end
       end
 
@@ -476,18 +476,18 @@ MANIFEST
 
         it 'should accept to come from the default directory' do
           define('foo')
-          classpath_sources.should include('src/test/resources')
+          expect(classpath_sources).to include('src/test/resources')
         end
 
         it 'should share a classpath entry if it comes from a directory with code' do
           write 'src/test/java/config-test.properties'
           define('foo') { test.resources.from('src/test/java').exclude('**/*.java') }
-          classpath_sources.select { |path| path == 'src/test/java'}.length.should == 1
+          expect(classpath_sources.select { |path| path == 'src/test/java'}.length).to eq(1)
         end
 
         it 'should go to the default target directory' do
           define('foo')
-          classpath_specific_output('src/test/resources').should == 'target/test/resources'
+          expect(classpath_specific_output('src/test/resources')).to eq('target/test/resources')
         end
       end
     end
@@ -503,8 +503,8 @@ MANIFEST
         }
         task('eclipse').invoke
         File.open(File.join('bar', '.classpath')) do |f|
-          REXML::Document.new(f).root.
-            elements.collect("classpathentry[@kind='src']") { |n| n.attributes['path'] }.should include('/myproject-foo')
+          expect(REXML::Document.new(f).root.
+            elements.collect("classpathentry[@kind='src']") { |n| n.attributes['path'] }).to include('/myproject-foo')
         end
       end
 
@@ -518,8 +518,8 @@ MANIFEST
         }
         task('eclipse').invoke
         File.open(File.join('bar', '.classpath')) do |f|
-          REXML::Document.new(f).root.
-            elements.collect("classpathentry[@kind='src']") { |n| n.attributes['path'] }.should include('/eclipsefoo')
+          expect(REXML::Document.new(f).root.
+            elements.collect("classpathentry[@kind='src']") { |n| n.attributes['path'] }).to include('/eclipsefoo')
         end
       end
     end
@@ -532,8 +532,8 @@ MANIFEST
     end
 
     it 'should have a lib artifact reference in the .classpath file' do
-      classpath_xml_elements.collect("classpathentry[@kind='lib']") { |n| n.attributes['path'] }.
-        should include('lib/some-local.jar')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='lib']") { |n| n.attributes['path'] }).
+        to include('lib/some-local.jar')
     end
   end
 
@@ -552,8 +552,8 @@ MANIFEST
     end
 
     it 'supports generating library paths with classpath variables' do
-      classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }.
-        should include('LIBS/some-local.jar')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }).
+        to include('LIBS/some-local.jar')
     end
   end
 
@@ -564,8 +564,8 @@ MANIFEST
     end
 
     it 'should have src reference in the .classpath file' do
-      classpath_xml_elements.collect("classpathentry[@kind='src']") { |n| n.attributes['path'] }.
-        should include('lib')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='src']") { |n| n.attributes['path'] }).
+        to include('lib')
     end
   end
 
@@ -577,22 +577,22 @@ MANIFEST
     end
 
     it 'should have a reference in the .classpath file relative to the local M2 repo' do
-      classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }.
-        should include('M2_REPO/com/example/library/2.0/library-2.0.jar')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }).
+        to include('M2_REPO/com/example/library/2.0/library-2.0.jar')
     end
 
     it 'should be downloaded' do
-      file(artifact('com.example:library:jar:2.0').name).should exist
+      expect(file(artifact('com.example:library:jar:2.0').name)).to exist
     end
 
     it 'should have a source artifact reference in the .classpath file' do
-      sourcepath_for_path('M2_REPO/com/example/library/2.0/library-2.0.jar').
-        should == ['M2_REPO/com/example/library/2.0/library-2.0-sources.jar']
+      expect(sourcepath_for_path('M2_REPO/com/example/library/2.0/library-2.0.jar')).
+        to eq(['M2_REPO/com/example/library/2.0/library-2.0-sources.jar'])
     end
 
     it 'should have a javadoc artifact reference in the .classpath file' do
-      javadocpath_for_path('M2_REPO/com/example/library/2.0/library-2.0.jar').
-        should == ['M2_REPO/com/example/library/2.0/library-2.0-javadoc.jar']
+      expect(javadocpath_for_path('M2_REPO/com/example/library/2.0/library-2.0.jar')).
+        to eq(['M2_REPO/com/example/library/2.0/library-2.0-javadoc.jar'])
     end
   end
 
@@ -605,8 +605,8 @@ MANIFEST
       artifact('com.example:library:jar:2.0') { |task| write task.name }
 
       task('eclipse').invoke
-      classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }.
-        should include('PROJ_REPO/com/example/library/2.0/library-2.0.jar')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }).
+        to include('PROJ_REPO/com/example/library/2.0/library-2.0.jar')
     end
 
     it 'should pick the parent value by default' do
@@ -618,8 +618,8 @@ MANIFEST
           eclipse.options.m2_repo_var = 'BAR2_REPO'
         end
       end
-      project('foo:bar').eclipse.options.m2_repo_var.should eql('FOO_REPO')
-      project('foo:bar2').eclipse.options.m2_repo_var.should eql('BAR2_REPO')
+      expect(project('foo:bar').eclipse.options.m2_repo_var).to eql('FOO_REPO')
+      expect(project('foo:bar2').eclipse.options.m2_repo_var).to eql('BAR2_REPO')
     end
   end
 
@@ -630,7 +630,7 @@ MANIFEST
         compile.using(:javac).with('com.example:library:jar:2.0')
       end
       artifact('com.example:library:jar:2.0') { |task| write task.name }
-      project_natures.should include('dummyNature')
+      expect(project_natures).to include('dummyNature')
     end
 
     it 'should pick the parent value by default' do
@@ -642,15 +642,15 @@ MANIFEST
           eclipse.natures = 'bar2_nature'
         end
       end
-      project('foo:bar').eclipse.natures.should include('foo_nature')
-      project('foo:bar2').eclipse.natures.should include('bar2_nature')
+      expect(project('foo:bar').eclipse.natures).to include('foo_nature')
+      expect(project('foo:bar2').eclipse.natures).to include('bar2_nature')
     end
 
     it 'should handle arrays correctly' do
       define('foo') do
         eclipse.natures ['foo_nature', 'bar_nature']
       end
-      project('foo').eclipse.natures.should == ['foo_nature', 'bar_nature']
+      expect(project('foo').eclipse.natures).to eq(['foo_nature', 'bar_nature'])
     end
   end
 
@@ -661,7 +661,7 @@ MANIFEST
         compile.using(:javac).with('com.example:library:jar:2.0')
       end
       artifact('com.example:library:jar:2.0') { |task| write task.name }
-      build_commands.should include('dummyBuilder')
+      expect(build_commands).to include('dummyBuilder')
     end
 
     it 'should pick the parent value by default' do
@@ -673,15 +673,15 @@ MANIFEST
           eclipse.builders = 'bar2_builder'
         end
       end
-      project('foo:bar').eclipse.builders.should include('foo_builder')
-      project('foo:bar2').eclipse.builders.should include('bar2_builder')
+      expect(project('foo:bar').eclipse.builders).to include('foo_builder')
+      expect(project('foo:bar2').eclipse.builders).to include('bar2_builder')
     end
 
     it 'should handle arrays correctly' do
       define('foo') do
         eclipse.builders ['foo_builder', 'bar_builder']
       end
-      project('foo').eclipse.builders.should == ['foo_builder', 'bar_builder']
+      expect(project('foo').eclipse.builders).to eq(['foo_builder', 'bar_builder'])
     end
   end
 
@@ -692,7 +692,7 @@ MANIFEST
         compile.using(:javac).with('com.example:library:jar:2.0')
       end
       artifact('com.example:library:jar:2.0') { |task| write task.name }
-      classpath_containers.should include('myOlGoodContainer')
+      expect(classpath_containers).to include('myOlGoodContainer')
     end
 
     it 'should pick the parent value by default' do
@@ -704,15 +704,15 @@ MANIFEST
           eclipse.classpath_containers = 'bar2_classpath_containers'
         end
       end
-      project('foo:bar').eclipse.classpath_containers.should include('foo_classpath_containers')
-      project('foo:bar2').eclipse.classpath_containers.should include('bar2_classpath_containers')
+      expect(project('foo:bar').eclipse.classpath_containers).to include('foo_classpath_containers')
+      expect(project('foo:bar2').eclipse.classpath_containers).to include('bar2_classpath_containers')
     end
 
     it 'should handle arrays correctly' do
       define('foo') do
         eclipse.classpath_containers ['foo_cc', 'bar_cc']
       end
-      project('foo').eclipse.classpath_containers.should == ['foo_cc', 'bar_cc']
+      expect(project('foo').eclipse.classpath_containers).to eq(['foo_cc', 'bar_cc'])
     end
   end
 
@@ -725,8 +725,8 @@ MANIFEST
       artifact('com.example:library:jar:2.0') { |task| write task.name }
 
       task('eclipse').invoke
-      classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }.
-        should_not include('M2_REPO/com/example/library/2.0/library-2.0.jar')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='var']") { |n| n.attributes['path'] }).
+        not_to include('M2_REPO/com/example/library/2.0/library-2.0.jar')
     end
     it 'should support string paths' do
       define('foo') do
@@ -736,8 +736,8 @@ MANIFEST
       write project('foo').path_to('path/to/library.jar')
 
       task('eclipse').invoke
-      classpath_xml_elements.collect("classpathentry[@kind='lib']") { |n| n.attributes['path'] }.
-        should_not include('path/to/library.jar')
+      expect(classpath_xml_elements.collect("classpathentry[@kind='lib']") { |n| n.attributes['path'] }).
+        not_to include('path/to/library.jar')
     end
   end
 end

--- a/spec/ide/idea_spec.rb
+++ b/spec/ide/idea_spec.rb
@@ -19,9 +19,9 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'xpath_matchers
 
 def ensure_facet_xpath(doc, type, name)
   facet_xpath = "/module/component[@name='FacetManager']/facet"
-  doc.should have_xpath(facet_xpath)
+  expect(doc).to have_xpath(facet_xpath)
   web_facet_xpath = "#{facet_xpath}[@type='#{type}' && @name='#{name}']"
-  doc.should have_xpath(web_facet_xpath)
+  expect(doc).to have_xpath(web_facet_xpath)
   web_facet_xpath
 end
 
@@ -60,7 +60,7 @@ describe Buildr::IntellijIdea do
   end
 
   def xml_document(filename)
-    File.should be_exist(filename)
+    expect(File).to be_exist(filename)
     REXML::Document.new(File.read(filename))
   end
 
@@ -86,22 +86,22 @@ describe Buildr::IntellijIdea do
     end
 
     it "should remove the ipr file" do
-      File.exists?("foo.ipr").should be_false
+      expect(File.exists?("foo.ipr")).to be_falsey
     end
 
     it "should remove the project iml file" do
-      File.exists?("foo.iml").should be_false
+      expect(File.exists?("foo.iml")).to be_falsey
     end
 
     it "should remove the subproject iml file" do
-      File.exists?("foo.iml").should be_false
+      expect(File.exists?("foo.iml")).to be_falsey
     end
 
     it "should not remove other iml and ipr files" do
-      File.exists?("other.ipr").should be_true
-      File.exists?("other.iml").should be_true
-      File.exists?("bar/other.ipr").should be_true
-      File.exists?("bar/other.iml").should be_true
+      expect(File.exists?("other.ipr")).to be_truthy
+      expect(File.exists?("other.iml")).to be_truthy
+      expect(File.exists?("bar/other.ipr")).to be_truthy
+      expect(File.exists?("bar/other.iml")).to be_truthy
     end
   end
 
@@ -122,7 +122,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates one exported 'module-library' orderEntry in IML" do
-          root_module_xml(@foo).should have_nodes("#{order_entry_xpath}[@type='module-library' && @exported='']/library/CLASSES/root", 1)
+          expect(root_module_xml(@foo)).to have_nodes("#{order_entry_xpath}[@type='module-library' && @exported='']/library/CLASSES/root", 1)
         end
       end
 
@@ -136,7 +136,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates one exported 'module-library' orderEntry in IML" do
-          root_module_xml(@foo).should have_nodes("#{order_entry_xpath}[@type='module-library' && @scope='TEST']/library/CLASSES/root", 1)
+          expect(root_module_xml(@foo)).to have_nodes("#{order_entry_xpath}[@type='module-library' && @scope='TEST']/library/CLASSES/root", 1)
         end
       end
 
@@ -150,7 +150,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates one non-exported test scope 'module-library' orderEntry in IML" do
-          root_module_xml(@foo).should have_nodes("#{order_entry_xpath}[@type='module-library' && @scope='TEST']/library/CLASSES/root", 1)
+          expect(root_module_xml(@foo)).to have_nodes("#{order_entry_xpath}[@type='module-library' && @scope='TEST']/library/CLASSES/root", 1)
         end
       end
 
@@ -164,7 +164,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates one non-exported 'module-library' orderEntry in IML" do
-          root_module_xml(@foo).should have_nodes("#{order_entry_xpath}[@type='module-library' && @scope='TEST']/library/CLASSES/root", 1)
+          expect(root_module_xml(@foo)).to have_nodes("#{order_entry_xpath}[@type='module-library' && @scope='TEST']/library/CLASSES/root", 1)
         end
       end
 
@@ -179,7 +179,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates 'module-library' orderEntry in IML with SOURCES specified" do
-          root_module_xml(@foo).should have_nodes("#{order_entry_xpath}[@type='module-library' && @exported='']/library/SOURCES/root", 1)
+          expect(root_module_xml(@foo)).to have_nodes("#{order_entry_xpath}[@type='module-library' && @exported='']/library/SOURCES/root", 1)
         end
       end
 
@@ -197,7 +197,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates orderEntry with absolute path for classes jar" do
-          root_module_xml(@foo).should match_xpath("#{order_entry_xpath}/library/CLASSES/root/@url",
+          expect(root_module_xml(@foo)).to match_xpath("#{order_entry_xpath}/library/CLASSES/root/@url",
                                                    "jar://$MODULE_DIR$/home/.m2/repository/group/id/1.0/id-1.0.jar!/")
         end
       end
@@ -212,7 +212,7 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates orderEntry with absolute path for classes jar" do
-          root_module_xml(@foo).should match_xpath("#{order_entry_xpath}/library/CLASSES/root/@url",
+          expect(root_module_xml(@foo)).to match_xpath("#{order_entry_xpath}/library/CLASSES/root/@url",
                                                    "jar://$MAVEN_REPOSITORY$/group/id/1.0/id-1.0.jar!/")
         end
       end
@@ -229,7 +229,7 @@ describe Buildr::IntellijIdea do
       end
 
       it "generates multiple 'module-library' orderEntry in IML" do
-        root_module_xml(@foo).should have_nodes("#{order_entry_xpath}[@type='module-library']", 2)
+        expect(root_module_xml(@foo)).to have_nodes("#{order_entry_xpath}[@type='module-library']", 2)
       end
     end
 
@@ -244,7 +244,7 @@ describe Buildr::IntellijIdea do
       end
 
       it "generates one exported 'module-library' orderEntry in IML" do
-        root_module_xml(@foo).should match_xpath("#{order_entry_xpath}/library/CLASSES/root/@url",
+        expect(root_module_xml(@foo)).to match_xpath("#{order_entry_xpath}/library/CLASSES/root/@url",
                                                  "jar://$MODULE_DIR$/foo-dep.jar!/")
       end
     end
@@ -260,13 +260,13 @@ describe Buildr::IntellijIdea do
 
       it "generate an IPR with extra modules specified" do
         doc = xml_document(@foo._("foo.ipr"))
-        doc.should have_nodes("#{xpath_to_module}", 3)
+        expect(doc).to have_nodes("#{xpath_to_module}", 3)
         module_ref = "$PROJECT_DIR$/foo.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
         module_ref = "$PROJECT_DIR$/other.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
         module_ref = "$PROJECT_DIR$/other_other.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
       end
     end
 
@@ -312,20 +312,20 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'gwt', 'GWT')
         setting_xpath = "#{facet_xpath}/configuration/setting"
-        doc.should have_xpath("#{setting_xpath}[@name='gwtSdkUrl', value='file://$GWT_TOOLS$']")
-        doc.should have_xpath("#{setting_xpath}[@name='gwtScriptOutputStyle', value='PRETTY']")
-        doc.should have_xpath("#{setting_xpath}[@name='compilerParameters', value='-draftCompile -localWorkers 2 -strict']")
-        doc.should have_xpath("#{setting_xpath}[@name='compilerParameters', value='-draftCompile -localWorkers 2 -strict']")
-        doc.should have_xpath("#{setting_xpath}[@name='compilerMaxHeapSize', value='512']")
-        doc.should have_xpath("#{setting_xpath}[@name='webFacet', value='Web']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtSdkUrl', value='file://$GWT_TOOLS$']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtScriptOutputStyle', value='PRETTY']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='compilerParameters', value='-draftCompile -localWorkers 2 -strict']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='compilerParameters', value='-draftCompile -localWorkers 2 -strict']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='compilerMaxHeapSize', value='512']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='webFacet', value='Web']")
       end
 
       it "generates a gwt facet with specified modules" do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'gwt', 'GWT')
         prefix = "#{facet_xpath}/configuration/packaging/module"
-        doc.should have_xpath("#{prefix}[@name='com.biz.MyModule' && @enabled='true']")
-        doc.should have_xpath("#{prefix}[@name='com.biz.MyOtherModule' && @enabled='false']")
+        expect(doc).to have_xpath("#{prefix}[@name='com.biz.MyModule' && @enabled='true']")
+        expect(doc).to have_xpath("#{prefix}[@name='com.biz.MyOtherModule' && @enabled='false']")
       end
     end
 
@@ -343,8 +343,8 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'gwt', 'GWT')
         setting_xpath = "#{facet_xpath}/configuration/setting"
-        doc.should have_xpath("#{setting_xpath}[@name='gwtSdkType', value='maven']")
-        doc.should have_xpath("#{setting_xpath}[@name='gwtSdkUrl', value='$MAVEN_REPOSITORY$/com/google/gwt/gwt-dev/2.5.1-not-a-release']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtSdkType', value='maven']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtSdkUrl', value='$MAVEN_REPOSITORY$/com/google/gwt/gwt-dev/2.5.1-not-a-release']")
       end
     end
 
@@ -361,8 +361,8 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'gwt', 'GWT')
         setting_xpath = "#{facet_xpath}/configuration/setting"
-        doc.should have_xpath("#{setting_xpath}[@name='gwtSdkType', value='maven']")
-        doc.should have_xpath("#{setting_xpath}[@name='gwtSdkUrl', value='$MAVEN_REPOSITORY$/com/google/gwt/gwt-dev/2.5.1']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtSdkType', value='maven']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtSdkUrl', value='$MAVEN_REPOSITORY$/com/google/gwt/gwt-dev/2.5.1']")
       end
     end
 
@@ -379,9 +379,9 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'gwt', 'GWT')
         setting_xpath = "#{facet_xpath}/configuration/setting"
-        doc.should have_xpath("#{setting_xpath}[@name='zang', value='zang']")
-        doc.should have_xpath("#{setting_xpath}[@name='gwtScriptOutputStyle', value='OTHER']")
-        doc.should have_xpath("#{setting_xpath}[@name='compilerMaxHeapSize', value='1024']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='zang', value='zang']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='gwtScriptOutputStyle', value='OTHER']")
+        expect(doc).to have_xpath("#{setting_xpath}[@name='compilerMaxHeapSize', value='1024']")
       end
     end
 
@@ -400,7 +400,7 @@ describe Buildr::IntellijIdea do
       it "generates a web facet with jsf facet auto-detected" do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
-        doc.should have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
+        expect(doc).to have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
       end
     end
 
@@ -417,7 +417,7 @@ describe Buildr::IntellijIdea do
       it "does not generate a web facet with jsf facet" do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
-        doc.should_not have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
+        expect(doc).not_to have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
       end
     end
 
@@ -436,7 +436,7 @@ describe Buildr::IntellijIdea do
       it "does not generate a web facet with jsf facet" do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
-        doc.should_not have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
+        expect(doc).not_to have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
       end
     end
 
@@ -455,7 +455,7 @@ describe Buildr::IntellijIdea do
       it "does not generate a web facet with jsf facet" do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
-        doc.should_not have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
+        expect(doc).not_to have_xpath("#{web_facet_xpath}/facet[@type='jsf' && @name='JSF']")
       end
     end
 
@@ -475,14 +475,14 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
         deployment_descriptor_xpath = "#{web_facet_xpath}/configuration/descriptors/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='web.xml',  url='file://$MODULE_DIR$/src/main/webapp/WEB-INF/web.xml']")
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='glassfish-web.xml',  url='file://$MODULE_DIR$/src/main/webapp/WEB-INF/glassfish-web.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='web.xml',  url='file://$MODULE_DIR$/src/main/webapp/WEB-INF/web.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='glassfish-web.xml',  url='file://$MODULE_DIR$/src/main/webapp/WEB-INF/glassfish-web.xml']")
       end
 
       it "generates a web facet with derived webroots" do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
-        doc.should have_xpath("#{web_facet_xpath}/configuration/webroots/root[@url='file://$MODULE_DIR$/src/main/webapp' && @relative='/']")
+        expect(doc).to have_xpath("#{web_facet_xpath}/configuration/webroots/root[@url='file://$MODULE_DIR$/src/main/webapp' && @relative='/']")
       end
     end
 
@@ -499,14 +499,14 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
         deployment_descriptor_xpath = "#{web_facet_xpath}/configuration/descriptors/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='web.xml',  url='file://$MODULE_DIR$/src/main/webapp2/WEB-INF/web.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='web.xml',  url='file://$MODULE_DIR$/src/main/webapp2/WEB-INF/web.xml']")
       end
 
       it "generates a web facet with specified webroots" do
         doc = xml_document(@foo._("foo.iml"))
         web_facet_xpath = ensure_facet_xpath(doc, 'web', 'Web')
-        doc.should have_xpath("#{web_facet_xpath}/configuration/webroots/root[@url='file://$MODULE_DIR$/src/main/webapp2' && @relative='/']")
-        doc.should have_xpath("#{web_facet_xpath}/configuration/webroots/root[@url='file://$MODULE_DIR$/src/main/css' && @relative='/css']")
+        expect(doc).to have_xpath("#{web_facet_xpath}/configuration/webroots/root[@url='file://$MODULE_DIR$/src/main/webapp2' && @relative='/']")
+        expect(doc).to have_xpath("#{web_facet_xpath}/configuration/webroots/root[@url='file://$MODULE_DIR$/src/main/css' && @relative='/css']")
       end
     end
 
@@ -525,15 +525,15 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
         deployment_descriptor_xpath = "#{facet_xpath}/configuration/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='persistence.xml',  url='file://$MODULE_DIR$/src/main/resources/META-INF/persistence.xml']")
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='orm.xml',  url='file://$MODULE_DIR$/src/main/resources/META-INF/orm.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='persistence.xml',  url='file://$MODULE_DIR$/src/main/resources/META-INF/persistence.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='orm.xml',  url='file://$MODULE_DIR$/src/main/resources/META-INF/orm.xml']")
       end
 
       it "generates a jpa facet with default settings" do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='Hibernate']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='Hibernate']")
       end
     end
 
@@ -554,15 +554,15 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
         deployment_descriptor_xpath = "#{facet_xpath}/configuration/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='persistence.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/persistence.xml']")
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='orm.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/orm.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='persistence.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/persistence.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='orm.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/orm.xml']")
       end
 
       it "generates a jpa facet with default settings" do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='Hibernate']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='Hibernate']")
       end
     end
 
@@ -583,8 +583,8 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
         deployment_descriptor_xpath = "#{facet_xpath}/configuration/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='persistence.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/persistence.xml']")
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='orm.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/orm.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='persistence.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/persistence.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='orm.xml',  url='file://$MODULE_DIR$/src/main/resources2/META-INF/orm.xml']")
       end
     end
 
@@ -602,8 +602,8 @@ describe Buildr::IntellijIdea do
       it "generates a jpa facet with default settings" do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='Hibernate']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='Hibernate']")
       end
     end
 
@@ -621,8 +621,8 @@ describe Buildr::IntellijIdea do
       it "generates a jpa facet with default settings" do
         doc = xml_document(@foo._("foo.iml"))
         facet_xpath = ensure_facet_xpath(doc, 'jpa', 'JPA')
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
-        doc.should have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='EclipseLink']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='validation-enabled' && @value='true']")
+        expect(doc).to have_xpath("#{facet_xpath}/configuration/setting[@name='provider-name' && @value='EclipseLink']")
       end
     end
 
@@ -641,14 +641,14 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         ejb_facet_xpath = ensure_facet_xpath(doc, 'ejb', 'EJB')
         deployment_descriptor_xpath = "#{ejb_facet_xpath}/configuration/descriptors/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='ejb-jar.xml',  url='file://$MODULE_DIR$/src/main/resources/WEB-INF/ejb-jar.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='ejb-jar.xml',  url='file://$MODULE_DIR$/src/main/resources/WEB-INF/ejb-jar.xml']")
       end
 
       it "generates an ejb facet with derived ejbRoots" do
         doc = xml_document(@foo._("foo.iml"))
         ejb_facet_xpath = ensure_facet_xpath(doc, 'ejb', 'EJB')
-        doc.should have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/src/main/java']")
-        doc.should have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/src/main/resources']")
+        expect(doc).to have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/src/main/java']")
+        expect(doc).to have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/src/main/resources']")
       end
     end
 
@@ -665,14 +665,14 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         ejb_facet_xpath = ensure_facet_xpath(doc, 'ejb', 'EJB')
         deployment_descriptor_xpath = "#{ejb_facet_xpath}/configuration/descriptors/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='ejb-jar.xml',  url='file://$MODULE_DIR$/generated/main/resources/WEB-INF/ejb-jar.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='ejb-jar.xml',  url='file://$MODULE_DIR$/generated/main/resources/WEB-INF/ejb-jar.xml']")
       end
 
       it "generates an ejb facet with derived ejbRoots" do
         doc = xml_document(@foo._("foo.iml"))
         ejb_facet_xpath = ensure_facet_xpath(doc, 'ejb', 'EJB')
-        doc.should have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/generated/main/java']")
-        doc.should have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/generated/main/resources']")
+        expect(doc).to have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/generated/main/java']")
+        expect(doc).to have_xpath("#{ejb_facet_xpath}/configuration/ejbRoots/root[@url='file://$MODULE_DIR$/generated/main/resources']")
       end
     end
 
@@ -690,7 +690,7 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.iml"))
         ejb_facet_xpath = ensure_facet_xpath(doc, 'ejb', 'EJB')
         deployment_descriptor_xpath = "#{ejb_facet_xpath}/configuration/descriptors/deploymentDescriptor"
-        doc.should have_xpath("#{deployment_descriptor_xpath}[@name='ejb-jar.xml',  url='file://$MODULE_DIR$/src/main/resources2/WEB-INF/ejb-jar.xml']")
+        expect(doc).to have_xpath("#{deployment_descriptor_xpath}[@name='ejb-jar.xml',  url='file://$MODULE_DIR$/src/main/resources2/WEB-INF/ejb-jar.xml']")
       end
     end
 
@@ -706,15 +706,15 @@ describe Buildr::IntellijIdea do
       it "generates a jruby facet with appropriate sdk" do
         doc = xml_document(@foo._("foo.iml"))
         jruby_facet_xpath = ensure_facet_xpath(doc, 'JRUBY', 'JRuby')
-        doc.should have_xpath("#{jruby_facet_xpath}/configuration/JRUBY_FACET_CONFIG_ID[@NAME='JRUBY_SDK_NAME', VALUE='jruby-1.6.7.2']")
+        expect(doc).to have_xpath("#{jruby_facet_xpath}/configuration/JRUBY_FACET_CONFIG_ID[@NAME='JRUBY_SDK_NAME', VALUE='jruby-1.6.7.2']")
       end
 
       it "generates a jruby facet with appropriate paths" do
         doc = xml_document(@foo._("foo.iml"))
         jruby_facet_xpath = ensure_facet_xpath(doc, 'JRUBY', 'JRuby')
         prefix = "#{jruby_facet_xpath}/configuration"
-        doc.should have_xpath("#{prefix}/LOAD_PATH[@number='0']")
-        doc.should have_xpath("#{prefix}/I18N_FOLDERS[@number='0']")
+        expect(doc).to have_xpath("#{prefix}/LOAD_PATH[@number='0']")
+        expect(doc).to have_xpath("#{prefix}/I18N_FOLDERS[@number='0']")
       end
     end
 
@@ -732,15 +732,15 @@ describe Buildr::IntellijIdea do
       it "generates a jruby facet with appropriate sdk" do
         doc = xml_document(@foo._("foo.iml"))
         jruby_facet_xpath = ensure_facet_xpath(doc, 'JRUBY', 'JRuby')
-        doc.should have_xpath("#{jruby_facet_xpath}/configuration/JRUBY_FACET_CONFIG_ID[@NAME='JRUBY_SDK_NAME', VALUE='rbenv: jruby-1.7.2']")
+        expect(doc).to have_xpath("#{jruby_facet_xpath}/configuration/JRUBY_FACET_CONFIG_ID[@NAME='JRUBY_SDK_NAME', VALUE='rbenv: jruby-1.7.2']")
       end
 
       it "generates a jruby facet with appropriate paths" do
         doc = xml_document(@foo._("foo.iml"))
         jruby_facet_xpath = ensure_facet_xpath(doc, 'JRUBY', 'JRuby')
         prefix = "#{jruby_facet_xpath}/configuration"
-        doc.should have_xpath("#{prefix}/LOAD_PATH[@number='0']")
-        doc.should have_xpath("#{prefix}/I18N_FOLDERS[@number='0']")
+        expect(doc).to have_xpath("#{prefix}/LOAD_PATH[@number='0']")
+        expect(doc).to have_xpath("#{prefix}/I18N_FOLDERS[@number='0']")
       end
     end
 
@@ -762,16 +762,16 @@ describe Buildr::IntellijIdea do
       it "generates a data source manager with specified data source" do
         doc = xml_document(@foo._("foo.ipr"))
         prefix_xpath = "/project/component[@name='DataSourceManagerImpl' && @format='xml' && @hash='3208837817']/data-source"
-        doc.should have_nodes(prefix_xpath, 1)
+        expect(doc).to have_nodes(prefix_xpath, 1)
         ds_path = "#{prefix_xpath}[@source='LOCAL' && @name='Postgres']"
-        doc.should have_xpath(ds_path)
-        doc.should have_xpath("#{ds_path}/synchronize/text() = 'true'")
-        doc.should have_xpath("#{ds_path}/jdbc-driver/text() = 'org.postgresql.Driver'")
-        doc.should have_xpath("#{ds_path}/jdbc-url/text() = 'jdbc:postgresql://127.0.0.1:5432/MyDb'")
-        doc.should have_xpath("#{ds_path}/user-name/text() = 'MyDBUser'")
-        doc.should have_xpath("#{ds_path}/user-password/text() = 'dfd9dfcfdfc9dfd8dfcfdfdedfc5'")
-        doc.should have_xpath("#{ds_path}/default-dialect/text() = 'PostgreSQL'")
-        doc.should have_xpath("#{ds_path}/libraries/library/url/text() = '$MAVEN_REPOSITORY$/org/postgresql/postgresql/9.not-a-version/postgresql-9.not-a-version.jar'")
+        expect(doc).to have_xpath(ds_path)
+        expect(doc).to have_xpath("#{ds_path}/synchronize/text() = 'true'")
+        expect(doc).to have_xpath("#{ds_path}/jdbc-driver/text() = 'org.postgresql.Driver'")
+        expect(doc).to have_xpath("#{ds_path}/jdbc-url/text() = 'jdbc:postgresql://127.0.0.1:5432/MyDb'")
+        expect(doc).to have_xpath("#{ds_path}/user-name/text() = 'MyDBUser'")
+        expect(doc).to have_xpath("#{ds_path}/user-password/text() = 'dfd9dfcfdfc9dfd8dfcfdfdedfc5'")
+        expect(doc).to have_xpath("#{ds_path}/default-dialect/text() = 'PostgreSQL'")
+        expect(doc).to have_xpath("#{ds_path}/libraries/library/url/text() = '$MAVEN_REPOSITORY$/org/postgresql/postgresql/9.not-a-version/postgresql-9.not-a-version.jar'")
       end
     end
 
@@ -788,15 +788,15 @@ describe Buildr::IntellijIdea do
       it "generates a data source manager with specified data source" do
         doc = xml_document(@foo._("foo.ipr"))
         prefix_xpath = "/project/component[@name='DataSourceManagerImpl' && @format='xml' && @hash='3208837817']/data-source"
-        doc.should have_nodes(prefix_xpath, 1)
+        expect(doc).to have_nodes(prefix_xpath, 1)
         ds_path = "#{prefix_xpath}[@source='LOCAL' && @name='Postgres']"
-        doc.should have_xpath(ds_path)
-        doc.should have_xpath("#{ds_path}/synchronize/text() = 'true'")
-        doc.should have_xpath("#{ds_path}/jdbc-driver/text() = 'org.postgresql.Driver'")
-        doc.should have_xpath("#{ds_path}/jdbc-url/text() = 'jdbc:postgresql://127.0.0.1:5432/MyDb'")
-        doc.should have_xpath("#{ds_path}/user-name/text() = 'Bob'")
-        doc.should have_xpath("#{ds_path}/default-dialect/text() = 'PostgreSQL'")
-        doc.should have_xpath("#{ds_path}/libraries/library/url/text() = '$MAVEN_REPOSITORY$/org/postgresql/postgresql/9.2-1003-jdbc4/postgresql-9.2-1003-jdbc4.jar'")
+        expect(doc).to have_xpath(ds_path)
+        expect(doc).to have_xpath("#{ds_path}/synchronize/text() = 'true'")
+        expect(doc).to have_xpath("#{ds_path}/jdbc-driver/text() = 'org.postgresql.Driver'")
+        expect(doc).to have_xpath("#{ds_path}/jdbc-url/text() = 'jdbc:postgresql://127.0.0.1:5432/MyDb'")
+        expect(doc).to have_xpath("#{ds_path}/user-name/text() = 'Bob'")
+        expect(doc).to have_xpath("#{ds_path}/default-dialect/text() = 'PostgreSQL'")
+        expect(doc).to have_xpath("#{ds_path}/libraries/library/url/text() = '$MAVEN_REPOSITORY$/org/postgresql/postgresql/9.2-1003-jdbc4/postgresql-9.2-1003-jdbc4.jar'")
       end
     end
 
@@ -813,16 +813,16 @@ describe Buildr::IntellijIdea do
       it "generates a data source manager with specified data source" do
         doc = xml_document(@foo._("foo.ipr"))
         prefix_xpath = "/project/component[@name='DataSourceManagerImpl' && @format='xml' && @hash='3208837817']/data-source"
-        doc.should have_nodes(prefix_xpath, 1)
+        expect(doc).to have_nodes(prefix_xpath, 1)
         ds_path = "#{prefix_xpath}[@source='LOCAL' && @name='SqlServer']"
-        doc.should have_xpath(ds_path)
+        expect(doc).to have_xpath(ds_path)
 
-        doc.should have_xpath("#{ds_path}/synchronize/text() = 'true'")
-        doc.should have_xpath("#{ds_path}/jdbc-driver/text() = 'net.sourceforge.jtds.jdbc.Driver'")
-        doc.should have_xpath("#{ds_path}/jdbc-url/text() = 'jdbc:jtds:sqlserver://127.0.0.1:1433/MyDb'")
-        doc.should have_xpath("#{ds_path}/user-name/text() = 'Bob'")
-        doc.should have_xpath("#{ds_path}/default-dialect/text() = 'TSQL'")
-        doc.should have_xpath("#{ds_path}/libraries/library/url/text() = '$MAVEN_REPOSITORY$/net/sourceforge/jtds/1.2.7/jtds-1.2.7.jar'")
+        expect(doc).to have_xpath("#{ds_path}/synchronize/text() = 'true'")
+        expect(doc).to have_xpath("#{ds_path}/jdbc-driver/text() = 'net.sourceforge.jtds.jdbc.Driver'")
+        expect(doc).to have_xpath("#{ds_path}/jdbc-url/text() = 'jdbc:jtds:sqlserver://127.0.0.1:1433/MyDb'")
+        expect(doc).to have_xpath("#{ds_path}/user-name/text() = 'Bob'")
+        expect(doc).to have_xpath("#{ds_path}/default-dialect/text() = 'TSQL'")
+        expect(doc).to have_xpath("#{ds_path}/libraries/library/url/text() = '$MAVEN_REPOSITORY$/net/sourceforge/jtds/1.2.7/jtds-1.2.7.jar'")
       end
     end
 
@@ -844,9 +844,9 @@ describe Buildr::IntellijIdea do
       it "generates an IPR with multiple jar artifacts" do
         doc = xml_document(@foo._("foo.ipr"))
         facet_xpath = "/project/component[@name='ArtifactManager']/artifact"
-        doc.should have_nodes(facet_xpath, 2)
-        doc.should have_xpath("#{facet_xpath}[@type='jar' && @name='MyFancy.jar']")
-        doc.should have_xpath("#{facet_xpath}[@type='jar' && @name='MyOtherFancy.jar']")
+        expect(doc).to have_nodes(facet_xpath, 2)
+        expect(doc).to have_xpath("#{facet_xpath}[@type='jar' && @name='MyFancy.jar']")
+        expect(doc).to have_xpath("#{facet_xpath}[@type='jar' && @name='MyOtherFancy.jar']")
       end
     end
 
@@ -870,10 +870,10 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.ipr"))
         base_xpath = "/project/component[@name='ArtifactManager']/artifact"
         facet_xpath = "#{base_xpath}[@type='jar' && @name='bar.jar' && @build-on-make='false']"
-        doc.should have_xpath(facet_xpath)
+        expect(doc).to have_xpath(facet_xpath)
 
-        doc.should have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
-        doc.should have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='module-output' && @name='bar']")
+        expect(doc).to have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='module-output' && @name='bar']")
       end
     end
 
@@ -903,12 +903,12 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.ipr"))
         base_xpath = "/project/component[@name='ArtifactManager']/artifact"
         facet_xpath = "#{base_xpath}[@type='jar' && @name='bar.jar' && @build-on-make='true']"
-        doc.should have_xpath(facet_xpath)
+        expect(doc).to have_xpath(facet_xpath)
 
-        doc.should have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/bink")
-        doc.should have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='module-output' && @name='bar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='jpa-descriptors' && @facet='p/jpa/JPA']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='javaee-facet-resources' && @facet='x/ejb/EJB']")
+        expect(doc).to have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/bink")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='module-output' && @name='bar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='jpa-descriptors' && @facet='p/jpa/JPA']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='archive' && @name='bar.jar']/element[@id='javaee-facet-resources' && @facet='x/ejb/EJB']")
       end
     end
 
@@ -934,11 +934,11 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.ipr"))
         base_xpath = "/project/component[@name='ArtifactManager']/artifact"
         facet_xpath = "#{base_xpath}[@type='exploded-ejb' && @name='bar' && @build-on-make='false']"
-        doc.should have_xpath(facet_xpath)
-        doc.should have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='module-output' && @name='bar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='jpa-descriptors' && @facet='p/jpa/JPA']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='x/ejb/EJB']")
+        expect(doc).to have_xpath(facet_xpath)
+        expect(doc).to have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='module-output' && @name='bar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='jpa-descriptors' && @facet='p/jpa/JPA']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='x/ejb/EJB']")
       end
     end
 
@@ -962,10 +962,10 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.ipr"))
         base_xpath = "/project/component[@name='ArtifactManager']/artifact"
         facet_xpath = "#{base_xpath}[@type='exploded-ejb' && @name='bar' && @build-on-make='false']"
-        doc.should have_xpath(facet_xpath)
+        expect(doc).to have_xpath(facet_xpath)
 
-        doc.should have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='module-output' && @name='bar']")
+        expect(doc).to have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='module-output' && @name='bar']")
       end
     end
 
@@ -990,12 +990,12 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.ipr"))
         base_xpath = "/project/component[@name='ArtifactManager']/artifact"
         facet_xpath = "#{base_xpath}[@type='exploded-war' && @name='bar' && @build-on-make='false']"
-        doc.should have_xpath(facet_xpath)
+        expect(doc).to have_xpath(facet_xpath)
 
-        doc.should have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='classes']/element[@id='module-output' && @name='bar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='file-copy' && @path='$MAVEN_REPOSITORY$/net/sourceforge/jtds/jtds/1.2.7.XX/jtds-1.2.7.XX.jar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='bar/web/Web']")
+        expect(doc).to have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/bar")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='classes']/element[@id='module-output' && @name='bar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='file-copy' && @path='$MAVEN_REPOSITORY$/net/sourceforge/jtds/jtds/1.2.7.XX/jtds-1.2.7.XX.jar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='bar/web/Web']")
       end
     end
 
@@ -1024,17 +1024,17 @@ describe Buildr::IntellijIdea do
         doc = xml_document(@foo._("foo.ipr"))
         base_xpath = "/project/component[@name='ArtifactManager']/artifact"
         facet_xpath = "#{base_xpath}[@type='exploded-war' @name='MyFancy.jar' && @build-on-make='false']"
-        doc.should have_xpath(facet_xpath)
+        expect(doc).to have_xpath(facet_xpath)
 
-        doc.should have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/gar")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='classes']/element[@id='module-output' && @name='bar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='file-copy' && @path='$MAVEN_REPOSITORY$/net/sourceforge/jtds/jtds/1.2.7.XX/jtds-1.2.7.XX.jar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='x/web/Web']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='y/web/Web']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='gwt-compiler-output' && @facet='p/gwt/GWT']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='gwt-compiler-output' && @facet='q/gwt/GWT']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='artifact' && @artifact-name='baz.jar']")
-        doc.should have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='artifact' && @artifact-name='biz.jar']")
+        expect(doc).to have_xpath("#{facet_xpath}/output-path/text() = $PROJECT_DIR$/artifacts/gar")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='classes']/element[@id='module-output' && @name='bar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='file-copy' && @path='$MAVEN_REPOSITORY$/net/sourceforge/jtds/jtds/1.2.7.XX/jtds-1.2.7.XX.jar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='x/web/Web']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='javaee-facet-resources' && @facet='y/web/Web']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='gwt-compiler-output' && @facet='p/gwt/GWT']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='gwt-compiler-output' && @facet='q/gwt/GWT']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='artifact' && @artifact-name='baz.jar']")
+        expect(doc).to have_xpath("#{facet_xpath}/root[@id='root']/element[@id='directory' && @name='WEB-INF']/element[@id='directory' && @name='lib']/element[@id='artifact' && @artifact-name='biz.jar']")
       end
     end
 
@@ -1068,9 +1068,9 @@ describe Buildr::IntellijIdea do
       it "generates an IPR with multiple configurations" do
         doc = xml_document(@foo._("foo.ipr"))
         facet_xpath = "/project/component[@name='ProjectRunConfigurationManager']/configuration"
-        doc.should have_nodes(facet_xpath, 2)
-        doc.should have_xpath("#{facet_xpath}[@type='GWT.ConfigurationType' && @name='Run Contacts.html']")
-        doc.should have_xpath("#{facet_xpath}[@type='GWT.ConfigurationType' && @name='Run Planner.html']")
+        expect(doc).to have_nodes(facet_xpath, 2)
+        expect(doc).to have_xpath("#{facet_xpath}[@type='GWT.ConfigurationType' && @name='Run Contacts.html']")
+        expect(doc).to have_xpath("#{facet_xpath}[@type='GWT.ConfigurationType' && @name='Run Planner.html']")
       end
     end
 
@@ -1094,8 +1094,8 @@ describe Buildr::IntellijIdea do
       it "generates an IPR with default configuration" do
         doc = xml_document(@foo._("foo.ipr"))
         facet_xpath = "/project/component[@name='ProjectRunConfigurationManager']/configuration"
-        doc.should have_nodes(facet_xpath, 1)
-        doc.should have_xpath("#{facet_xpath}[@type='GWT.ConfigurationType' && @factoryName='GWT Configuration' && @default='true']")
+        expect(doc).to have_nodes(facet_xpath, 1)
+        expect(doc).to have_xpath("#{facet_xpath}[@type='GWT.ConfigurationType' && @factoryName='GWT Configuration' && @default='true']")
       end
     end
 
@@ -1110,11 +1110,11 @@ describe Buildr::IntellijIdea do
       it "generates an IPR with default configuration" do
         doc = xml_document(@foo._("foo.ipr"))
         configurations_xpath = "/project/component[@name='ProjectRunConfigurationManager']/configuration"
-        doc.should have_nodes(configurations_xpath, 1)
+        expect(doc).to have_nodes(configurations_xpath, 1)
         configuration_xpath = "#{configurations_xpath}[@type='TestNG' && @factoryName='TestNG' && @default='true']"
-        doc.should have_xpath(configuration_xpath)
-        doc.should have_xpath("#{configuration_xpath}/option[@name='VM_PARAMETERS' && @value='-ea']")
-        doc.should have_xpath("#{configuration_xpath}/option[@name='WORKING_DIRECTORY' && @value='$PROJECT_DIR$']")
+        expect(doc).to have_xpath(configuration_xpath)
+        expect(doc).to have_xpath("#{configuration_xpath}/option[@name='VM_PARAMETERS' && @value='-ea']")
+        expect(doc).to have_xpath("#{configuration_xpath}/option[@name='WORKING_DIRECTORY' && @value='$PROJECT_DIR$']")
       end
     end
 
@@ -1129,11 +1129,11 @@ describe Buildr::IntellijIdea do
       it "generates an IPR with default configuration" do
         doc = xml_document(@foo._("foo.ipr"))
         configurations_xpath = "/project/component[@name='ProjectRunConfigurationManager']/configuration"
-        doc.should have_nodes(configurations_xpath, 1)
+        expect(doc).to have_nodes(configurations_xpath, 1)
         configuration_xpath = "#{configurations_xpath}[@type='TestNG' && @factoryName='TestNG' && @default='true']"
-        doc.should have_xpath(configuration_xpath)
-        doc.should have_xpath("#{configuration_xpath}/option[@name='VM_PARAMETERS' && @value='-ea -Dtest.db.url=xxxx']")
-        doc.should have_xpath("#{configuration_xpath}/option[@name='WORKING_DIRECTORY' && @value='C:/blah']")
+        expect(doc).to have_xpath(configuration_xpath)
+        expect(doc).to have_xpath("#{configuration_xpath}/option[@name='VM_PARAMETERS' && @value='-ea -Dtest.db.url=xxxx']")
+        expect(doc).to have_xpath("#{configuration_xpath}/option[@name='WORKING_DIRECTORY' && @value='C:/blah']")
       end
     end
 
@@ -1155,15 +1155,15 @@ describe Buildr::IntellijIdea do
 
       it "generate an IPR with correct group references" do
         doc = xml_document(@foo._("foo.ipr"))
-        doc.should have_nodes("#{xpath_to_module}", 4)
+        expect(doc).to have_nodes("#{xpath_to_module}", 4)
         module_ref = "$PROJECT_DIR$/foo.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']")
         module_ref = "$PROJECT_DIR$/rab/rab.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}' @group = 'MyGroup']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}' @group = 'MyGroup']")
         module_ref = "$PROJECT_DIR$/bar/bar.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}' @group = 'foo']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}' @group = 'foo']")
         module_ref = "$PROJECT_DIR$/bar/baz/baz.iml"
-        doc.should have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}' @group = 'foo/bar']")
+        expect(doc).to have_xpath("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}' @group = 'foo/bar']")
       end
     end
 
@@ -1175,26 +1175,26 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates a single IPR" do
-          Dir[@foo._("**/*.ipr")].should have(1).entry
+          expect(Dir[@foo._("**/*.ipr")].size).to eq(1)
         end
 
         it "generate an IPR in the root directory" do
-          File.should be_exist(@foo._("foo.ipr"))
+          expect(File).to be_exist(@foo._("foo.ipr"))
         end
 
         it "generates a single IML" do
-          Dir[@foo._("**/*.iml")].should have(1).entry
+          expect(Dir[@foo._("**/*.iml")].size).to eq(1)
         end
 
         it "generates an IML in the root directory" do
-          File.should be_exist(@foo._("foo.iml"))
+          expect(File).to be_exist(@foo._("foo.iml"))
         end
 
         it "generate an IPR with the reference to correct module file" do
-          File.should be_exist(@foo._("foo.ipr"))
+          expect(File).to be_exist(@foo._("foo.ipr"))
           doc = xml_document(@foo._("foo.ipr"))
           module_ref = "$PROJECT_DIR$/foo.iml"
-          doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
         end
       end
 
@@ -1207,13 +1207,13 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates no IML" do
-          Dir[@foo._("**/*.iml")].should have(0).entry
+          expect(Dir[@foo._("**/*.iml")].size).to eq(0)
         end
 
         it "generate an IPR with no references" do
-          File.should be_exist(@foo._("foo.ipr"))
+          expect(File).to be_exist(@foo._("foo.ipr"))
           doc = xml_document(@foo._("foo.ipr"))
-          doc.should have_nodes("#{xpath_to_module}", 0)
+          expect(doc).to have_nodes("#{xpath_to_module}", 0)
         end
       end
 
@@ -1226,11 +1226,11 @@ describe Buildr::IntellijIdea do
         end
 
         it "generates a single IML" do
-          Dir[@foo._("**/*.iml")].should have(1).entry
+          expect(Dir[@foo._("**/*.iml")].size).to eq(1)
         end
 
         it "generate no IPR" do
-          File.should_not be_exist(@foo._("foo.ipr"))
+          expect(File).not_to be_exist(@foo._("foo.ipr"))
         end
       end
 
@@ -1247,22 +1247,22 @@ describe Buildr::IntellijIdea do
         end
 
         it "generate an IPR in the root directory" do
-          File.should be_exist(@foo._("fooble.ipr"))
+          expect(File).to be_exist(@foo._("fooble.ipr"))
         end
 
         it "generates an IML in the root directory" do
-          File.should be_exist(@foo._("feap.iml"))
+          expect(File).to be_exist(@foo._("feap.iml"))
         end
 
         it "generates an IML in the subproject directory" do
-          File.should be_exist(@foo._("bar/baz.iml"))
+          expect(File).to be_exist(@foo._("bar/baz.iml"))
         end
 
         it "generate an IPR with the reference to correct module file" do
-          File.should be_exist(@foo._("fooble.ipr"))
+          expect(File).to be_exist(@foo._("fooble.ipr"))
           doc = xml_document(@foo._("fooble.ipr"))
           module_ref = "$PROJECT_DIR$/feap.iml"
-          doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
         end
       end
 
@@ -1276,19 +1276,19 @@ describe Buildr::IntellijIdea do
         end
 
         it "generate an IPR in the root directory" do
-          File.should be_exist(@foo._("foo-ipr-suffix.ipr"))
+          expect(File).to be_exist(@foo._("foo-ipr-suffix.ipr"))
         end
 
         it "generates an IML in the root directory" do
-          File.should be_exist(@foo._("foo-iml-suffix.iml"))
+          expect(File).to be_exist(@foo._("foo-iml-suffix.iml"))
         end
 
         it "generate an IPR with the reference to correct module file" do
-          File.should be_exist(@foo._("foo-ipr-suffix.ipr"))
+          expect(File).to be_exist(@foo._("foo-ipr-suffix.ipr"))
           doc = xml_document(@foo._("foo-ipr-suffix.ipr"))
-          doc.should have_nodes("#{xpath_to_module}", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}", 1)
           module_ref = "$PROJECT_DIR$/foo-iml-suffix.iml"
-          doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
         end
       end
 
@@ -1302,19 +1302,19 @@ describe Buildr::IntellijIdea do
         end
 
         it "generate an IPR in the root directory" do
-          File.should be_exist(@foo._("ipr-prefix-foo.ipr"))
+          expect(File).to be_exist(@foo._("ipr-prefix-foo.ipr"))
         end
 
         it "generates an IML in the root directory" do
-          File.should be_exist(@foo._("iml-prefix-foo.iml"))
+          expect(File).to be_exist(@foo._("iml-prefix-foo.iml"))
         end
 
         it "generate an IPR with the reference to correct module file" do
-          File.should be_exist(@foo._("ipr-prefix-foo.ipr"))
+          expect(File).to be_exist(@foo._("ipr-prefix-foo.ipr"))
           doc = xml_document(@foo._("ipr-prefix-foo.ipr"))
-          doc.should have_nodes("#{xpath_to_module}", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}", 1)
           module_ref = "$PROJECT_DIR$/iml-prefix-foo.iml"
-          doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
         end
       end
 
@@ -1330,19 +1330,19 @@ describe Buildr::IntellijIdea do
         end
 
         it "generate an IPR in the root directory" do
-          File.should be_exist(@foo._("ipr-prefix-foo-ipr-suffix.ipr"))
+          expect(File).to be_exist(@foo._("ipr-prefix-foo-ipr-suffix.ipr"))
         end
 
         it "generates an IML in the root directory" do
-          File.should be_exist(@foo._("iml-prefix-foo-iml-suffix.iml"))
+          expect(File).to be_exist(@foo._("iml-prefix-foo-iml-suffix.iml"))
         end
 
         it "generate an IPR with the reference to correct module file" do
-          File.should be_exist(@foo._("ipr-prefix-foo-ipr-suffix.ipr"))
+          expect(File).to be_exist(@foo._("ipr-prefix-foo-ipr-suffix.ipr"))
           doc = xml_document(@foo._("ipr-prefix-foo-ipr-suffix.ipr"))
-          doc.should have_nodes("#{xpath_to_module}", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}", 1)
           module_ref = "$PROJECT_DIR$/iml-prefix-foo-iml-suffix.iml"
-          doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
         end
       end
     end
@@ -1356,21 +1356,21 @@ describe Buildr::IntellijIdea do
       end
 
       it "creates the subproject directory" do
-        File.should be_exist(@foo._("bar"))
+        expect(File).to be_exist(@foo._("bar"))
       end
 
       it "generates an IML in the subproject directory" do
-        File.should be_exist(@foo._("bar/bar.iml"))
+        expect(File).to be_exist(@foo._("bar/bar.iml"))
       end
 
       it "generate an IPR with the reference to correct module file" do
-        File.should be_exist(@foo._("foo.ipr"))
+        expect(File).to be_exist(@foo._("foo.ipr"))
         doc = xml_document(@foo._("foo.ipr"))
-        doc.should have_nodes("#{xpath_to_module}", 2)
+        expect(doc).to have_nodes("#{xpath_to_module}", 2)
         module_ref = "$PROJECT_DIR$/foo.iml"
-        doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+        expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
         module_ref = "$PROJECT_DIR$/bar/bar.iml"
-        doc.should have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
+        expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://#{module_ref}' && @filepath='#{module_ref}']", 1)
       end
     end
 
@@ -1388,26 +1388,26 @@ describe Buildr::IntellijIdea do
       end
 
       it "generates a subproject IML in the specified directory" do
-        File.should be_exist(@foo._("fe/bar.iml"))
+        expect(File).to be_exist(@foo._("fe/bar.iml"))
       end
 
       it "generates a sub-subproject IML in the specified directory" do
-        File.should be_exist(@foo._("fi/baz.iml"))
+        expect(File).to be_exist(@foo._("fi/baz.iml"))
       end
 
       it "generates a sub-sub-subproject IML that inherits the specified directory" do
-        File.should be_exist(@foo._("fi/foe/foe.iml"))
+        expect(File).to be_exist(@foo._("fi/foe/foe.iml"))
       end
 
       it "generates a sub-subproject IML that inherits the specified directory" do
-        File.should be_exist(@foo._("fe/fum/fum.iml"))
+        expect(File).to be_exist(@foo._("fe/fum/fum.iml"))
       end
 
       it "generate an IPR with the references to correct module files" do
         doc = xml_document(@foo._("foo.ipr"))
-        doc.should have_nodes("#{xpath_to_module}", 5)
+        expect(doc).to have_nodes("#{xpath_to_module}", 5)
         ["foo.iml", "fe/bar.iml", "fi/baz.iml", "fi/foe/foe.iml", "fe/fum/fum.iml"].each do |module_ref|
-          doc.should have_nodes("#{xpath_to_module}[@fileurl='file://$PROJECT_DIR$/#{module_ref}' && @filepath='$PROJECT_DIR$/#{module_ref}']", 1)
+          expect(doc).to have_nodes("#{xpath_to_module}[@fileurl='file://$PROJECT_DIR$/#{module_ref}' && @filepath='$PROJECT_DIR$/#{module_ref}']", 1)
         end
       end
     end
@@ -1446,19 +1446,19 @@ describe Buildr::IntellijIdea do
       end
 
       it "depends on the associated module exactly once" do
-        @bar_iml.should have_nodes("//orderEntry[@type='module' && @module-name='foo' && @exported=""]", 1)
+        expect(@bar_iml).to have_nodes("//orderEntry[@type='module' && @module-name='foo' && @exported=""]", 1)
       end
 
       it "does not depend on the other project's packaged JAR" do
-        @bar_lib_urls.grep(%r{#{project('root:foo').packages.first}}).should == []
+        expect(@bar_lib_urls.grep(%r{#{project('root:foo').packages.first}})).to eq([])
       end
 
       it "does not depend on the the other project's target/classes directory" do
-        @bar_lib_urls.grep(%r{foo/target/classes}).should == []
+        expect(@bar_lib_urls.grep(%r{foo/target/classes})).to eq([])
       end
 
       it "does not depend on the the other project's target/resources directory" do
-        @bar_lib_urls.grep(%r{file://\$MODULE_DIR\$/../foo/target/resources}).size.should == 0
+        expect(@bar_lib_urls.grep(%r{file://\$MODULE_DIR\$/../foo/target/resources}).size).to eq(0)
        end
     end
 
@@ -1468,11 +1468,11 @@ describe Buildr::IntellijIdea do
       end
 
       it "informs the user about generating IPR" do
-        lambda { invoke_generate_task }.should show_info(/Writing (.+)\/foo\.ipr/)
+        expect { invoke_generate_task }.to show_info(/Writing (.+)\/foo\.ipr/)
       end
 
       it "informs the user about generating IML" do
-        lambda { invoke_generate_task }.should show_info(/Writing (.+)\/foo\.iml/)
+        expect { invoke_generate_task }.to show_info(/Writing (.+)\/foo\.iml/)
       end
     end
     describe "with a subproject" do
@@ -1483,7 +1483,7 @@ describe Buildr::IntellijIdea do
       end
 
       it "informs the user about generating subporoject IML" do
-        lambda { invoke_generate_task }.should show_info(/Writing (.+)\/bar\/bar\.iml/)
+        expect { invoke_generate_task }.to show_info(/Writing (.+)\/bar\/bar\.iml/)
       end
     end
 
@@ -1498,13 +1498,13 @@ describe Buildr::IntellijIdea do
 
       it "generate an ProjectRootManager with 1.5 jdk specified" do
         #raise File.read(@foo._("foo.ipr"))
-        xml_document(@foo._("foo.ipr")).
-          should have_xpath("/project/component[@name='ProjectRootManager' && @project-jdk-name = '1.5' && @languageLevel = 'JDK_1_5']")
+        expect(xml_document(@foo._("foo.ipr"))).
+          to have_xpath("/project/component[@name='ProjectRootManager' && @project-jdk-name = '1.5' && @languageLevel = 'JDK_1_5']")
       end
 
       it "generates a ProjectDetails component with the projectName option set" do
-        xml_document(@foo._("foo.ipr")).
-          should have_xpath("/project/component[@name='ProjectDetails']/option[@name = 'projectName' && @value = 'foo']")
+        expect(xml_document(@foo._("foo.ipr"))).
+          to have_xpath("/project/component[@name='ProjectDetails']/option[@name = 'projectName' && @value = 'foo']")
       end
     end
 
@@ -1517,8 +1517,8 @@ describe Buildr::IntellijIdea do
       end
 
       it "generate an ProjectRootManager with 1.6 jdk specified" do
-        xml_document(@foo._("foo.ipr")).
-          should have_xpath("/project/component[@name='ProjectRootManager' && @project-jdk-name = '1.6' && @languageLevel = 'JDK_1_6']")
+        expect(xml_document(@foo._("foo.ipr"))).
+          to have_xpath("/project/component[@name='ProjectRootManager' && @project-jdk-name = '1.6' && @languageLevel = 'JDK_1_6']")
       end
     end
 
@@ -1532,7 +1532,7 @@ describe Buildr::IntellijIdea do
 
       it "generate an IML with no content section" do
         doc = xml_document(@foo._(root_module_filename(@foo)))
-        doc.should_not have_xpath("/module/component[@name='NewModuleRootManager']/content")
+        expect(doc).not_to have_xpath("/module/component[@name='NewModuleRootManager']/content")
       end
     end
 
@@ -1544,15 +1544,15 @@ describe Buildr::IntellijIdea do
       end
 
       it "generate an IML with content section" do
-        root_module_xml(@foo).should have_xpath("/module/component[@name='NewModuleRootManager']/content")
+        expect(root_module_xml(@foo)).to have_xpath("/module/component[@name='NewModuleRootManager']/content")
       end
 
       it "generate an exclude in content section for reports" do
-        root_module_xml(@foo).should have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/reports']")
+        expect(root_module_xml(@foo)).to have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/reports']")
       end
 
       it "generate an exclude in content section for target" do
-        root_module_xml(@foo).should have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/target']")
+        expect(root_module_xml(@foo)).to have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/target']")
       end
     end
 
@@ -1568,11 +1568,11 @@ describe Buildr::IntellijIdea do
       end
 
       it "generates the correct source directories" do
-        @bar_doc.should have_xpath("//content/sourceFolder[@url='file://$MODULE_DIR$/src/main/bar']")
+        expect(@bar_doc).to have_xpath("//content/sourceFolder[@url='file://$MODULE_DIR$/src/main/bar']")
       end
 
       it "generates the correct exclude directories" do
-        @bar_doc.should have_xpath("//content/excludeFolder[@url='file://$MODULE_DIR$/target']")
+        expect(@bar_doc).to have_xpath("//content/excludeFolder[@url='file://$MODULE_DIR$/target']")
       end
     end
 
@@ -1587,11 +1587,11 @@ describe Buildr::IntellijIdea do
       end
 
       it "generates the correct main source directories" do
-        root_module_xml(@foo).should have_xpath("//content/sourceFolder[@url='file://$MODULE_DIR$/src/main/baz' && @isTestSource='false']")
+        expect(root_module_xml(@foo)).to have_xpath("//content/sourceFolder[@url='file://$MODULE_DIR$/src/main/baz' && @isTestSource='false']")
       end
 
       it "generates the correct test source directories" do
-        root_module_xml(@foo).should have_xpath("//content/sourceFolder[@url='file://$MODULE_DIR$/src/test/foo' && @isTestSource='true']")
+        expect(root_module_xml(@foo)).to have_xpath("//content/sourceFolder[@url='file://$MODULE_DIR$/src/test/foo' && @isTestSource='true']")
       end
     end
 
@@ -1606,11 +1606,11 @@ describe Buildr::IntellijIdea do
       end
 
       it "generate an exclude in content section for target" do
-        root_module_xml(@foo).should have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/target']")
+        expect(root_module_xml(@foo)).to have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/target']")
       end
 
       it "generates an content section without an exclude for report dir" do
-        root_module_xml(@foo).should have_nodes("/module/component[@name='NewModuleRootManager']/content/excludeFolder", 1)
+        expect(root_module_xml(@foo)).to have_nodes("/module/component[@name='NewModuleRootManager']/content/excludeFolder", 1)
       end
     end
 
@@ -1626,11 +1626,11 @@ describe Buildr::IntellijIdea do
       end
 
       it "generate an exclude in content section for reports" do
-        root_module_xml(@foo).should have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/reports']")
+        expect(root_module_xml(@foo)).to have_xpath("/module/component[@name='NewModuleRootManager']/content/excludeFolder[@url='file://$MODULE_DIR$/reports']")
       end
 
       it "generates an content section without an exclude for target dir" do
-        root_module_xml(@foo).should have_nodes("/module/component[@name='NewModuleRootManager']/content/excludeFolder", 1)
+        expect(root_module_xml(@foo)).to have_nodes("/module/component[@name='NewModuleRootManager']/content/excludeFolder", 1)
       end
     end
 
@@ -1754,12 +1754,12 @@ PROJECT_XML
         end
 
         it "replaces ProjectModuleManager component in existing ipr file" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_generated_xpath)
-          xml_document(@foo._("foo.ipr")).should_not have_xpath(ipr_from_existing_shadowing_generated_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_generated_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).not_to have_xpath(ipr_from_existing_shadowing_generated_xpath)
         end
 
         it "merges component in existing ipr file" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_existing_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_existing_xpath)
         end
 
         def iml_from_generated_xpath
@@ -1767,12 +1767,12 @@ PROJECT_XML
         end
 
         it "replaces NewModuleRootManager component in existing iml file" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_generated_xpath)
-          xml_document(@foo._("foo.iml")).should_not have_xpath(iml_from_existing_shadowing_generated_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_generated_xpath)
+          expect(xml_document(@foo._("foo.iml"))).not_to have_xpath(iml_from_existing_shadowing_generated_xpath)
         end
 
         it "merges component in existing iml file" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_existing_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_existing_xpath)
         end
       end
 
@@ -1789,11 +1789,11 @@ PROJECT_XML
         end
 
         it "replaces generated components" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_generated_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_generated_xpath)
         end
 
         it "merges component in iml template" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_template_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_template_xpath)
         end
       end
 
@@ -1811,17 +1811,17 @@ PROJECT_XML
         end
 
         it "replaces generated components" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_generated_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_generated_xpath)
         end
 
         it "merges component in iml template" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_template_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_template_xpath)
         end
 
         it "merges components not in iml template and not generated by task" do
-          xml_document(@foo._("foo.iml")).should have_xpath(iml_from_existing_xpath)
-          xml_document(@foo._("foo.iml")).should_not have_xpath(iml_from_existing_shadowing_template_xpath)
-          xml_document(@foo._("foo.iml")).should_not have_xpath(iml_from_existing_shadowing_generated_xpath)
+          expect(xml_document(@foo._("foo.iml"))).to have_xpath(iml_from_existing_xpath)
+          expect(xml_document(@foo._("foo.iml"))).not_to have_xpath(iml_from_existing_shadowing_template_xpath)
+          expect(xml_document(@foo._("foo.iml"))).not_to have_xpath(iml_from_existing_shadowing_generated_xpath)
         end
       end
 
@@ -1838,11 +1838,11 @@ PROJECT_XML
         end
 
         it "replaces generated component in ipr template" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_generated_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_generated_xpath)
         end
 
         it "merges component in ipr template" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_template_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_template_xpath)
         end
       end
 
@@ -1860,17 +1860,17 @@ PROJECT_XML
         end
 
         it "replaces generated component in ipr template" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_generated_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_generated_xpath)
         end
 
         it "merges component in ipr template" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_template_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_template_xpath)
         end
 
         it "merges components not in ipr template and not generated by task" do
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_existing_xpath)
-          xml_document(@foo._("foo.ipr")).should_not have_xpath(ipr_from_existing_shadowing_generated_xpath)
-          xml_document(@foo._("foo.ipr")).should have_xpath(ipr_from_existing_shadowing_template_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_existing_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).not_to have_xpath(ipr_from_existing_shadowing_generated_xpath)
+          expect(xml_document(@foo._("foo.ipr"))).to have_xpath(ipr_from_existing_shadowing_template_xpath)
         end
       end
     end
@@ -1884,11 +1884,11 @@ PROJECT_XML
       end
 
       it "has correct default iml.type setting" do
-        @foo.iml.type.should == "JAVA_MODULE"
+        expect(@foo.iml.type).to eq("JAVA_MODULE")
       end
 
       it "has correct default iml.local_repository_env_override setting" do
-        @foo.iml.local_repository_env_override.should == "MAVEN_REPOSITORY"
+        expect(@foo.iml.local_repository_env_override).to eq("MAVEN_REPOSITORY")
       end
     end
 
@@ -1904,14 +1904,14 @@ PROJECT_XML
 
       it "generates root IML with specified type" do
         module_file = root_module_filename(@foo)
-        File.should be_exist(module_file)
-        File.read(module_file).should =~ /FOO_MODULE_TYPE/
+        expect(File).to be_exist(module_file)
+        expect(File.read(module_file)).to match(/FOO_MODULE_TYPE/)
       end
 
       it "generates subproject IML with inherited type" do
         module_file = subproject_module_filename(@foo, "bar")
-        File.should be_exist(module_file)
-        File.read(module_file).should =~ /FOO_MODULE_TYPE/
+        expect(File).to be_exist(module_file)
+        expect(File.read(module_file)).to match(/FOO_MODULE_TYPE/)
       end
 
     end
@@ -1926,7 +1926,7 @@ PROJECT_XML
           end
 
           it "generates relative paths correctly" do
-            @foo.iml.send(:resolve_path, "E:/foo").should eql('E:/foo')
+            expect(@foo.iml.send(:resolve_path, "E:/foo")).to eql('E:/foo')
           end
         end
 
@@ -1938,7 +1938,7 @@ PROJECT_XML
           end
 
           it "generates relative paths correctly" do
-            @foo.iml.send(:resolve_path, "C:/foo").should eql('$MODULE_DIR$/../foo')
+            expect(@foo.iml.send(:resolve_path, "C:/foo")).to eql('$MODULE_DIR$/../foo')
           end
         end
       end
@@ -1947,19 +1947,19 @@ PROJECT_XML
 
   describe "project extension" do
     it "provides an 'idea' task" do
-      Rake::Task.tasks.detect { |task| task.to_s == "idea" }.should_not be_nil
+      expect(Rake::Task.tasks.detect { |task| task.to_s == "idea" }).not_to be_nil
     end
 
     it "documents the 'idea' task" do
-      Rake::Task.tasks.detect { |task| task.to_s == "idea" }.comment.should_not be_nil
+      expect(Rake::Task.tasks.detect { |task| task.to_s == "idea" }.comment).not_to be_nil
     end
 
     it "provides an 'idea:clean' task" do
-      Rake::Task.tasks.detect { |task| task.to_s == "idea:clean" }.should_not be_nil
+      expect(Rake::Task.tasks.detect { |task| task.to_s == "idea:clean" }).not_to be_nil
     end
 
     it "documents the 'idea:clean' task" do
-      Rake::Task.tasks.detect { |task| task.to_s == "idea:clean" }.comment.should_not be_nil
+      expect(Rake::Task.tasks.detect { |task| task.to_s == "idea:clean" }.comment).not_to be_nil
     end
 
     describe "#no_iml" do
@@ -1967,7 +1967,7 @@ PROJECT_XML
         @foo = define "foo" do
           project.no_iml
         end
-        @foo.iml?.should be_false
+        expect(@foo.iml?).to be_falsey
       end
     end
 
@@ -1986,22 +1986,22 @@ PROJECT_XML
       end
 
       it "inherits the direct parent's IML settings" do
-        project('foo:bar:baz').iml.suffix.should == "-mid"
+        expect(project('foo:bar:baz').iml.suffix).to eq("-mid")
       end
 
       it "does not modify the parent's IML settings" do
-        project('foo').iml.suffix.should == "-top"
+        expect(project('foo').iml.suffix).to eq("-top")
       end
 
       it "works even when the parent has no IML" do
-        lambda {
+        expect {
           define "a" do
             project.no_iml
             define "b" do
               iml.suffix = "-alone"
             end
           end
-        }.should_not raise_error
+        }.not_to raise_error
       end
 
       it "inherits from the first ancestor which has an IML" do
@@ -2023,7 +2023,7 @@ PROJECT_XML
           end
         end
 
-        project("a:b:c:d:e:f").iml.suffix.should == "-b"
+        expect(project("a:b:c:d:e:f").iml.suffix).to eq("-b")
       end
     end
   end

--- a/spec/java/ant_spec.rb
+++ b/spec/java/ant_spec.rb
@@ -23,15 +23,15 @@ describe Buildr::Ant do
     begin
       Buildr::Ant.instance_eval { @dependencies = nil }
       write 'build.yaml', 'ant: 1.2.3'
-      Buildr::Ant.dependencies.should include("org.apache.ant:ant:jar:1.2.3")
+      expect(Buildr::Ant.dependencies).to include("org.apache.ant:ant:jar:1.2.3")
     ensure
       Buildr::Ant.instance_eval { @dependencies = nil }
     end
   end
 
   it 'should have REQUIRES up to version 1.5 since it was deprecated in version 1.3.3' do
-    Buildr::VERSION.should < '1.5'
-    lambda { Ant::REQUIRES }.should_not raise_error
+    expect(Buildr::VERSION).to be < '1.5'
+    expect { Ant::REQUIRES }.not_to raise_error
   end
 
 end

--- a/spec/java/bdd_spec.rb
+++ b/spec/java/bdd_spec.rb
@@ -24,7 +24,7 @@ describe Buildr::RSpec do
   end
 
   it 'should be selected by :rspec name' do
-    project('foo').test.framework.should eql(:rspec)
+    expect(project('foo').test.framework).to eql(:rspec)
   end
 
   # These tests will fail because they expect that a version of rspec will be present in the local gem
@@ -35,7 +35,7 @@ describe Buildr::RSpec do
       write('src/spec/ruby/success_spec.rb', 'describe("success") { it("is true") { nil.should be_nil } }')
 
       project('foo').test.invoke
-      project('foo').test.passed_tests.should eql([File.expand_path('src/spec/ruby/success_spec.rb')])
+      expect(project('foo').test.passed_tests).to eql([File.expand_path('src/spec/ruby/success_spec.rb')])
     end
 
     it 'should read result yaml to obtain the list of failed specs' do
@@ -46,10 +46,10 @@ describe Buildr::RSpec do
       error = File.expand_path('src/spec/ruby/error_spec.rb')
       write(error, 'describe("error") { it("raises") { lambda; } }')
 
-      lambda { project('foo').test.invoke }.should raise_error(/Tests failed/)
-      project('foo').test.tests.should include(success, failure, error)
-      project('foo').test.failed_tests.sort.should eql([failure, error].sort)
-      project('foo').test.passed_tests.should eql([success])
+      expect { project('foo').test.invoke }.to raise_error(/Tests failed/)
+      expect(project('foo').test.tests).to include(success, failure, error)
+      expect(project('foo').test.failed_tests.sort).to eql([failure, error].sort)
+      expect(project('foo').test.passed_tests).to eql([success])
     end
   end
 
@@ -70,37 +70,37 @@ describe Buildr::JBehave do
   it 'should apply to projects having JBehave sources' do
     define('one', :base_dir => 'one') do
       write _('src/spec/java/SomeBehaviour.java'), 'public class SomeBehaviour {}'
-      JBehave.applies_to?(self).should be_true
+      expect(JBehave.applies_to?(self)).to be_truthy
     end
     define('two', :base_dir => 'two') do
       write _('src/test/java/SomeBehaviour.java'), 'public class SomeBehaviour {}'
-      JBehave.applies_to?(self).should be_false
+      expect(JBehave.applies_to?(self)).to be_falsey
     end
     define('three', :base_dir => 'three') do
       write _('src/spec/java/SomeBehavior.java'), 'public class SomeBehavior {}'
-      JBehave.applies_to?(self).should be_true
+      expect(JBehave.applies_to?(self)).to be_truthy
     end
     define('four', :base_dir => 'four') do
       write _('src/test/java/SomeBehavior.java'), 'public class SomeBehavior {}'
-      JBehave.applies_to?(self).should be_false
+      expect(JBehave.applies_to?(self)).to be_falsey
     end
   end
 
   it 'should be selected by :jbehave name' do
-    foo { test.framework.should eql(:jbehave) }
+    foo { expect(test.framework).to eql(:jbehave) }
   end
 
   it 'should select a java compiler for its sources' do
     write 'src/test/java/SomeBehavior.java', 'public class SomeBehavior {}'
     foo do
-      test.compile.language.should eql(:java)
+      expect(test.compile.language).to eql(:java)
     end
   end
 
   it 'should include JBehave dependencies' do
     foo do
-      test.compile.dependencies.should include(artifact("org.jbehave:jbehave:jar::#{JBehave.version}"))
-      test.dependencies.should include(artifact("org.jbehave:jbehave:jar::#{JBehave.version}"))
+      expect(test.compile.dependencies).to include(artifact("org.jbehave:jbehave:jar::#{JBehave.version}"))
+      expect(test.dependencies).to include(artifact("org.jbehave:jbehave:jar::#{JBehave.version}"))
     end
   end
 
@@ -108,8 +108,8 @@ describe Buildr::JBehave do
     foo do
       two_or_later = JMock.version[0,1].to_i >= 2
       group = two_or_later ? "org.jmock" : "jmock"
-      test.compile.dependencies.should include(artifact("#{group}:jmock:jar:#{JMock.version}"))
-      test.dependencies.should include(artifact("#{group}:jmock:jar:#{JMock.version}"))
+      expect(test.compile.dependencies).to include(artifact("#{group}:jmock:jar:#{JMock.version}"))
+      expect(test.dependencies).to include(artifact("#{group}:jmock:jar:#{JMock.version}"))
     end
   end
 
@@ -126,7 +126,7 @@ describe Buildr::JBehave do
     JAVA
     foo.tap do |project|
       project.test.invoke
-      project.test.tests.should include('some.FooBehavior')
+      expect(project.test.tests).to include('some.FooBehavior')
     end
   end
 
@@ -153,7 +153,7 @@ describe Buildr::JBehave do
     JAVA
     foo.tap do |project|
       project.test.invoke
-      project.test.tests.should include('some.MyBehaviours')
+      expect(project.test.tests).to include('some.MyBehaviours')
     end
   end
 

--- a/spec/java/cobertura_spec.rb
+++ b/spec/java/cobertura_spec.rb
@@ -35,19 +35,19 @@ describe Buildr::Cobertura do
 
     describe 'data file' do
       it 'should have a default value' do
-        define('foo').cobertura.data_file.should point_to_path('reports/cobertura.ser')
+        expect(define('foo').cobertura.data_file).to point_to_path('reports/cobertura.ser')
       end
 
       it 'should be overridable' do
         define('foo') { cobertura.data_file = path_to('target/data.cobertura') }
-        project('foo').cobertura.data_file.should point_to_path('target/data.cobertura')
+        expect(project('foo').cobertura.data_file).to point_to_path('target/data.cobertura')
       end
 
       it 'should be created during instrumentation' do
         write 'src/main/java/Foo.java', 'public class Foo {}'
         define('foo')
         task('foo:cobertura:instrument').invoke
-        file(project('foo').cobertura.data_file).should exist
+        expect(file(project('foo').cobertura.data_file)).to exist
       end
 
       it 'should not instrument projects which have no sources' do
@@ -70,20 +70,20 @@ describe Buildr::Cobertura do
       it 'should instrument only included classes' do
         define('foo') { cobertura.include 'Foo' }
         task("foo:cobertura:instrument").invoke
-        Dir.chdir('target/instrumented/classes') { Dir.glob('*').sort.should == ['Foo.class'] }
+        Dir.chdir('target/instrumented/classes') { expect(Dir.glob('*').sort).to eq(['Foo.class']) }
       end
 
       it 'should not instrument excluded classes' do
         define('foo') { cobertura.exclude 'Foo' }
         task("foo:cobertura:instrument").invoke
-        Dir.chdir('target/instrumented/classes') { Dir.glob('*').sort.should == ['Bar.class'] }
+        Dir.chdir('target/instrumented/classes') { expect(Dir.glob('*').sort).to eq(['Bar.class']) }
       end
 
       it 'should instrument classes that are included but not excluded' do
         write 'src/main/java/Baz.java', 'public class Baz {}'
         define('foo') { cobertura.include('Ba').exclude('ar') }
         task("foo:cobertura:instrument").invoke
-        Dir.chdir('target/instrumented/classes') { Dir.glob('*').sort.should == ['Baz.class'] }
+        Dir.chdir('target/instrumented/classes') { expect(Dir.glob('*').sort).to eq(['Baz.class']) }
       end
     end
 
@@ -106,7 +106,7 @@ JAVA
 
       it 'should not raise errors during execution' do
         define('foo')  { cobertura.include 'Foo' }
-        lambda {task("foo:cobertura:check").invoke}.should_not raise_error
+        expect {task("foo:cobertura:check").invoke}.not_to raise_error
       end
 
     end

--- a/spec/java/commands_spec.rb
+++ b/spec/java/commands_spec.rb
@@ -27,50 +27,50 @@ describe Java::Commands do
         <target name="dist"/>
     </project>
 BUILD
-    lambda { Java::Commands.java("org.apache.tools.ant.Main", :classpath => Buildr::Ant.dependencies) }.should_not show_info(/java/)
-    lambda { Java::Commands.java("org.apache.tools.ant.Main", :classpath => Buildr::Ant.dependencies, :verbose => true) }.should show_info(/java/)
+    expect { Java::Commands.java("org.apache.tools.ant.Main", :classpath => Buildr::Ant.dependencies) }.not_to show_info(/java/)
+    expect { Java::Commands.java("org.apache.tools.ant.Main", :classpath => Buildr::Ant.dependencies, :verbose => true) }.to show_info(/java/)
   end
 
   describe "Java::Commands.javac" do
 
     it "should compile java" do
       write "Foo.java", "public class Foo {}"
-      lambda { Java::Commands.javac("Foo.java") }.should change {File.exist?("Foo.class")}.to(true)
+      expect { Java::Commands.javac("Foo.java") }.to change {File.exist?("Foo.class")}.to(true)
     end
 
     it 'should let the user specify an output directory' do
       write "Foo.java", "public class Foo {}"
-      lambda { Java::Commands.javac("Foo.java", :output => "classes") }.should change {File.exist?("classes/Foo.class")}.to(true)
+      expect { Java::Commands.javac("Foo.java", :output => "classes") }.to change {File.exist?("classes/Foo.class")}.to(true)
     end
 
     it "should let the user specify a different name" do
       write "Foo.java", "public class Foo {}"
-      lambda { Java::Commands.javac("Foo.java", :name => "bar") }.should show_info("Compiling 1 source files in bar")
+      expect { Java::Commands.javac("Foo.java", :name => "bar") }.to show_info("Compiling 1 source files in bar")
     end
 
     it "should let the user specify a source path" do
       write "ext/org/Bar.java", "package org; public class Bar {}"
       write "Foo.java", "import org.Bar;\n public class Foo {}"
-      lambda { Java::Commands.javac("Foo.java", :sourcepath => File.expand_path("ext")) }.should change {File.exist?("Foo.class")}.to(true)
+      expect { Java::Commands.javac("Foo.java", :sourcepath => File.expand_path("ext")) }.to change {File.exist?("Foo.class")}.to(true)
     end
 
     it "should let the user specify a classpath" do
       write "ext/org/Bar.java", "package org; public class Bar {}"
       Java::Commands.javac("ext/org/Bar.java", :output => "lib")
       write "Foo.java", "import org.Bar;\n public class Foo {}"
-      lambda { Java::Commands.javac("Foo.java", :classpath => File.expand_path("lib")) }.should change {File.exist?("Foo.class")}.to(true)
+      expect { Java::Commands.javac("Foo.java", :classpath => File.expand_path("lib")) }.to change {File.exist?("Foo.class")}.to(true)
     end
   end
 
   describe "Java::Commands.javadoc" do
 
     it "should fail if no output is defined" do
-      lambda { Java::Commands.javadoc("Foo.java") }.should raise_error(/No output defined for javadoc/)
+      expect { Java::Commands.javadoc("Foo.java") }.to raise_error(/No output defined for javadoc/)
     end
 
     it "should create javadoc" do
       write "Foo.java", "public class Foo {}"
-      lambda { Java::Commands.javadoc("Foo.java", :output => "doc") }.should change {File.exist?("doc/Foo.html")}.to(true)
+      expect { Java::Commands.javadoc("Foo.java", :output => "doc") }.to change {File.exist?("doc/Foo.html")}.to(true)
     end
 
     it "should accept file tasks as arguments" do
@@ -79,7 +79,7 @@ BUILD
           write file.to_s, "public class Foo {}"
         end
       end
-      lambda { Java::Commands.javadoc(foo, :output => "doc") }.should change {File.exist?("doc/Foo.html")}.to(true)
+      expect { Java::Commands.javadoc(foo, :output => "doc") }.to change {File.exist?("doc/Foo.html")}.to(true)
     end
 
     it "should accept projects as arguments" do
@@ -87,7 +87,7 @@ BUILD
       write "src/main/java/bar/Foobar.java", "package bar; public class Foobar {}"
       define "foo" do
       end
-      lambda { Java::Commands.javadoc(project("foo"), :output => "doc") }.should change {File.exist?("doc/Foo.html") && File.exist?("doc/bar/Foobar.html")}.to(true)
+      expect { Java::Commands.javadoc(project("foo"), :output => "doc") }.to change {File.exist?("doc/Foo.html") && File.exist?("doc/bar/Foobar.html")}.to(true)
     end
   end
 end

--- a/spec/java/compiler_spec.rb
+++ b/spec/java/compiler_spec.rb
@@ -20,7 +20,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers')
 describe 'javac compiler' do
   it 'should identify itself from source directories' do
     write 'src/main/java/com/example/Test.java', 'package com.example; class Test {}'
-    define('foo').compile.compiler.should eql(:javac)
+    expect(define('foo').compile.compiler).to eql(:javac)
   end
 
   it 'should identify from source directories using custom layout' do
@@ -30,8 +30,8 @@ describe 'javac compiler' do
     custom[:source, :main, :java] = 'src'
     custom[:source, :test, :java] = 'testing'
     define 'foo', :layout=>custom do
-      compile.compiler.should eql(:javac)
-      test.compile.compiler.should eql(:javac)
+      expect(compile.compiler).to eql(:javac)
+      expect(test.compile.compiler).to eql(:javac)
     end
   end
 
@@ -39,25 +39,25 @@ describe 'javac compiler' do
     write 'src/com/example/Code.java', 'package com.example; class Code {}'
     write 'testing/com/example/Test.java', 'package com.example; class Test {}'
     define 'foo' do
-      lambda { compile.from 'src' }.should change { compile.compiler }.to(:javac)
-      lambda { test.compile.from 'testing' }.should change { test.compile.compiler }.to(:javac)
+      expect { compile.from 'src' }.to change { compile.compiler }.to(:javac)
+      expect { test.compile.from 'testing' }.to change { test.compile.compiler }.to(:javac)
     end
   end
 
   it 'should report the language as :java' do
-    define('foo').compile.using(:javac).language.should eql(:java)
+    expect(define('foo').compile.using(:javac).language).to eql(:java)
   end
 
   it 'should set the target directory to target/classes' do
     define 'foo' do
-      lambda { compile.using(:javac) }.should change { compile.target.to_s }.to(File.expand_path('target/classes'))
+      expect { compile.using(:javac) }.to change { compile.target.to_s }.to(File.expand_path('target/classes'))
     end
   end
 
   it 'should not override existing target directory' do
     define 'foo' do
       compile.into('classes')
-      lambda { compile.using(:javac) }.should_not change { compile.target }
+      expect { compile.using(:javac) }.not_to change { compile.target }
     end
   end
 
@@ -74,13 +74,13 @@ describe 'javac compiler' do
       compile.from(f)
       package(:jar)
     end.compile.invoke
-    file('target/classes/Foo.class').should exist
+    expect(file('target/classes/Foo.class')).to exist
   end
 
   it 'should not change existing list of sources' do
     define 'foo' do
       compile.from('sources')
-      lambda { compile.using(:javac) }.should_not change { compile.sources }
+      expect { compile.using(:javac) }.not_to change { compile.sources }
     end
   end
 
@@ -94,7 +94,7 @@ describe 'javac compiler' do
       end
       write 'src/test/DependencyTest.java', 'class DependencyTest { Dependency _var; }'
       define('foo').compile.from('src/test').with(project('dependency')).invoke
-      file('target/classes/DependencyTest.class').should exist
+      expect(file('target/classes/DependencyTest.class')).to exist
     end
   end
 
@@ -104,14 +104,14 @@ describe 'javac compiler' do
       public class UseApt { }
     JAVA
     define('foo').compile.invoke
-    file('target/classes/UseApt.class').should exist
+    expect(file('target/classes/UseApt.class')).to exist
   end
 
   it 'should ignore package-info.java files in up-to-date check' do
     write 'src/main/java/foo/Test.java', 'package foo; class Test { public void foo() {} }'
     write 'src/main/java/foo/package-info.java', 'package foo;'
-    lambda{ define('foo').compile.invoke }.should run_task('foo:compile')
-    lambda{ define('bar').compile.invoke }.should_not run_task('bar:compile')
+    expect{ define('foo').compile.invoke }.to run_task('foo:compile')
+    expect{ define('bar').compile.invoke }.not_to run_task('bar:compile')
   end
 end
 
@@ -126,133 +126,133 @@ describe 'javac compiler options' do
   end
 
   it 'should set warnings option to false by default' do
-    compile_task.options.warnings.should be_false
+    expect(compile_task.options.warnings).to be_falsey
   end
 
   it 'should set warnings option to true when running with --verbose option' do
     verbose true
-    compile_task.options.warnings.should be_false
+    expect(compile_task.options.warnings).to be_falsey
   end
 
   it 'should use -nowarn argument when warnings is false' do
     compile_task.using(:warnings=>false)
-    javac_args.should include('-nowarn')
+    expect(javac_args).to include('-nowarn')
   end
 
   it 'should not use -nowarn argument when warnings is true' do
     compile_task.using(:warnings=>true)
-    javac_args.should_not include('-nowarn')
+    expect(javac_args).not_to include('-nowarn')
   end
 
   it 'should not use -verbose argument by default' do
-    javac_args.should_not include('-verbose')
+    expect(javac_args).not_to include('-verbose')
   end
 
   it 'should use -verbose argument when running with --trace=javac option' do
     Buildr.application.options.trace_categories = [:javac]
-    javac_args.should include('-verbose')
+    expect(javac_args).to include('-verbose')
   end
 
   it 'should set debug option to true by default' do
-    compile_task.options.debug.should be_true
+    expect(compile_task.options.debug).to be_truthy
   end
 
   it 'should set debug option to false based on Buildr.options' do
     Buildr.options.debug = false
-    compile_task.options.debug.should be_false
+    expect(compile_task.options.debug).to be_falsey
   end
 
   it 'should set debug option to false based on debug environment variable' do
     ENV['debug'] = 'no'
-    compile_task.options.debug.should be_false
+    expect(compile_task.options.debug).to be_falsey
   end
 
   it 'should set debug option to false based on DEBUG environment variable' do
     ENV['DEBUG'] = 'no'
-    compile_task.options.debug.should be_false
+    expect(compile_task.options.debug).to be_falsey
   end
 
   it 'should use -g argument when debug option is true' do
     compile_task.using(:debug=>true)
-    javac_args.should include('-g')
+    expect(javac_args).to include('-g')
   end
 
   it 'should not use -g argument when debug option is false' do
     compile_task.using(:debug=>false)
-    javac_args.should_not include('-g')
+    expect(javac_args).not_to include('-g')
   end
 
   it 'should set deprecation option to false by default' do
-    compile_task.options.deprecation.should be_false
+    expect(compile_task.options.deprecation).to be_falsey
   end
 
   it 'should use -deprecation argument when deprecation is true' do
     compile_task.using(:deprecation=>true)
-    javac_args.should include('-deprecation')
+    expect(javac_args).to include('-deprecation')
   end
 
   it 'should not use -deprecation argument when deprecation is false' do
     compile_task.using(:deprecation=>false)
-    javac_args.should_not include('-deprecation')
+    expect(javac_args).not_to include('-deprecation')
   end
 
   it 'should not set source option by default' do
-    compile_task.options.source.should be_nil
-    javac_args.should_not include('-source')
+    expect(compile_task.options.source).to be_nil
+    expect(javac_args).not_to include('-source')
   end
 
   it 'should not set target option by default' do
-    compile_task.options.target.should be_nil
-    javac_args.should_not include('-target')
+    expect(compile_task.options.target).to be_nil
+    expect(javac_args).not_to include('-target')
   end
 
   it 'should use -source nn argument if source option set' do
     compile_task.using(:source=>'1.5')
-    javac_args.should include('-source', '1.5')
+    expect(javac_args).to include('-source', '1.5')
   end
 
   it 'should use -target nn argument if target option set' do
     compile_task.using(:target=>'1.5')
-    javac_args.should include('-target', '1.5')
+    expect(javac_args).to include('-target', '1.5')
   end
 
   it 'should set lint option to false by default' do
-    compile_task.options.lint.should be_false
+    expect(compile_task.options.lint).to be_falsey
   end
 
   it 'should use -lint argument if lint option is true' do
     compile_task.using(:lint=>true)
-    javac_args.should include('-Xlint')
+    expect(javac_args).to include('-Xlint')
   end
 
   it 'should use -lint argument with value of option' do
     compile_task.using(:lint=>'all')
-    javac_args.should include('-Xlint:all')
+    expect(javac_args).to include('-Xlint:all')
   end
 
   it 'should use -lint argument with value of option as array' do
     compile_task.using(:lint=>['path', 'serial'])
-    javac_args.should include('-Xlint:path,serial')
+    expect(javac_args).to include('-Xlint:path,serial')
   end
 
   it 'should not set other option by default' do
-    compile_task.options.other.should be_nil
+    expect(compile_task.options.other).to be_nil
   end
 
   it 'should pass other argument if other option is string' do
     compile_task.using(:other=>'-Xprint')
-    javac_args.should include('-Xprint')
+    expect(javac_args).to include('-Xprint')
   end
 
   it 'should pass other argument if other option is array' do
     compile_task.using(:other=>['-Xstdout', 'msgs'])
-    javac_args.should include('-Xstdout', 'msgs')
+    expect(javac_args).to include('-Xstdout', 'msgs')
   end
 
   it 'should complain about options it doesn\'t know' do
     write 'source/Test.java', 'class Test {}'
     compile_task.using(:unknown=>'option')
-    lambda { compile_task.from('source').invoke }.should raise_error(ArgumentError, /no such option/i)
+    expect { compile_task.from('source').invoke }.to raise_error(ArgumentError, /no such option/i)
   end
 
   it 'should inherit options from parent' do
@@ -260,11 +260,11 @@ describe 'javac compiler options' do
       compile.using(:warnings=>true, :debug=>true, :deprecation=>true, :source=>'1.5', :target=>'1.4')
       define 'bar' do
         compile.using(:javac)
-        compile.options.warnings.should be_true
-        compile.options.debug.should be_true
-        compile.options.deprecation.should be_true
-        compile.options.source.should eql('1.5')
-        compile.options.target.should eql('1.4')
+        expect(compile.options.warnings).to be_truthy
+        expect(compile.options.debug).to be_truthy
+        expect(compile.options.deprecation).to be_truthy
+        expect(compile.options.source).to eql('1.5')
+        expect(compile.options.target).to eql('1.4')
       end
     end
   end

--- a/spec/java/doc_spec.rb
+++ b/spec/java/doc_spec.rb
@@ -32,8 +32,8 @@ describe 'Javadoc' do
       end
     end
 
-    project('foo').doc.options[:windowtitle].should eql('foo')
-    project('foo:bar').doc.options[:windowtitle].should eql('foo:bar')
+    expect(project('foo').doc.options[:windowtitle]).to eql('foo')
+    expect(project('foo:bar').doc.options[:windowtitle]).to eql('foo:bar')
   end
 
   it 'should pick -windowtitle from project description by default, if available' do
@@ -41,7 +41,7 @@ describe 'Javadoc' do
     define 'foo' do
       compile.using(:javac)
     end
-    project('foo').doc.options[:windowtitle].should eql('My App')
+    expect(project('foo').doc.options[:windowtitle]).to eql('My App')
   end
 
   it 'should not override explicit :windowtitle' do
@@ -49,7 +49,7 @@ describe 'Javadoc' do
       compile.using(:javac)
       doc.using :windowtitle => 'explicit'
     end
-    project('foo').doc.options[:windowtitle].should eql('explicit')
+    expect(project('foo').doc.options[:windowtitle]).to eql('explicit')
   end
 
 end

--- a/spec/java/ecj_spec.rb
+++ b/spec/java/ecj_spec.rb
@@ -40,7 +40,7 @@ describe Buildr::Compiler::Ecj do
     it "should be the default Java compiler once loaded" do
       write 'src/main/java/Foo.java', 'public class Foo {}'
     foo = define('foo')
-    foo.compile.compiler.should == :ecj
+    expect(foo.compile.compiler).to eq(:ecj)
   end
 
   describe "should compile a Java project just in the same way javac does" do
@@ -55,7 +55,7 @@ describe Buildr::Compiler::Ecj do
   # and returning the content of the error buffer.
   #
   def redirect_java_err
-    pending "RJB doesn't support well instantiating a class that has several constructors" unless RUBY_PLATFORM =~ /java/
+    skip "RJB doesn't support well instantiating a class that has several constructors" unless RUBY_PLATFORM =~ /java/
     err = Java.java.io.ByteArrayOutputStream.new
     original_err = Java.java.lang.System.err
     begin
@@ -75,7 +75,7 @@ describe Buildr::Compiler::Ecj do
       compile.options.source = "1.5"
       compile.options.target = "1.5"
     }
-    redirect_java_err { foo.compile.invoke }.should_not match(/WARNING/)
+    expect(redirect_java_err { foo.compile.invoke }).not_to match(/WARNING/)
   end
 
   it "should issue warnings for type casting when warnings are set" do
@@ -85,7 +85,7 @@ describe Buildr::Compiler::Ecj do
       compile.options.target = "1.5"
       compile.options.warnings = true
     }
-    redirect_java_err { foo.compile.invoke }.should match(/WARNING/)
+    expect(redirect_java_err { foo.compile.invoke }).to match(/WARNING/)
   end
 
   after(:all) do

--- a/spec/java/emma_spec.rb
+++ b/spec/java/emma_spec.rb
@@ -35,30 +35,30 @@ describe Buildr::Emma do
   describe 'project-specific' do
     describe 'metadata file' do
       it 'should have a default value' do
-        define('foo').emma.metadata_file.should point_to_path('reports/emma/coverage.em')
+        expect(define('foo').emma.metadata_file).to point_to_path('reports/emma/coverage.em')
       end
 
       it 'should be overridable' do
         define('foo') { emma.metadata_file = path_to('target/metadata.emma') }
-        project('foo').emma.metadata_file.should point_to_path('target/metadata.emma')
+        expect(project('foo').emma.metadata_file).to point_to_path('target/metadata.emma')
       end
 
       it 'should be created during instrumentation' do
         write 'src/main/java/Foo.java', 'public class Foo {}'
         define('foo')
         task('foo:emma:instrument').invoke
-        file(project('foo').emma.metadata_file).should exist
+        expect(file(project('foo').emma.metadata_file)).to exist
       end
     end
 
     describe 'coverage file' do
       it 'should have a default value' do
-        define('foo').emma.coverage_file.should point_to_path('reports/emma/coverage.ec')
+        expect(define('foo').emma.coverage_file).to point_to_path('reports/emma/coverage.ec')
       end
 
       it 'should be overridable' do
         define('foo') { emma.coverage_file = path_to('target/coverage.emma') }
-        project('foo').emma.coverage_file.should point_to_path('target/coverage.emma')
+        expect(project('foo').emma.coverage_file).to point_to_path('target/coverage.emma')
       end
 
       it 'should be created during test' do
@@ -66,7 +66,7 @@ describe Buildr::Emma do
         write_test :for=>'Foo', :in=>'src/test/java'
         define('foo')
         task('foo:test').invoke
-        file(project('foo').emma.coverage_file).should exist
+        expect(file(project('foo').emma.coverage_file)).to exist
       end
     end
 
@@ -78,20 +78,20 @@ describe Buildr::Emma do
       it 'should instrument only included classes' do
         define('foo') { emma.include 'Foo' }
         task("foo:emma:instrument").invoke
-        Dir.chdir('target/instrumented/classes') { Dir.glob('*').sort.should == ['Foo.class'] }
+        Dir.chdir('target/instrumented/classes') { expect(Dir.glob('*').sort).to eq(['Foo.class']) }
       end
 
       it 'should not instrument excluded classes' do
         define('foo') { emma.exclude 'Foo' }
         task("foo:emma:instrument").invoke
-        Dir.chdir('target/instrumented/classes') { Dir.glob('*').sort.should == ['Bar.class'] }
+        Dir.chdir('target/instrumented/classes') { expect(Dir.glob('*').sort).to eq(['Bar.class']) }
       end
 
       it 'should instrument classes that are included but not excluded' do
         write 'src/main/java/Baz.java', 'public class Baz {}'
         define('foo') { emma.include('Ba*').exclude('*ar') }
         task("foo:emma:instrument").invoke
-        Dir.chdir('target/instrumented/classes') { Dir.glob('*').sort.should == ['Baz.class'] }
+        Dir.chdir('target/instrumented/classes') { expect(Dir.glob('*').sort).to eq(['Baz.class']) }
       end
     end
 
@@ -105,8 +105,8 @@ describe Buildr::Emma do
         it 'should inform the user if no coverage data' do
           rm 'src/test/java/FooTest.java'
           define('foo')
-          lambda { task('foo:emma:html').invoke }.
-            should show_info(/No test coverage report for foo. Missing: #{project('foo').emma.coverage_file}/)
+          expect { task('foo:emma:html').invoke }.
+            to show_info(/No test coverage report for foo. Missing: #{project('foo').emma.coverage_file}/)
         end
       end
 
@@ -114,7 +114,7 @@ describe Buildr::Emma do
         it 'should have an xml file' do
           define('foo')
           task('foo:emma:xml').invoke
-          file(File.join(project('foo').emma.report_dir, 'coverage.xml')).should exist
+          expect(file(File.join(project('foo').emma.report_dir, 'coverage.xml'))).to exist
         end
       end
     end

--- a/spec/java/external_spec.rb
+++ b/spec/java/external_spec.rb
@@ -43,7 +43,7 @@ describe Buildr::Compiler::ExternalJavac do
     end
     begin
       trace true #We set it true to grab the trace statement with the jvm path in it!
-      lambda {lambda {project("foo").compile.invoke}.should raise_error(RuntimeError, /Failed to compile, see errors above/)}.should show(/somepath\/bin\/javac .*/)
+      expect {expect {project("foo").compile.invoke}.to raise_error(RuntimeError, /Failed to compile, see errors above/)}.to show(/somepath\/bin\/javac .*/)
     end
     trace false
   end

--- a/spec/java/java_spec.rb
+++ b/spec/java/java_spec.rb
@@ -22,18 +22,18 @@ unless RUBY_PLATFORM =~ /java/
     before do
       @old_home, ENV['JAVA_HOME'] = ENV['JAVA_HOME'], nil
       @old_env_java = Object.module_eval { remove_const :ENV_JAVA }
-      RbConfig::CONFIG.should_receive(:[]).at_least(:once).with('host_os').and_return('darwin0.9')
+      expect(RbConfig::CONFIG).to receive(:[]).at_least(:once).with('host_os').and_return('darwin0.9')
     end
 
     it 'should point to default JVM' do
       load File.expand_path('../lib/buildr/java/rjb.rb')
-      ENV['JAVA_HOME'].should == '/System/Library/Frameworks/JavaVM.framework/Home'
+      expect(ENV['JAVA_HOME']).to eq('/System/Library/Frameworks/JavaVM.framework/Home')
     end
 
     it 'should use value of environment variable if specified' do
       ENV['JAVA_HOME'] = '/System/Library/Frameworks/JavaVM.specified'
       load File.expand_path('../lib/buildr/java/rjb.rb')
-      ENV['JAVA_HOME'].should == '/System/Library/Frameworks/JavaVM.specified'
+      expect(ENV['JAVA_HOME']).to eq('/System/Library/Frameworks/JavaVM.specified')
     end
 
     after do
@@ -46,7 +46,7 @@ else
     it 'should enforce a minimum version of jruby' do
       check =File.read(File.expand_path('../lib/buildr/java/jruby.rb')).match(/JRUBY_MIN_VERSION.*\n.*JRUBY_MIN_VERSION\n/).to_s
       check.sub!('JRUBY_VERSION', "'0.0.0'")
-      lambda {  eval(check) }.should raise_error(/JRuby must be at least at version /)
+      expect {  eval(check) }.to raise_error(/JRuby must be at least at version /)
     end
   end
 end
@@ -65,7 +65,7 @@ describe 'Java.tools_jar' do
     end
 
     it 'should return the path to tools.jar' do
-      Java.tools_jar.should point_to_path('jdk/lib/tools.jar')
+      expect(Java.tools_jar).to point_to_path('jdk/lib/tools.jar')
     end
   end
 
@@ -77,7 +77,7 @@ describe 'Java.tools_jar' do
     end
 
     it 'should return the path to tools.jar' do
-      Java.tools_jar.should point_to_path('jdk/lib/tools.jar')
+      expect(Java.tools_jar).to point_to_path('jdk/lib/tools.jar')
     end
   end
 
@@ -88,7 +88,7 @@ describe 'Java.tools_jar' do
     end
 
     it 'should return nil' do
-      Java.tools_jar.should be_nil
+      expect(Java.tools_jar).to be_nil
     end
   end
 
@@ -113,7 +113,7 @@ describe 'Java#java' do
         Java.java ['-version']
         fail 'Java.java did not fail with JAVA_HOME pointing to invalid JRE/JDK installation'
       rescue => error
-        error.message.to_s.should match(/JAVA_HOME/)
+        expect(error.message.to_s).to match(/JAVA_HOME/)
       end
     end
   end
@@ -126,7 +126,7 @@ end
 
 describe Java::JavaWrapper do
   it 'should be removed in version 1.5 since it was deprecated in version 1.3' do
-    Buildr::VERSION.should < '1.5'
-    lambda { Java::JavaWrapper }.should_not raise_error
+    expect(Buildr::VERSION).to be < '1.5'
+    expect { Java::JavaWrapper }.not_to raise_error
   end
 end

--- a/spec/java/packaging_spec.rb
+++ b/spec/java/packaging_spec.rb
@@ -21,33 +21,33 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'packaging', 'p
 describe Project, '#manifest' do
   it 'should include user name' do
     ENV['USER'] = 'MysteriousJoe'
-    define('foo').manifest['Build-By'].should eql('MysteriousJoe')
+    expect(define('foo').manifest['Build-By']).to eql('MysteriousJoe')
   end
 
   it 'should include JDK version' do
-    define('foo').manifest['Build-Jdk'].should =~ /^1\.\d+\.\w+$/
+    expect(define('foo').manifest['Build-Jdk']).to match(/^1\.\d+\.\w+$/)
   end
 
   it 'should include project comment' do
     desc 'My Project'
-    define('foo').manifest['Implementation-Title'].should eql('My Project')
+    expect(define('foo').manifest['Implementation-Title']).to eql('My Project')
   end
 
   it 'should include project name if no comment' do
-    define('foo').manifest['Implementation-Title'].should eql('foo')
+    expect(define('foo').manifest['Implementation-Title']).to eql('foo')
   end
 
   it 'should include project version' do
-    define('foo', :version=>'2.1').manifest['Implementation-Version'].should eql('2.1')
+    expect(define('foo', :version=>'2.1').manifest['Implementation-Version']).to eql('2.1')
   end
 
   it 'should not include project version unless specified' do
-    define('foo').manifest['Implementation-Version'].should be_nil
+    expect(define('foo').manifest['Implementation-Version']).to be_nil
   end
 
   it 'should inherit from parent project' do
     define('foo', :version=>'2.1') { define 'bar' }
-    project('foo:bar').manifest['Implementation-Version'].should eql('2.1')
+    expect(project('foo:bar').manifest['Implementation-Version']).to eql('2.1')
   end
 
 end
@@ -76,15 +76,15 @@ shared_examples_for 'package with manifest' do
     ENV['USER'] = 'MysteriousJoe'
     package_with_manifest # Nothing for default.
     inspect_manifest do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main.should == {
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main).to eq({
         'Manifest-Version'        =>'1.0',
         'Created-By'              =>'Buildr',
         'Implementation-Title'    =>@project.name,
         'Implementation-Version'  =>'1.2',
         'Build-Jdk'               =>ENV_JAVA['java.version'],
         'Build-By'                =>'MysteriousJoe'
-      }
+      })
     end
   end
 
@@ -92,7 +92,7 @@ shared_examples_for 'package with manifest' do
     package_with_manifest false
     @project.package(@packaging).invoke
     Zip::File.open(@project.package(@packaging).to_s) do |zip|
-      zip.exist?('META-INF/MANIFEST.MF').should be_false
+      expect(zip.exist?('META-INF/MANIFEST.MF')).to be_falsey
     end
   end
 
@@ -103,7 +103,7 @@ shared_examples_for 'package with manifest' do
     begin
       manifest = Buildr::Packaging::Java::Manifest.from_zip('tmp.zip')
       manifest.each do |key, val|
-        Buildr::Packaging::Java::Manifest::STANDARD_HEADER.should include(key)
+        expect(Buildr::Packaging::Java::Manifest::STANDARD_HEADER).to include(key)
       end
     ensure
       rm 'tmp.zip'
@@ -113,11 +113,11 @@ shared_examples_for 'package with manifest' do
   it 'should map manifest from hash' do
     package_with_manifest 'Foo'=>1, :bar=>'Bar'
     inspect_manifest do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Created-By'].should eql('Buildr')
-      manifest.main['Foo'].should eql('1')
-      manifest.main['bar'].should eql('Bar')
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Created-By']).to eql('Buildr')
+      expect(manifest.main['Foo']).to eql('1')
+      expect(manifest.main['bar']).to eql('Bar')
     end
   end
 
@@ -128,31 +128,31 @@ shared_examples_for 'package with manifest' do
     module AccessManifestTMP
       attr_reader :manifest_tmp
     end
-    (package.dup.extend(AccessManifestTMP).manifest_tmp.closed?).should be_true
+    expect(package.dup.extend(AccessManifestTMP).manifest_tmp.closed?).to be_truthy
   end
 
   it 'should end hash manifest with EOL' do
     package_with_manifest 'Foo'=>1, :bar=>'Bar'
     package = project('foo').package(@packaging)
     package.invoke
-    Zip::File.open(package.to_s) { |zip| zip.read('META-INF/MANIFEST.MF').should =~ /#{Buildr::Packaging::Java::Manifest::LINE_SEPARATOR}$/ }
+    Zip::File.open(package.to_s) { |zip| expect(zip.read('META-INF/MANIFEST.MF')).to match(/#{Buildr::Packaging::Java::Manifest::LINE_SEPARATOR}$/) }
   end
 
   it 'should break hash manifest lines longer than 72 characters using continuations' do
     package_with_manifest 'foo'=>@long_line
     package = project('foo').package(@packaging)
     inspect_manifest do |manifest|
-      manifest.main['foo'].should == @long_line
+      expect(manifest.main['foo']).to eq(@long_line)
     end
   end
 
   it 'should map manifest from array' do
     package_with_manifest [ { :foo=>'first' }, { :bar=>'second' } ]
     inspect_manifest do |manifest|
-      manifest.sections.size.should be(2)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['foo'].should eql('first')
-      manifest.sections.last['bar'].should eql('second')
+      expect(manifest.sections.size).to be(2)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['foo']).to eql('first')
+      expect(manifest.sections.last['bar']).to eql('second')
     end
   end
 
@@ -160,14 +160,14 @@ shared_examples_for 'package with manifest' do
     package_with_manifest [ { :foo=>'first' }, { :bar=>'second' } ]
     package = project('foo').package(@packaging)
     package.invoke
-    Zip::File.open(package.to_s) { |zip| zip.read('META-INF/MANIFEST.MF')[-1].should == ?\n }
+    Zip::File.open(package.to_s) { |zip| expect(zip.read('META-INF/MANIFEST.MF')[-1]).to eq(?\n) }
   end
 
   it 'should break array manifest lines longer than 72 characters using continuations' do
     package_with_manifest ['foo'=>@long_line]
     package = project('foo').package(@packaging)
     inspect_manifest do |manifest|
-      manifest.main['foo'].should == @long_line
+      expect(manifest.main['foo']).to eq(@long_line)
     end
   end
 
@@ -176,16 +176,16 @@ shared_examples_for 'package with manifest' do
     package = project('foo').package(@packaging)
     package.invoke
     inspect_manifest do |manifest|
-      manifest.sections[1]["Name"].should == "first"
+      expect(manifest.sections[1]["Name"]).to eq("first")
     end
   end
 
   it 'should create manifest from proc' do
     package_with_manifest lambda { 'Meta: data' }
     inspect_manifest do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Meta'].should eql('data')
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Meta']).to eql('data')
     end
   end
 
@@ -193,8 +193,8 @@ shared_examples_for 'package with manifest' do
     write 'MANIFEST.MF', 'Meta: data'
     package_with_manifest 'MANIFEST.MF'
     inspect_manifest do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Meta'].should eql('data')
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Meta']).to eql('data')
     end
   end
 
@@ -205,7 +205,7 @@ shared_examples_for 'package with manifest' do
     Zip::File.open(package.to_s) do |zip|
       permissions = format("%o", zip.find_entry('META-INF/MANIFEST.MF').unix_perms)
       expected_mode = Buildr::Util.win_os? ? /666$/ : /644$/
-      permissions.should match expected_mode
+      expect(permissions).to match expected_mode
     end
   end
 
@@ -215,7 +215,7 @@ shared_examples_for 'package with manifest' do
     package ||= project('foo').package(@packaging)
     package.invoke
     Zip::File.open(package.to_s) do |zip|
-      zip.read('META-INF/MANIFEST.MF').scan(/(Manifest-Version)/m).size.should == 1
+      expect(zip.read('META-INF/MANIFEST.MF').scan(/(Manifest-Version)/m).size).to eq(1)
     end
   end
 
@@ -223,7 +223,7 @@ shared_examples_for 'package with manifest' do
     write 'MANIFEST.MF', 'Manifest-Version: 1.9'
     package_with_manifest 'MANIFEST.MF'
     inspect_manifest do |manifest|
-      manifest.main['Manifest-Version'].should == '1.9'
+      expect(manifest.main['Manifest-Version']).to eq('1.9')
     end
   end
 
@@ -233,9 +233,9 @@ shared_examples_for 'package with manifest' do
     end
     package_with_manifest 'MANIFEST.MF'
     inspect_manifest do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Meta'].should eql('data')
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Meta']).to eql('data')
     end
   end
 
@@ -244,7 +244,7 @@ shared_examples_for 'package with manifest' do
     mkpath 'target/classes'
     packaging = @packaging
     define('foo', :version=>'1.0') { package(packaging).with :manifest=>{'Foo'=>'data'} }
-    inspect_manifest { |manifest| manifest.main['Foo'].should eql('data') }
+    inspect_manifest { |manifest| expect(manifest.main['Foo']).to eql('data') }
   end
 
   it 'should include META-INF directory' do
@@ -252,7 +252,7 @@ shared_examples_for 'package with manifest' do
     package = define('foo', :version=>'1.0') { package(packaging) }.packages.first
     package.invoke
     Zip::File.open(package.to_s) do |zip|
-      zip.entries.map(&:to_s).should include('META-INF/')
+      expect(zip.entries.map(&:to_s)).to include('META-INF/')
     end
   end
 
@@ -269,11 +269,11 @@ shared_examples_for 'package with manifest' do
       end
     end
     inspect_manifest(package) do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Created-By'].should eql('Buildr')
-      manifest.main['Foo'].should eql('1')
-      manifest.main['bar'].should eql('Bar')
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Created-By']).to eql('Buildr')
+      expect(manifest.main['Foo']).to eql('1')
+      expect(manifest.main['bar']).to eql('Bar')
     end
   end
 
@@ -292,28 +292,28 @@ shared_examples_for 'package with manifest' do
       end
     end
     inspect_manifest(project('foo').packages.first) do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Created-By'].should eql('Buildr')
-      manifest.main['Foo'].should eql('1')
-      manifest.main['bar'].should be_nil
-      manifest.main['baz'].should be_nil
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Created-By']).to eql('Buildr')
+      expect(manifest.main['Foo']).to eql('1')
+      expect(manifest.main['bar']).to be_nil
+      expect(manifest.main['baz']).to be_nil
     end
     inspect_manifest(project('foo:bar').packages.first) do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Created-By'].should eql('Buildr')
-      manifest.main['Foo'].should eql('1')
-      manifest.main['bar'].should eql('Bar')
-      manifest.main['baz'].should be_nil
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Created-By']).to eql('Buildr')
+      expect(manifest.main['Foo']).to eql('1')
+      expect(manifest.main['bar']).to eql('Bar')
+      expect(manifest.main['baz']).to be_nil
     end
     inspect_manifest(project('foo:baz').packages.first) do |manifest|
-      manifest.sections.size.should be(1)
-      manifest.main['Manifest-Version'].should eql('1.0')
-      manifest.main['Created-By'].should eql('Buildr')
-      manifest.main['Foo'].should eql('1')
-      manifest.main['baz'].should eql('Baz')
-      manifest.main['bar'].should be_nil
+      expect(manifest.sections.size).to be(1)
+      expect(manifest.main['Manifest-Version']).to eql('1.0')
+      expect(manifest.main['Created-By']).to eql('Buildr')
+      expect(manifest.main['Foo']).to eql('1')
+      expect(manifest.main['baz']).to eql('Baz')
+      expect(manifest.main['bar']).to be_nil
     end
   end
 end
@@ -321,28 +321,28 @@ end
 
 describe Project, '#meta_inf' do
   it 'should by an array' do
-    define('foo').meta_inf.should be_kind_of(Array)
+    expect(define('foo').meta_inf).to be_kind_of(Array)
   end
 
   it 'should include LICENSE file if found' do
     write 'LICENSE'
-    define('foo').meta_inf.first.should point_to_path('LICENSE')
+    expect(define('foo').meta_inf.first).to point_to_path('LICENSE')
   end
 
   it 'should be empty unless LICENSE exists' do
-    define('foo').meta_inf.should be_empty
+    expect(define('foo').meta_inf).to be_empty
   end
 
   it 'should inherit from parent project' do
     write 'LICENSE'
     define('foo') { define 'bar' }
-    project('foo:bar').meta_inf.first.should point_to_path('LICENSE')
+    expect(project('foo:bar').meta_inf.first).to point_to_path('LICENSE')
   end
 
   it 'should expect LICENSE file parent project' do
     write 'bar/LICENSE'
     define('foo') { define 'bar' }
-    project('foo:bar').meta_inf.should be_empty
+    expect(project('foo:bar').meta_inf).to be_empty
   end
 end
 
@@ -363,7 +363,7 @@ shared_examples_for 'package with meta_inf' do
     assumed = Array(@meta_inf_ignore)
     Zip::File.open(package.to_s) do |zip|
       entries = zip.entries.map(&:name).select { |f| File.dirname(f) == 'META-INF' }.map { |f| File.basename(f) }
-      assumed.each { |f| entries.should include(f) }
+      assumed.each { |f| expect(entries).to include(f) }
       yield entries - assumed if block_given?
     end
   end
@@ -371,47 +371,47 @@ shared_examples_for 'package with meta_inf' do
   it 'should default to LICENSE file' do
     write 'LICENSE'
     package_with_meta_inf
-    inspect_meta_inf { |files| files.should eql(['LICENSE']) }
+    inspect_meta_inf { |files| expect(files).to eql(['LICENSE']) }
   end
 
   it 'should be empty if no LICENSE file' do
     package_with_meta_inf
-    inspect_meta_inf { |files| files.should be_empty }
+    inspect_meta_inf { |files| expect(files).to be_empty }
   end
 
   it 'should include file specified by :meta_inf option' do
     write 'README'
     package_with_meta_inf 'README'
-    inspect_meta_inf { |files| files.should eql(['README']) }
+    inspect_meta_inf { |files| expect(files).to eql(['README']) }
   end
 
   it 'should include files specified by :meta_inf option' do
     files = ['README', 'DISCLAIMER'].each { |file| write file }
     package_with_meta_inf files
-    inspect_meta_inf { |files| files.should eql(files) }
+    inspect_meta_inf { |files| expect(files).to eql(files) }
   end
 
   it 'should include file task specified by :meta_inf option' do
     file('README') { |task| write task.to_s }
     package_with_meta_inf file('README')
-    inspect_meta_inf { |files| files.should eql(['README']) }
+    inspect_meta_inf { |files| expect(files).to eql(['README']) }
   end
 
   it 'should include file tasks specified by :meta_inf option' do
     files = ['README', 'DISCLAIMER'].each { |file| file(file) { |task| write task.to_s } }
     package_with_meta_inf files.map { |f| file(f) }
-    inspect_meta_inf { |files| files.should eql(files) }
+    inspect_meta_inf { |files| expect(files).to eql(files) }
   end
 
   it 'should complain if cannot find file' do
     package_with_meta_inf 'README'
-    lambda { inspect_meta_inf }.should raise_error(RuntimeError, /README/)
+    expect { inspect_meta_inf }.to raise_error(RuntimeError, /README/)
   end
 
   it 'should complain if cannot build task' do
     file('README')  { fail 'Failed' }
     package_with_meta_inf 'README'
-    lambda { inspect_meta_inf }.should raise_error(RuntimeError, /Failed/)
+    expect { inspect_meta_inf }.to raise_error(RuntimeError, /Failed/)
   end
 
   it 'should respond to with() and accept manifest and meta_inf' do
@@ -419,7 +419,7 @@ shared_examples_for 'package with meta_inf' do
     mkpath 'target/classes'
     packaging = @packaging
     define('foo', :version=>'1.0') { package(packaging).with :meta_inf=>'DISCLAIMER' }
-    inspect_meta_inf { |files| files.should eql(['DISCLAIMER']) }
+    inspect_meta_inf { |files| expect(files).to eql(['DISCLAIMER']) }
   end
 end
 
@@ -438,7 +438,7 @@ describe Packaging, 'jar' do
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
       entries_to_s = jar.entries.map(&:to_s).delete_if {|entry| entry[-1,1] == "/"}
       # Sometimes META-INF/ is counted as first entry, which is fair game.
-      (entries_to_s.first == 'META-INF/MANIFEST.MF' || entries_to_s[1] == 'META-INF/MANIFEST.MF').should be_true
+      expect(entries_to_s.first == 'META-INF/MANIFEST.MF' || entries_to_s[1] == 'META-INF/MANIFEST.MF').to be_truthy
     end
   end
 
@@ -447,7 +447,7 @@ describe Packaging, 'jar' do
     define('foo', :version=>'1.0') { package(:jar) }
     project('foo').package(:jar).invoke
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
-      jar.entries.map(&:to_s).sort.should include('META-INF/MANIFEST.MF', 'Test.class')
+      expect(jar.entries.map(&:to_s).sort).to include('META-INF/MANIFEST.MF', 'Test.class')
     end
   end
 
@@ -456,7 +456,7 @@ describe Packaging, 'jar' do
     define('foo', :version=>'1.0') { package(:jar) }
     project('foo').package(:jar).invoke
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
-      jar.entries.map(&:to_s).sort.should include('test/important.properties')
+      expect(jar.entries.map(&:to_s).sort).to include('test/important.properties')
     end
   end
 
@@ -465,7 +465,7 @@ describe Packaging, 'jar' do
     define('foo', :version=>'1.0') { package(:jar) }
     project('foo').package(:jar).invoke
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
-      jar.entries.map(&:to_s).sort.should include('code/')
+      expect(jar.entries.map(&:to_s).sort).to include('code/')
     end
   end
 
@@ -474,7 +474,7 @@ describe Packaging, 'jar' do
     define('foo', :version=>'1.0') { package(:jar) }
     project('foo').package(:jar).invoke
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
-      jar.entries.map(&:to_s).sort.should include('test/.config')
+      expect(jar.entries.map(&:to_s).sort).to include('test/.config')
     end
   end
 
@@ -483,14 +483,14 @@ describe Packaging, 'jar' do
     define('foo', :version=>'1.0') { package(:jar) }
     project('foo').package(:jar).invoke
     Zip::File.open(project('foo').package(:jar).to_s) do |jar|
-      jar.entries.map(&:to_s).sort.should include('empty/')
+      expect(jar.entries.map(&:to_s).sort).to include('empty/')
     end
   end
 
   it 'should raise error when calling with() with nil value' do
-    lambda {
+    expect {
       define('foo', :version=>'1.0') { package(:jar).with(nil) }
-    }.should raise_error
+    }.to raise_error /package\.with\(\) should not contain nil values/
   end
 
   it 'should exclude resources when ordered to do so' do
@@ -498,7 +498,7 @@ describe Packaging, 'jar' do
     foo = define('foo', :version => '1.0') { package(:jar).exclude('foo.xml')}
     foo.package(:jar).invoke
     Zip::File.open(foo.package(:jar).to_s) do |jar|
-      jar.entries.map(&:to_s).sort.should_not include('foo.xml')
+      expect(jar.entries.map(&:to_s).sort).not_to include('foo.xml')
     end
   end
 
@@ -527,13 +527,13 @@ describe Packaging, 'war' do
   it 'should use files from webapp directory if nothing included' do
     write 'src/main/webapp/test.html'
     define('foo', :version=>'1.0') { package(:war) }
-    inspect_war { |files| files.should include('test.html') }
+    inspect_war { |files| expect(files).to include('test.html') }
   end
 
   it 'should use files from added assets directory if nothing included' do
     write 'generated/main/webapp/test.html'
     define('foo', :version => '1.0') { assets.paths << 'generated/main/webapp/'; package(:war) }
-    inspect_war { |files| files.should include('test.html') }
+    inspect_war { |files| expect(files).to include('test.html') }
   end
 
   it 'should use files from generated assets directory if nothing included' do
@@ -547,92 +547,92 @@ describe Packaging, 'war' do
       end
       package(:war)
     end
-    inspect_war { |files| files.should include('test.html') }
+    inspect_war { |files| expect(files).to include('test.html') }
   end
 
   it 'should accept files from :classes option', :retry => (Buildr::Util.win_os? ? 4 : 1) do
     write 'classes/test'
     define('foo', :version=>'1.0') { package(:war).with(:classes=>'classes') }
-    inspect_war { |files| files.should include('WEB-INF/classes/test') }
+    inspect_war { |files| expect(files).to include('WEB-INF/classes/test') }
   end
 
   it 'should use files from compile directory if nothing included' do
     write 'src/main/java/Test.java', 'class Test {}'
     define('foo', :version=>'1.0') { package(:war) }
-    inspect_war { |files| files.should include('WEB-INF/classes/Test.class') }
+    inspect_war { |files| expect(files).to include('WEB-INF/classes/Test.class') }
   end
 
   it 'should ignore compile directory if no source files to compile' do
     define('foo', :version=>'1.0') { package(:war) }
-    inspect_war { |files| files.should_not include('target/classes') }
+    inspect_war { |files| expect(files).not_to include('target/classes') }
   end
 
   it 'should include only specified classes directories' do
     write 'src/main/java'
     define('foo', :version=>'1.0') { package(:war).with :classes=>_('additional') }
-    project('foo').package(:war).classes.should_not include(project('foo').file('target/classes'))
-    project('foo').package(:war).classes.should include(project('foo').file('additional'))
+    expect(project('foo').package(:war).classes).not_to include(project('foo').file('target/classes'))
+    expect(project('foo').package(:war).classes).to include(project('foo').file('additional'))
   end
 
   it 'should use files from resources directory if nothing included' do
     write 'src/main/resources/test/important.properties'
     define('foo', :version=>'1.0') { package(:war) }
-    inspect_war { |files| files.should include('WEB-INF/classes/test/important.properties') }
+    inspect_war { |files| expect(files).to include('WEB-INF/classes/test/important.properties') }
   end
 
   it 'should include empty resource directories' do
     mkpath 'src/main/resources/empty'
     define('foo', :version=>'1.0') { package(:war) }
-    inspect_war { |files| files.should include('WEB-INF/classes/empty/') }
+    inspect_war { |files| expect(files).to include('WEB-INF/classes/empty/') }
   end
 
   it 'should accept file from :libs option' do
     write 'lib/foo.jar'
     define('foo', :version=>'1.0') { package(:war).libs << 'lib/foo.jar' }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/foo.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/foo.jar') }
   end
 
 
   it 'should accept artifacts from :libs option' do
     make_jars
     define('foo', :version=>'1.0') { package(:war).with(:libs=>'group:id:jar:1.0') }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
   end
 
   it 'should accept artifacts from :libs option' do
     make_jars
     define('foo', :version=>'1.0') { package(:war).with(:libs=>['group:id:jar:1.0', 'group:id:jar:2.0']) }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar', 'WEB-INF/lib/id-2.0.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar', 'WEB-INF/lib/id-2.0.jar') }
   end
 
   it 'should use artifacts from compile classpath if no libs specified' do
     make_jars
     define('foo', :version=>'1.0') { compile.with 'group:id:jar:1.0', 'group:id:jar:2.0' ; package(:war) }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar', 'WEB-INF/lib/id-2.0.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar', 'WEB-INF/lib/id-2.0.jar') }
   end
 
   it 'should use artifacts from compile classpath if no libs specified, leaving the user specify which to exclude as files' do
     make_jars
     define('foo', :version=>'1.0') { compile.with 'group:id:jar:1.0', 'group:id:jar:2.0' ; package(:war).path('WEB-INF/lib').exclude('id-2.0.jar')  }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
   end
 
   it 'should use artifacts from compile classpath if no libs specified, leaving the user specify which to exclude as files with glob expressions' do
     make_jars
     define('foo', :version=>'1.0') { compile.with 'group:id:jar:1.0', 'group:id:jar:2.0' ; package(:war).path('WEB-INF/lib').exclude('**/id-2.0.jar')   }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
   end
 
   it 'should exclude files regardless of the path where they are included, using wildcards' do
     make_jars
     define('foo', :version=>'1.0') { compile.with 'group:id:jar:1.0', 'group:id:jar:2.0' ; package(:war).exclude('**/id-2.0.jar')   }
-    inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
+    inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
   end
 
   it 'should exclude files regardless of the path where they are included, specifying target path entirely' do
      make_jars
      define('foo', :version=>'1.0') { compile.with 'group:id:jar:1.0', 'group:id:jar:2.0' ; package(:war).exclude('WEB-INF/lib/id-2.0.jar')   }
-     inspect_war { |files| files.should include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
+     inspect_war { |files| expect(files).to include('META-INF/MANIFEST.MF', 'WEB-INF/lib/id-1.0.jar') }
    end
 
   it 'should exclude files regardless of the path where they are included for war files' do
@@ -644,8 +644,8 @@ describe Packaging, 'war' do
        end
      end
      inspect_war do |files|
-       files.should include('WEB-INF/classes/com/example/included/Test.class')
-       files.should_not include('WEB-INF/classes/com/example/excluded/Test.class')
+       expect(files).to include('WEB-INF/classes/com/example/included/Test.class')
+       expect(files).not_to include('WEB-INF/classes/com/example/excluded/Test.class')
      end
    end
 
@@ -654,8 +654,8 @@ describe Packaging, 'war' do
       compile.with 'group:id:jar:1.0'
       package(:war).with :libs=>'additional:id:jar:1.0'
     end
-    project('foo').package(:war).libs.should_not include(artifact('group:id:jar:1.0'))
-    project('foo').package(:war).libs.should include(artifact('additional:id:jar:1.0'))
+    expect(project('foo').package(:war).libs).not_to include(artifact('group:id:jar:1.0'))
+    expect(project('foo').package(:war).libs).to include(artifact('additional:id:jar:1.0'))
   end
 
 end
@@ -686,49 +686,49 @@ describe Packaging, 'aar' do
   it 'should automatically include services.xml and any *.wsdl files under src/main/axis2' do
     write 'src/main/axis2/my-service.wsdl'
     define('foo', :version=>'1.0') { package(:aar) }
-    inspect_aar { |files| files.should include('META-INF/MANIFEST.MF', 'META-INF/services.xml', 'META-INF/my-service.wsdl') }
+    inspect_aar { |files| expect(files).to include('META-INF/MANIFEST.MF', 'META-INF/services.xml', 'META-INF/my-service.wsdl') }
   end
 
   it 'should accept files from :include option' do
     write 'test'
     define('foo', :version=>'1.0') { package(:aar).include 'test' }
-    inspect_aar { |files| files.should include('META-INF/MANIFEST.MF', 'test') }
+    inspect_aar { |files| expect(files).to include('META-INF/MANIFEST.MF', 'test') }
   end
 
   it 'should use files from compile directory if nothing included' do
     write 'src/main/java/Test.java', 'class Test {}'
     define('foo', :version=>'1.0') { package(:aar) }
-    inspect_aar { |files| files.should include('Test.class') }
+    inspect_aar { |files| expect(files).to include('Test.class') }
   end
 
   it 'should use files from resources directory if nothing included' do
     write 'src/main/resources/test/important.properties'
     define('foo', :version=>'1.0') { package(:aar) }
-    inspect_aar { |files| files.should include('test/important.properties') }
+    inspect_aar { |files| expect(files).to include('test/important.properties') }
   end
 
   it 'should include empty resource directories' do
     mkpath 'src/main/resources/empty'
     define('foo', :version=>'1.0') { package(:aar) }
-    inspect_aar { |files| files.should include('empty/') }
+    inspect_aar { |files| expect(files).to include('empty/') }
   end
 
   it 'should accept file from :libs option' do
     make_jars
     define('foo', :version=>'1.0') { package(:aar).with :libs=>'group:id:jar:1.0' }
-    inspect_aar { |files| files.should include('META-INF/MANIFEST.MF', 'lib/id-1.0.jar') }
+    inspect_aar { |files| expect(files).to include('META-INF/MANIFEST.MF', 'lib/id-1.0.jar') }
   end
 
   it 'should accept file from :libs option' do
     make_jars
     define('foo', :version=>'1.0') { package(:aar).with :libs=>['group:id:jar:1.0', 'group:id:jar:2.0'] }
-    inspect_aar { |files| files.should include('META-INF/MANIFEST.MF', 'lib/id-1.0.jar', 'lib/id-2.0.jar') }
+    inspect_aar { |files| expect(files).to include('META-INF/MANIFEST.MF', 'lib/id-1.0.jar', 'lib/id-2.0.jar') }
   end
 
   it 'should NOT use artifacts from compile classpath if no libs specified' do
     make_jars
     define('foo', :version=>'1.0') { compile.with 'group:id:jar:1.0', 'group:id:jar:2.0' ; package(:aar) }
-    inspect_aar { |files| files.should include('META-INF/MANIFEST.MF') }
+    inspect_aar { |files| expect(files).to include('META-INF/MANIFEST.MF') }
   end
 
   it 'should return all libraries from libs attribute' do
@@ -736,8 +736,8 @@ describe Packaging, 'aar' do
       compile.with 'group:id:jar:1.0'
       package(:aar).with :libs=>'additional:id:jar:1.0'
     end
-    project('foo').package(:aar).libs.should_not include(artifact('group:id:jar:1.0'))
-    project('foo').package(:aar).libs.should include(artifact('additional:id:jar:1.0'))
+    expect(project('foo').package(:aar).libs).not_to include(artifact('group:id:jar:1.0'))
+    expect(project('foo').package(:aar).libs).to include(artifact('additional:id:jar:1.0'))
   end
 
 end
@@ -777,9 +777,9 @@ describe Packaging, 'ear' do
 
   it 'should set display name from project id' do
     define 'foo', :version=>'1.0' do
-      package(:ear).display_name.should eql('foo')
+      expect(package(:ear).display_name).to eql('foo')
       define 'bar' do
-        package(:ear).display_name.should eql('foo-bar')
+        expect(package(:ear).display_name).to eql('foo-bar')
       end
     end
   end
@@ -788,14 +788,14 @@ describe Packaging, 'ear' do
     define 'foo', :version=>'1.0' do
       package(:ear)
     end
-    inspect_application_xml { |xml| xml.get_text('/application/display-name').should == 'foo' }
+    inspect_application_xml { |xml| expect(xml.get_text('/application/display-name')).to eq('foo') }
   end
 
   it 'should accept different display name' do
     define 'foo', :version=>'1.0' do
       package(:ear).display_name = 'bar'
     end
-    inspect_application_xml { |xml| xml.get_text('/application/display-name').should == 'bar' }
+    inspect_application_xml { |xml| expect(xml.get_text('/application/display-name')).to eq('bar') }
   end
 
   it 'should set description in application.xml to project comment if not specified' do
@@ -803,21 +803,21 @@ describe Packaging, 'ear' do
     define 'foo', :version=>'1.0' do
       package(:ear)
     end
-    inspect_application_xml { |xml| xml.get_text('/application/description').should == 'MyDescription' }
+    inspect_application_xml { |xml| expect(xml.get_text('/application/description')).to eq('MyDescription') }
   end
 
   it 'should not set description in application.xml if not specified and no project comment' do
     define 'foo', :version=>'1.0' do
       package(:ear)
     end
-    inspect_application_xml { |xml| xml.get_text('/application/description').should be_nil }
+    inspect_application_xml { |xml| expect(xml.get_text('/application/description')).to be_nil }
   end
 
   it 'should set description in application.xml if specified' do
     define 'foo', :version=>'1.0' do
       package(:ear).description = "MyDescription"
     end
-    inspect_application_xml { |xml| xml.get_text('/application/description').should == 'MyDescription' }
+    inspect_application_xml { |xml| expect(xml.get_text('/application/description')).to eq('MyDescription') }
   end
 
   it 'should add security-roles to application.xml if given' do
@@ -826,8 +826,8 @@ describe Packaging, 'ear' do
 		:description=>'System Administrator', :name=>'systemadministrator'}
 	end
 	inspect_application_xml do |xml|
-		xml.get_text("/application/security-role[@id='sr1']/description").to_s.should eql('System Administrator')
-		xml.get_text("/application/security-role[@id='sr1']/role-name").to_s.should eql('systemadministrator')
+		expect(xml.get_text("/application/security-role[@id='sr1']/description").to_s).to eql('System Administrator')
+		expect(xml.get_text("/application/security-role[@id='sr1']/role-name").to_s).to eql('systemadministrator')
 	end
   end
 
@@ -835,14 +835,14 @@ describe Packaging, 'ear' do
     define 'foo', :version=>'1.0' do
       package(:ear) << package(:war)
     end
-    inspect_ear { |files| files.should include('war/foo-1.0.war') }
+    inspect_ear { |files| expect(files).to include('war/foo-1.0.war') }
   end
 
   it 'should map EJBs to /ejb directory' do
     define 'foo', :version=>'1.0' do
       package(:ear).add :ejb=>package(:jar)
     end
-    inspect_ear { |files| files.should include('ejb/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('ejb/foo-1.0.jar') }
   end
 
   it 'should not modify original artifact for its components' do
@@ -861,13 +861,13 @@ describe Packaging, 'ear' do
       package(:ear).add :ejb => project(:two).package(:jar)
     end
 
-    inspect_ear { |files| files.should include('lib/one-1.0.jar', 'ejb/two-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('lib/one-1.0.jar', 'ejb/two-1.0.jar') }
 
-    Buildr::Packaging::Java::Manifest.from_zip(project('one').package(:jar)).main['Class-Path'].should be_nil
-    Buildr::Packaging::Java::Manifest.from_zip(project('two').package(:jar)).main['Class-Path'].should be_nil
+    expect(Buildr::Packaging::Java::Manifest.from_zip(project('one').package(:jar)).main['Class-Path']).to be_nil
+    expect(Buildr::Packaging::Java::Manifest.from_zip(project('two').package(:jar)).main['Class-Path']).to be_nil
 
     inspect_classpath 'ejb/two-1.0.jar' do |classpath|
-      classpath.should include('../lib/one-1.0.jar')
+      expect(classpath).to include('../lib/one-1.0.jar')
     end
   end
 
@@ -875,28 +875,28 @@ describe Packaging, 'ear' do
     define 'foo', :version=>'1.0' do
       package(:ear) << package(:jar)
     end
-    inspect_ear { |files| files.should include('lib/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('lib/foo-1.0.jar') }
   end
 
   it 'should accept component type with :type option' do
     define 'foo', :version=>'1.0' do
       package(:ear).add package(:jar), :type=>:ejb
     end
-    inspect_ear { |files| files.should include('ejb/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('ejb/foo-1.0.jar') }
   end
 
   it 'should accept component and its type as type=>artifact' do
     define 'foo', :version=>'1.0' do
       package(:ear).add :ejb=>package(:jar)
     end
-    inspect_ear { |files| files.should include('ejb/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('ejb/foo-1.0.jar') }
   end
 
   it 'should map typed JARs to /jar directory' do
     define 'foo', :version=>'1.0' do
       package(:ear).add :jar=>package(:jar)
     end
-    inspect_ear { |files| files.should include('jar/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('jar/foo-1.0.jar') }
   end
 
   it 'should add multiple components at a time using the type=>component style' do
@@ -915,8 +915,8 @@ describe Packaging, 'ear' do
                         :ejb => project('bar').package(:jar)
     end
     inspect_ear do |files|
-      files.should include(*%w{ lib/one-1.5.jar lib/two-1.5.jar war/bar-1.5.war ejb/bar-1.5.jar  })
-      files.should_not satisfy { files.any? { |f| f =~ /\.zip$/ } }
+      expect(files).to include(*%w{ lib/one-1.5.jar lib/two-1.5.jar war/bar-1.5.war ejb/bar-1.5.jar  })
+      expect(files).not_to satisfy { files.any? { |f| f =~ /\.zip$/ } }
     end
   end
 
@@ -934,14 +934,14 @@ describe Packaging, 'ear' do
       package(:ear).add projects(:bar, :baz)
     end
     inspect_ear do |files|
-      files.should include('war/bar-1.5.war', 'lib/bar-1.5.jar', 'lib/baz-1.5.jar', 'war/baz-1.5.war')
-      files.should_not satisfy { files.any? { |f| f =~ /\.zip$/ } }
+      expect(files).to include('war/bar-1.5.war', 'lib/bar-1.5.jar', 'lib/baz-1.5.jar', 'war/baz-1.5.war')
+      expect(files).not_to satisfy { files.any? { |f| f =~ /\.zip$/ } }
     end
   end
 
   it 'should complain about unknown component type' do
     define 'foo', :version=>'1.0' do
-      lambda { package(:ear).add package(:zip) }.should raise_error(RuntimeError, /ear component/i)
+      expect { package(:ear).add package(:zip) }.to raise_error(RuntimeError, /ear component/i)
     end
   end
 
@@ -949,14 +949,14 @@ describe Packaging, 'ear' do
     define 'foo', :version=>'1.0' do
       package(:ear).add :lib=>package(:zip)
     end
-    inspect_ear { |files| files.should include('lib/foo-1.0.zip') }
+    inspect_ear { |files| expect(files).to include('lib/foo-1.0.zip') }
   end
 
   it 'should accept alternative directory name' do
     define 'foo', :version=>'1.0' do
       package(:ear).add package(:jar), :path=>'trash'
     end
-    inspect_ear { |files| files.should include('trash/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('trash/foo-1.0.jar') }
   end
 
   it 'should accept customization of directory map' do
@@ -964,7 +964,7 @@ describe Packaging, 'ear' do
       package(:ear).dirs[:jar] = 'jarred'
       package(:ear).add :jar=>package(:jar)
     end
-    inspect_ear { |files| files.should include('jarred/foo-1.0.jar') }
+    inspect_ear { |files| expect(files).to include('jarred/foo-1.0.jar') }
   end
 
   it 'should accept customization of directory map with nil paths in application.xml' do
@@ -973,9 +973,9 @@ describe Packaging, 'ear' do
       package(:ear).add :war=>package(:war)
       package(:ear).add package(:jar)
     end
-    inspect_ear { |files| files.should include('foo-1.0.war') }
+    inspect_ear { |files| expect(files).to include('foo-1.0.war') }
     inspect_application_xml do |xml|
-      xml.get_text("/application/module[@id='foo']/web/web-uri").to_s.should eql('foo-1.0.war')
+      expect(xml.get_text("/application/module[@id='foo']/web/web-uri").to_s).to eql('foo-1.0.war')
     end
   end
 
@@ -986,7 +986,7 @@ describe Packaging, 'ear' do
       package(:ear) << package(:jar)
     end
     inspect_classpath 'war/foo-1.0.war' do |classpath|
-      classpath.should include('../foo-1.0.jar')
+      expect(classpath).to include('../foo-1.0.jar')
     end
   end
 
@@ -995,8 +995,8 @@ describe Packaging, 'ear' do
       package(:ear) << package(:war) << package(:war, :id=>'bar')
     end
     inspect_application_xml do |xml|
-      xml.get_elements("/application/module[@id='foo'][web]").should_not be_empty
-      xml.get_elements("/application/module[@id='bar'][web]").should_not be_empty
+      expect(xml.get_elements("/application/module[@id='foo'][web]")).not_to be_empty
+      expect(xml.get_elements("/application/module[@id='bar'][web]")).not_to be_empty
     end
   end
 
@@ -1006,8 +1006,8 @@ describe Packaging, 'ear' do
       package(:ear).add package(:war, :id=>'bar'), :path=>'ws'
     end
     inspect_application_xml do |xml|
-      xml.get_text("/application/module[@id='foo']/web/web-uri").to_s.should eql('war/foo-1.0.war')
-      xml.get_text("/application/module[@id='bar']/web/web-uri").to_s.should eql('ws/bar-1.0.war')
+      expect(xml.get_text("/application/module[@id='foo']/web/web-uri").to_s).to eql('war/foo-1.0.war')
+      expect(xml.get_text("/application/module[@id='bar']/web/web-uri").to_s).to eql('ws/bar-1.0.war')
     end
   end
 
@@ -1017,8 +1017,8 @@ describe Packaging, 'ear' do
       package(:ear).add package(:war, :id=>'bar')
     end
     inspect_application_xml do |xml|
-      xml.get_text("/application/module[@id='foo']/web/context-root").to_s.should eql('/foo')
-      xml.get_text("/application/module[@id='bar']/web/context-root").to_s.should eql('/bar')
+      expect(xml.get_text("/application/module[@id='foo']/web/context-root").to_s).to eql('/foo')
+      expect(xml.get_text("/application/module[@id='bar']/web/context-root").to_s).to eql('/bar')
     end
   end
 
@@ -1027,7 +1027,7 @@ describe Packaging, 'ear' do
       package(:ear).add package(:war), :context_root=>'rooted'
     end
     inspect_application_xml do |xml|
-      xml.get_text("/application/module[@id='foo']/web/context-root").to_s.should eql('/rooted')
+      expect(xml.get_text("/application/module[@id='foo']/web/context-root").to_s).to eql('/rooted')
     end
   end
 
@@ -1036,7 +1036,7 @@ describe Packaging, 'ear' do
       package(:ear).add package(:war), :context_root=>false
     end
     inspect_application_xml do |xml|
-      xml.get_elements("/application/module[@id='foo']/web/context-root").should be_empty
+      expect(xml.get_elements("/application/module[@id='foo']/web/context-root")).to be_empty
     end
   end
 
@@ -1046,8 +1046,8 @@ describe Packaging, 'ear' do
       package(:ear).add :ejb=>package(:jar, :id=>'bar')
     end
     inspect_application_xml do |xml|
-      xml.get_text("/application/module[@id='foo']/ejb").to_s.should eql('ejb/foo-1.0.jar')
-      xml.get_text("/application/module[@id='bar']/ejb").to_s.should eql('ejb/bar-1.0.jar')
+      expect(xml.get_text("/application/module[@id='foo']/ejb").to_s).to eql('ejb/foo-1.0.jar')
+      expect(xml.get_text("/application/module[@id='bar']/ejb").to_s).to eql('ejb/bar-1.0.jar')
     end
   end
 
@@ -1057,7 +1057,7 @@ describe Packaging, 'ear' do
     end
     inspect_application_xml do |xml|
       jars = xml.get_elements('/application/jar').map(&:texts).map(&:join)
-      jars.should include('jar/foo-1.0.jar', 'jar/bar-1.0.jar')
+      expect(jars).to include('jar/foo-1.0.jar', 'jar/bar-1.0.jar')
     end
   end
 
@@ -1067,7 +1067,7 @@ describe Packaging, 'ear' do
       package(:ear).add package(:war)
     end
     inspect_classpath 'war/foo-1.0.war' do |classpath|
-      classpath.should include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
+      expect(classpath).to include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
     end
   end
 
@@ -1078,8 +1078,8 @@ describe Packaging, 'ear' do
       package(:ear).add package(:war)
     end
     inspect_classpath 'war/foo-1.0.war' do |classpath|
-      classpath.should_not include('../lib/lib1-1.0.jar')
-      classpath.should include('../lib/lib2-1.0.jar')
+      expect(classpath).not_to include('../lib/lib1-1.0.jar')
+      expect(classpath).to include('../lib/lib2-1.0.jar')
     end
   end
 
@@ -1089,7 +1089,7 @@ describe Packaging, 'ear' do
       package(:ear).add :ejb=>package(:jar, :id=>'foo')
     end
     inspect_classpath 'ejb/foo-1.0.jar' do |classpath|
-      classpath.should include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
+      expect(classpath).to include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
     end
   end
 
@@ -1099,7 +1099,7 @@ describe Packaging, 'ear' do
       package(:ear).add :jar=>package(:jar, :id=>'foo')
     end
     inspect_classpath 'jar/foo-1.0.jar' do |classpath|
-      classpath.should include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
+      expect(classpath).to include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
     end
   end
 
@@ -1109,7 +1109,7 @@ describe Packaging, 'ear' do
       package(:ear).add :jar=>package(:jar, :id=>'foo')
     end
     inspect_classpath 'jar/foo-1.0.jar' do |classpath|
-      classpath.should include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
+      expect(classpath).to include('../lib/lib1-1.0.jar', '../lib/lib2-1.0.jar')
     end
   end
 
@@ -1122,7 +1122,7 @@ describe Packaging, 'ear' do
       package(:ear).add :ejb => package(:jar, :id => 'ejb1'), :path => '.'
     end
     inspect_classpath 'ejb1-1.0.jar' do |classpath|
-      classpath.should include(*%w{ one-1.0.jar dos/two-1.0.jar tres/three-1.0.jar })
+      expect(classpath).to include(*%w{ one-1.0.jar dos/two-1.0.jar tres/three-1.0.jar })
     end
   end
 
@@ -1134,7 +1134,7 @@ describe Packaging, 'ear' do
       package(:ear).add :ejb => package(:jar, :id => 'ejb2'), :path => 'dos'
     end
     inspect_classpath 'dos/ejb2-1.0.jar' do |classpath|
-      classpath.should include(*%w{ ../one-1.0.jar two-1.0.jar ../tres/three-1.0.jar })
+      expect(classpath).to include(*%w{ ../one-1.0.jar two-1.0.jar ../tres/three-1.0.jar })
     end
   end
 
@@ -1147,7 +1147,7 @@ describe Packaging, 'ear' do
       package(:ear).add :ejb => package(:jar, :id => 'ejb4'), :path => 'dos/cuatro'
     end
     inspect_classpath 'dos/cuatro/ejb4-1.0.jar' do |classpath|
-      classpath.should include(*%w{ ../../one-1.0.jar ../two-1.0.jar ../tres/three-1.0.jar four-1.0.jar })
+      expect(classpath).to include(*%w{ ../../one-1.0.jar ../two-1.0.jar ../tres/three-1.0.jar four-1.0.jar })
     end
   end
 
@@ -1160,9 +1160,9 @@ describe Packaging, 'sources' do
 
   it 'should create package of type :jar and classifier \'sources\'' do
     define 'foo', :version=>'1.0' do
-      package(:sources).type.should eql(:jar)
-      package(:sources).classifier.should eql('sources')
-      package(:sources).name.should match(/foo-1.0-sources.jar$/)
+      expect(package(:sources).type).to eql(:jar)
+      expect(package(:sources).classifier).to eql('sources')
+      expect(package(:sources).name).to match(/foo-1.0-sources.jar$/)
     end
   end
 
@@ -1171,20 +1171,20 @@ describe Packaging, 'sources' do
     write 'src/main/resources/foo.properties', 'foo=bar'
     define('foo', :version=>'1.0') { package(:sources) }
     project('foo').task('package').invoke
-    project('foo').packages.first.should contain('Source.java')
-    project('foo').packages.first.should contain('foo.properties')
+    expect(project('foo').packages.first).to contain('Source.java')
+    expect(project('foo').packages.first).to contain('foo.properties')
   end
 
   it 'should create sources jar if resources exists (but not sources)' do
     write 'src/main/resources/foo.properties', 'foo=bar'
     define('foo', :version=>'1.0') { package(:sources) }
     project('foo').package(:sources).invoke
-    project('foo').packages.first.should contain('foo.properties')
+    expect(project('foo').packages.first).to contain('foo.properties')
   end
 
   it 'should be a ZipTask' do
     define 'foo', :version=>'1.0' do
-      package(:sources).should be_kind_of(ZipTask)
+      expect(package(:sources)).to be_kind_of(ZipTask)
     end
   end
 end
@@ -1195,9 +1195,9 @@ describe Packaging, 'javadoc' do
 
   it 'should create package of type :zip and classifier \'javadoc\'' do
     define 'foo', :version=>'1.0' do
-      package(:javadoc).type.should eql(:jar)
-      package(:javadoc).classifier.should eql('javadoc')
-      package(:javadoc).name.pathmap('%f').should eql('foo-1.0-javadoc.jar')
+      expect(package(:javadoc).type).to eql(:jar)
+      expect(package(:javadoc).classifier).to eql('javadoc')
+      expect(package(:javadoc).name.pathmap('%f')).to eql('foo-1.0-javadoc.jar')
     end
   end
 
@@ -1205,7 +1205,7 @@ describe Packaging, 'javadoc' do
     write 'src/main/java/Source.java', 'public class Source {}'
     define('foo', :version=>'1.0') { package(:javadoc) }
     project('foo').task('package').invoke
-    project('foo').packages.first.should contain('Source.html', 'index.html')
+    expect(project('foo').packages.first).to contain('Source.html', 'index.html')
   end
 
   it 'should use project description in window title' do
@@ -1213,12 +1213,12 @@ describe Packaging, 'javadoc' do
     desc 'My Project'
     define('foo', :version=>'1.0') { package(:javadoc) }
     project('foo').task('package').invoke
-    project('foo').packages.first.entry('index.html').should contain('My Project')
+    expect(project('foo').packages.first.entry('index.html')).to contain('My Project')
   end
 
   it 'should be a ZipTask' do
     define 'foo', :version=>'1.0' do
-      package(:javadoc).should be_kind_of(ZipTask)
+      expect(package(:javadoc)).to be_kind_of(ZipTask)
     end
   end
 end
@@ -1229,9 +1229,9 @@ describe Packaging, 'test_jar' do
 
   it 'should create package of type :jar and classifier \'tests\'' do
     define 'foo', :version=>'1.0' do
-      package(:test_jar).type.should eql(:jar)
-      package(:test_jar).classifier.should eql('tests')
-      package(:test_jar).name.should match(/foo-1.0-tests.jar$/)
+      expect(package(:test_jar).type).to eql(:jar)
+      expect(package(:test_jar).classifier).to eql('tests')
+      expect(package(:test_jar).name).to match(/foo-1.0-tests.jar$/)
     end
   end
 
@@ -1240,20 +1240,20 @@ describe Packaging, 'test_jar' do
     write 'src/test/resources/test.properties', 'foo=bar'
     define('foo', :version=>'1.0') { package(:test_jar) }
     project('foo').task('package').invoke
-    project('foo').packages.first.should contain('Test.class')
-    project('foo').packages.first.should contain('test.properties')
+    expect(project('foo').packages.first).to contain('Test.class')
+    expect(project('foo').packages.first).to contain('test.properties')
   end
 
   it 'should create test jar if resources exists (but not sources)' do
     write 'src/test/resources/test.properties', 'foo=bar'
     define('foo', :version=>'1.0') { package(:test_jar) }
     project('foo').package(:test_jar).invoke
-    project('foo').packages.first.should contain('test.properties')
+    expect(project('foo').packages.first).to contain('test.properties')
   end
 
   it 'should be a ZipTask' do
     define 'foo', :version=>'1.0' do
-      package(:test_jar).should be_kind_of(ZipTask)
+      expect(package(:test_jar)).to be_kind_of(ZipTask)
     end
   end
 end
@@ -1276,37 +1276,37 @@ shared_examples_for 'package_with_' do
 
   it 'should create package of the right packaging with classifier' do
     prepare
-    project('foo').packages.first.to_s.should =~ /foo-1.0-#{@packaging}.#{@ext}/
+    expect(project('foo').packages.first.to_s).to match(/foo-1.0-#{@packaging}.#{@ext}/)
   end
 
   it 'should create package for projects that have source files' do
     prepare
-    applied_to.should include('foo', 'foo:baz')
+    expect(applied_to).to include('foo', 'foo:baz')
   end
 
   it 'should not create package for projects that have no source files' do
     prepare
-    applied_to.should_not include('foo:bar')
+    expect(applied_to).not_to include('foo:bar')
   end
 
   it 'should limit to projects specified by :only' do
     prepare :only=>'baz'
-    applied_to.should eql(['foo:baz'])
+    expect(applied_to).to eql(['foo:baz'])
   end
 
   it 'should limit to projects specified by :only array' do
     prepare :only=>['baz']
-    applied_to.should eql(['foo:baz'])
+    expect(applied_to).to eql(['foo:baz'])
   end
 
   it 'should ignore project specified by :except' do
     prepare :except=>'baz'
-    applied_to.should eql(['foo'])
+    expect(applied_to).to eql(['foo'])
   end
 
   it 'should ignore projects specified by :except array' do
     prepare :except=>['baz']
-    applied_to.should eql(['foo'])
+    expect(applied_to).to eql(['foo'])
   end
 end
 

--- a/spec/java/pom_spec.rb
+++ b/spec/java/pom_spec.rb
@@ -64,7 +64,7 @@ XML
   it 'should respect exclusions when computing transitive dependencies' do
     pom = POM.load(artifact(@app).pom)
     specs = [ 'org.example:library:jar:1.1', 'org.example:foo:jar:2.0' ]
-    pom.dependencies.should eql(specs)
+    expect(pom.dependencies).to eql(specs)
   end
 end
 
@@ -120,6 +120,6 @@ XML
   it 'should respect exclusions when computing transitive dependencies when the pom includes properties' do
     pom = POM.load(artifact(@app).pom)
     specs = {"a.version"=>"1.1", "b.version"=>"1.1", "project.groupId"=>"group", "pom.groupId"=>"group", "groupId"=>"group", "project.artifactId"=>"app", "pom.artifactId"=>"app", "artifactId"=>"app"}
-    pom.properties.should eql(specs)
+    expect(pom.properties).to eql(specs)
   end
 end

--- a/spec/java/run_spec.rb
+++ b/spec/java/run_spec.rb
@@ -23,7 +23,7 @@ describe Run::JavaRunner do
     define 'foo' do
       run.using :java, :main => 'org.example.NonExistentMain' # class doesn't exist
     end
-    lambda { project('foo').run.invoke }.should raise_error(RuntimeError, /Failed to execute java/)
+    expect { project('foo').run.invoke }.to raise_error(RuntimeError, /Failed to execute java/)
   end
 
   it 'should execute main class' do
@@ -38,15 +38,15 @@ describe Run::JavaRunner do
     define 'foo' do
       run.using :main => 'org.example.Main'
     end
-    project('foo').run.prerequisites.should include(task("foo:compile"))
+    expect(project('foo').run.prerequisites).to include(task("foo:compile"))
   end
 
   it 'should accept :main option as an array including parameters for the main class' do
     define 'foo' do
       run.using :java, :main => ['org.example.Main', '-t', 'input.txt']
     end
-    Java::Commands.should_receive(:java).once.with do |*args|
-      args[0].should == ['org.example.Main', '-t', 'input.txt']
+    expect(Java::Commands).to receive(:java).once do |*args|
+      expect(args[0]).to eq(['org.example.Main', '-t', 'input.txt'])
     end
     project('foo').run.invoke
   end
@@ -55,9 +55,9 @@ describe Run::JavaRunner do
     define 'foo' do
       run.using :java, :main => 'foo', :java_args => ['-server']
     end
-    Java::Commands.should_receive(:java).once.with do |*args|
-      args[0].should == 'foo'
-      args[1][:java_args].should include('-server')
+    expect(Java::Commands).to receive(:java).once do |*args|
+      expect(args[0]).to eq('foo')
+      expect(args[1][:java_args]).to include('-server')
     end
     project('foo').run.invoke
   end
@@ -66,10 +66,10 @@ describe Run::JavaRunner do
     define 'foo' do
       run.using :java, :main => 'foo', :properties => { :foo => 'one', :bar => 'two' }
     end
-    Java::Commands.should_receive(:java).once.with do |*args|
-      args[0].should == 'foo'
-      args[1][:properties][:foo].should == 'one'
-      args[1][:properties][:bar].should == 'two'
+    expect(Java::Commands).to receive(:java) do |*args|
+      expect(args[0]).to eq('foo')
+      expect(args[1][:properties][:foo]).to eq('one')
+      expect(args[1][:properties][:bar]).to eq('two')
     end
     project('foo').run.invoke
   end

--- a/spec/java/tests_spec.rb
+++ b/spec/java/tests_spec.rb
@@ -24,48 +24,48 @@ describe Buildr::JUnit do
       public class FirstTest extends junit.framework.TestCase { }
     JAVA
     define 'foo'
-    project('foo').test.framework.should eql(:junit)
+    expect(project('foo').test.framework).to eql(:junit)
   end
 
   it 'should be picked if the test language is Java' do
     define 'foo' do
       test.compile.using(:javac)
-      test.framework.should eql(:junit)
+      expect(test.framework).to eql(:junit)
     end
   end
 
   it 'should include JUnit dependencies' do
     define('foo') { test.using(:junit) }
-    project('foo').test.compile.dependencies.should include(artifact("junit:junit:jar:#{JUnit.version}"))
-    project('foo').test.dependencies.should include(artifact("junit:junit:jar:#{JUnit.version}"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("junit:junit:jar:#{JUnit.version}"))
+    expect(project('foo').test.dependencies).to include(artifact("junit:junit:jar:#{JUnit.version}"))
   end
 
   it 'should have REQUIRES up to version 1.5 since it was deprecated in 1.3.3' do
-    Buildr::VERSION.should < '1.5'
-    lambda { JUnit::REQUIRES }.should_not raise_error
+    expect(Buildr::VERSION).to be < '1.5'
+    expect { JUnit::REQUIRES }.not_to raise_error
   end
 
   it 'should pick JUnit version from junit build settings' do
     Buildr::JUnit.instance_eval { @dependencies = nil }
     write 'build.yaml', 'junit: 1.2.3'
     define('foo') { test.using(:junit) }
-    project('foo').test.compile.dependencies.should include(artifact("junit:junit:jar:1.2.3"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("junit:junit:jar:1.2.3"))
   end
 
   it 'should include JMock dependencies' do
     define('foo') { test.using(:junit) }
     two_or_later = JMock.version[0,1].to_i >= 2
     group = two_or_later ? "org.jmock" : "jmock"
-    project('foo').test.compile.dependencies.should include(artifact("#{group}:jmock:jar:#{JMock.version}"))
-    project('foo').test.dependencies.should include(artifact("#{group}:jmock:jar:#{JMock.version}"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("#{group}:jmock:jar:#{JMock.version}"))
+    expect(project('foo').test.dependencies).to include(artifact("#{group}:jmock:jar:#{JMock.version}"))
   end
 
   it 'should not include Hamcrest dependencies for JUnit < 4.11' do
     begin
       Buildr.settings.build['junit'] = '4.10'
       define('foo') { test.using :junit }
-      project('foo').test.compile.dependencies.should_not include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
-      project('foo').test.dependencies.should_not include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
+      expect(project('foo').test.compile.dependencies).not_to include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
+      expect(project('foo').test.dependencies).not_to include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
     ensure
       Buildr.settings.build['junit'] = nil
     end
@@ -73,8 +73,8 @@ describe Buildr::JUnit do
 
   it 'should include Hamcrest dependencies for JUnit >= 4.11' do
     define('foo') { test.using :junit }
-    project('foo').test.compile.dependencies.should include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
-    project('foo').test.dependencies.should include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
+    expect(project('foo').test.dependencies).to include(artifact("org.hamcrest:hamcrest-core:jar:1.3"))
   end
 
 
@@ -83,7 +83,7 @@ describe Buildr::JUnit do
     Buildr::JMock.instance_eval { @dependencies = nil }
     write 'build.yaml', 'jmock: 1.2.3'
     define('foo') { test.using(:junit) }
-    project('foo').test.compile.dependencies.should include(artifact("jmock:jmock:jar:1.2.3"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("jmock:jmock:jar:1.2.3"))
   end
 
   it 'should include public classes extending junit.framework.TestCase' do
@@ -100,7 +100,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should include('com.example.FirstTest', 'com.example.AnotherOne')
+    expect(project('foo').test.tests).to include('com.example.FirstTest', 'com.example.AnotherOne')
   end
 
   it 'should include public classes with annotated test cases' do
@@ -114,7 +114,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should include('com.example.FirstTest')
+    expect(project('foo').test.tests).to include('com.example.FirstTest')
   end
 
   it 'should include public classes with RunWith annotation' do
@@ -136,7 +136,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should include('com.example.RunSuite')
+    expect(project('foo').test.tests).to include('com.example.RunSuite')
   end
 
   it 'should ignore classes not extending junit.framework.TestCase' do
@@ -144,7 +144,7 @@ describe Buildr::JUnit do
       public class NotATest { }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should be_empty
+    expect(project('foo').test.tests).to be_empty
   end
 
   it 'should ignore inner classes' do
@@ -158,7 +158,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should eql(['InnerClassTest'])
+    expect(project('foo').test.tests).to eql(['InnerClassTest'])
   end
 
   it 'should ignore abstract classes' do
@@ -168,7 +168,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should be_empty
+    expect(project('foo').test.tests).to be_empty
   end
 
   it 'should ignore classes with no tests in them' do
@@ -177,7 +177,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke
-    project('foo').test.tests.should be_empty
+    expect(project('foo').test.tests).to be_empty
   end
 
   it 'should pass when JUnit test case passes' do
@@ -186,7 +186,7 @@ describe Buildr::JUnit do
         public void testNothing() {}
       }
     JAVA
-    lambda { define('foo').test.invoke }.should_not raise_error
+    expect { define('foo').test.invoke }.not_to raise_error
   end
 
   it 'should fail when JUnit test case fails' do
@@ -197,14 +197,14 @@ describe Buildr::JUnit do
         }
       }
     JAVA
-    lambda { define('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/) rescue nil
+    expect { define('foo').test.invoke }.to raise_error(RuntimeError, /Tests failed/) rescue nil
   end
 
   it 'should fail when JUnit test case fails to compile' do
     write 'src/test/java/FailingTest.java', <<-JAVA
       public class FailingTest e xtends blah blah
     JAVA
-    lambda { define('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/) rescue nil
+    expect { define('foo').test.invoke }.to raise_error(RuntimeError, /Failed to compile/) rescue nil
   end
 
   it 'should report failed test names' do
@@ -216,7 +216,7 @@ describe Buildr::JUnit do
       }
     JAVA
     define('foo').test.invoke rescue
-    project('foo').test.failed_tests.should include('FailingTest')
+    expect(project('foo').test.failed_tests).to include('FailingTest')
   end
 
   it 'should report to reports/junit' do
@@ -226,11 +226,11 @@ describe Buildr::JUnit do
       }
     JAVA
     define 'foo' do
-      test.report_to.should be(file('reports/junit'))
+      expect(test.report_to).to be(file('reports/junit'))
     end
     project('foo').test.invoke
-    project('foo').file('reports/junit/TEST-PassingTest.txt').should exist
-    project('foo').file('reports/junit/TEST-PassingTest.xml').should exist
+    expect(project('foo').file('reports/junit/TEST-PassingTest.txt')).to exist
+    expect(project('foo').file('reports/junit/TEST-PassingTest.xml')).to exist
   end
 
   it 'should pass properties to JVM' do
@@ -243,7 +243,7 @@ describe Buildr::JUnit do
     JAVA
     define('foo').test.using :properties=>{ 'name'=>'value' }
     project('foo').test.invoke
-    project('foo').test.options[:properties]["baseDir"].should eql(project("foo").test.compile.target.to_s)
+    expect(project('foo').test.options[:properties]["baseDir"]).to eql(project("foo").test.compile.target.to_s)
   end
 
   it 'should pass environment to JVM' do
@@ -307,12 +307,12 @@ describe Buildr::JUnit do
 
   it 'should run all test cases in same VM if fork is once' do
     fork_tests :once
-    project('foo').test.failed_tests.size.should eql(1)
+    expect(project('foo').test.failed_tests.size).to eql(1)
   end
 
   it 'should run each test case in separate same VM if fork is each' do
     fork_tests :each
-    project('foo').test.failed_tests.should be_empty
+    expect(project('foo').test.failed_tests).to be_empty
   end
 
   after do
@@ -325,38 +325,38 @@ end
 
 describe Buildr::JUnit, 'report' do
   it 'should default to the target directory reports/junit' do
-    JUnit.report.target.should eql('reports/junit')
+    expect(JUnit.report.target).to eql('reports/junit')
   end
 
   it 'should generate report into the target directory' do
     JUnit.report.target = 'test-report'
-    lambda { task('junit:report').invoke }.should change { File.exist?(JUnit.report.target) }.to(true)
+    expect { task('junit:report').invoke }.to change { File.exist?(JUnit.report.target) }.to(true)
   end
 
   # for some reason this will intermittently fail under windows
   it 'should clean after itself', :retry => (Buildr::Util.win_os? ? 4 : 1) do
     mkpath JUnit.report.target
-    lambda { task('clean').invoke }.should change { File.exist?(JUnit.report.target) }.to(false)
+    expect { task('clean').invoke }.to change { File.exist?(JUnit.report.target) }.to(false)
   end
 
   it 'should generate a consolidated XML report' do
-    lambda { task('junit:report').invoke }.should change { File.exist?('reports/junit/TESTS-TestSuites.xml') }.to(true)
+    expect { task('junit:report').invoke }.to change { File.exist?('reports/junit/TESTS-TestSuites.xml') }.to(true)
   end
 
   it 'should default to generating a report with frames' do
-    JUnit.report.frames.should be_true
+    expect(JUnit.report.frames).to be_truthy
   end
 
   it 'should generate single page when frames is false' do
     JUnit.report.frames = false
     task('junit:report').invoke
-    file('reports/junit/html/junit-noframes.html').should exist
+    expect(file('reports/junit/html/junit-noframes.html')).to exist
   end
 
   it 'should generate frame page when frames is false' do
     JUnit.report.frames = true
     task('junit:report').invoke
-    file('reports/junit/html/index.html').should exist
+    expect(file('reports/junit/html/index.html')).to exist
   end
 
   it 'should generate reports from all projects that ran test cases' do
@@ -368,7 +368,7 @@ describe Buildr::JUnit, 'report' do
     define 'foo'
     project('foo').test.invoke
     task('junit:report').invoke
-    FileList['reports/junit/html/*TestSomething.html'].size.should be(1)
+    expect(FileList['reports/junit/html/*TestSomething.html'].size).to be(1)
   end
 
   after do
@@ -381,7 +381,7 @@ describe Buildr::TestNG do
   it 'should be selectable in project' do
     define 'foo' do
       test.using(:testng)
-      test.framework.should eql(:testng)
+      expect(test.framework).to eql(:testng)
     end
   end
 
@@ -391,15 +391,15 @@ describe Buildr::TestNG do
       test.using(:testng)
       define 'bar'
     end
-    project('foo:bar').test.framework.should eql(:testng)
+    expect(project('foo:bar').test.framework).to eql(:testng)
   end
 
   it 'should include TestNG dependencies for old version' do
     begin
       Buildr.settings.build['testng'] = '5.10'
       define('foo') { test.using :testng }
-      project('foo').test.compile.dependencies.should include(artifact("org.testng:testng:jar:jdk15:#{TestNG.version}"))
-      project('foo').test.dependencies.should include(artifact("org.testng:testng:jar:jdk15:#{TestNG.version}"))
+      expect(project('foo').test.compile.dependencies).to include(artifact("org.testng:testng:jar:jdk15:#{TestNG.version}"))
+      expect(project('foo').test.dependencies).to include(artifact("org.testng:testng:jar:jdk15:#{TestNG.version}"))
     ensure
       Buildr.settings.build['testng'] = nil
     end
@@ -407,18 +407,18 @@ describe Buildr::TestNG do
 
   it 'should include TestNG dependencies for old version' do
     define('foo') { test.using :testng }
-    project('foo').test.compile.dependencies.should include(artifact("org.testng:testng:jar:#{TestNG.version}"))
-    project('foo').test.compile.dependencies.should include(artifact("com.beust:jcommander:jar:1.27"))
-    project('foo').test.dependencies.should include(artifact("org.testng:testng:jar:#{TestNG.version}"))
-    project('foo').test.dependencies.should include(artifact("com.beust:jcommander:jar:1.27"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("org.testng:testng:jar:#{TestNG.version}"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("com.beust:jcommander:jar:1.27"))
+    expect(project('foo').test.dependencies).to include(artifact("org.testng:testng:jar:#{TestNG.version}"))
+    expect(project('foo').test.dependencies).to include(artifact("com.beust:jcommander:jar:1.27"))
   end
 
   it 'should include jmock dependencies' do
     define('foo') { test.using :testng }
     two_or_later = JMock.version[0,1].to_i >= 2
     group = two_or_later ? "org.jmock" : "jmock"
-    project('foo').test.compile.dependencies.should include(artifact("#{group}:jmock:jar:#{JMock.version}"))
-    project('foo').test.dependencies.should include(artifact("#{group}:jmock:jar:#{JMock.version}"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("#{group}:jmock:jar:#{JMock.version}"))
+    expect(project('foo').test.dependencies).to include(artifact("#{group}:jmock:jar:#{JMock.version}"))
   end
 
   it 'should include classes using TestNG annotations' do
@@ -436,14 +436,14 @@ describe Buildr::TestNG do
     JAVA
     define('foo') { test.using(:testng) }
     project('foo').test.invoke
-    project('foo').test.tests.should include('com.example.AnnotatedClass', 'com.example.AnnotatedMethod')
+    expect(project('foo').test.tests).to include('com.example.AnnotatedClass', 'com.example.AnnotatedMethod')
   end
 
   it 'should ignore classes not using TestNG annotations' do
     write 'src/test/java/NotATestClass.java', 'public class NotATestClass {}'
     define('foo') { test.using(:testng) }
     project('foo').test.invoke
-    project('foo').test.tests.should be_empty
+    expect(project('foo').test.tests).to be_empty
   end
 
   it 'should ignore inner classes' do
@@ -456,7 +456,7 @@ describe Buildr::TestNG do
     JAVA
     define('foo') { test.using(:testng) }
     project('foo').test.invoke
-    project('foo').test.tests.should eql(['InnerClassTest'])
+    expect(project('foo').test.tests).to eql(['InnerClassTest'])
   end
 
   it 'should pass when TestNG test case passes' do
@@ -467,7 +467,7 @@ describe Buildr::TestNG do
       }
     JAVA
     define('foo') { test.using(:testng) }
-    lambda { project('foo').test.invoke }.should_not raise_error
+    expect { project('foo').test.invoke }.not_to raise_error
   end
 
   it 'should fail when TestNG test case fails' do
@@ -480,7 +480,7 @@ describe Buildr::TestNG do
       }
     JAVA
     define('foo') { test.using(:testng) }
-    lambda { project('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/)
+    expect { project('foo').test.invoke }.to raise_error(RuntimeError, /Tests failed/)
   end
 
   it 'should fail when TestNG test case fails to compile' do
@@ -488,7 +488,7 @@ describe Buildr::TestNG do
       public class FailingTest exte lasjw9jc930d;kl;kl
     JAVA
     define('foo') { test.using(:testng) }
-    lambda { project('foo').test.invoke }.should raise_error(RuntimeError)
+    expect { project('foo').test.invoke }.to raise_error(RuntimeError)
   end
 
   it 'should fail when multiple TestNG test case fail' do
@@ -509,7 +509,7 @@ describe Buildr::TestNG do
       }
     JAVA
     define('foo') { test.using(:testng) }
-    lambda { project('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/)
+    expect { project('foo').test.invoke }.to raise_error(RuntimeError, /Tests failed/)
   end
 
   it 'should report failed test names' do
@@ -523,12 +523,12 @@ describe Buildr::TestNG do
     JAVA
     define('foo') { test.using(:testng) }
     project('foo').test.invoke rescue nil
-    project('foo').test.failed_tests.should include('FailingTest')
+    expect(project('foo').test.failed_tests).to include('FailingTest')
   end
 
   it 'should report to reports/testng' do
     define('foo') { test.using(:testng) }
-    project('foo').test.report_to.should be(project('foo').file('reports/testng'))
+    expect(project('foo').test.report_to).to be(project('foo').file('reports/testng'))
   end
 
   it 'should generate reports' do
@@ -539,7 +539,7 @@ describe Buildr::TestNG do
       }
     JAVA
     define('foo') { test.using(:testng) }
-    lambda { project('foo').test.invoke }.should change { File.exist?('reports/testng/index.html') }.to(true)
+    expect { project('foo').test.invoke }.to change { File.exist?('reports/testng/index.html') }.to(true)
   end
 
   it 'should include classes using TestNG annotations marked with a specific group' do
@@ -558,7 +558,7 @@ describe Buildr::TestNG do
       }
     JAVA
     define('foo').test.using :testng, :groups=>['included']
-    lambda { project('foo').test.invoke }.should_not raise_error
+    expect { project('foo').test.invoke }.not_to raise_error
   end
 
   it 'should exclude classes using TestNG annotations marked with a specific group' do
@@ -579,7 +579,7 @@ describe Buildr::TestNG do
       }
     JAVA
     define('foo').test.using :testng, :excludegroups=>['excluded']
-    lambda { project('foo').test.invoke }.should_not raise_error
+    expect { project('foo').test.invoke }.not_to raise_error
   end
 end
 
@@ -587,16 +587,16 @@ describe Buildr::MultiTest do
   it 'should be selectable in project' do
     define 'foo' do
       test.using(:multitest, :frameworks => [])
-      test.framework.should eql(:multitest)
+      expect(test.framework).to eql(:multitest)
     end
   end
 
   it 'should include dependencies of whichever test framework(s) are selected' do
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
-    project('foo').test.compile.dependencies.should include(artifact("junit:junit:jar:#{JUnit.version}"))
-    project('foo').test.compile.dependencies.should include(artifact("org.testng:testng:jar:#{TestNG.version}"))
-    project('foo').test.dependencies.should include(artifact("junit:junit:jar:#{JUnit.version}"))
-    project('foo').test.dependencies.should include(artifact("org.testng:testng:jar:#{TestNG.version}"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("junit:junit:jar:#{JUnit.version}"))
+    expect(project('foo').test.compile.dependencies).to include(artifact("org.testng:testng:jar:#{TestNG.version}"))
+    expect(project('foo').test.dependencies).to include(artifact("junit:junit:jar:#{JUnit.version}"))
+    expect(project('foo').test.dependencies).to include(artifact("org.testng:testng:jar:#{TestNG.version}"))
   end
 
   it 'should include classes of given test framework(s)' do
@@ -613,7 +613,7 @@ describe Buildr::MultiTest do
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
     project('foo').test.invoke
-    project('foo').test.tests.should include('com.example.JUnitTest', 'com.example.TestNGTest')
+    expect(project('foo').test.tests).to include('com.example.JUnitTest', 'com.example.TestNGTest')
   end
 
   it 'should pass when test case passes' do
@@ -623,7 +623,7 @@ describe Buildr::MultiTest do
       }
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
-    lambda { project('foo').test.invoke }.should_not raise_error
+    expect { project('foo').test.invoke }.not_to raise_error
   end
 
   it 'should fail when test case fails' do
@@ -636,7 +636,7 @@ describe Buildr::MultiTest do
       }
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
-    lambda { project('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/)
+    expect { project('foo').test.invoke }.to raise_error(RuntimeError, /Tests failed/)
   end
 
   it 'should fail when multiple test case fail' do
@@ -657,7 +657,7 @@ describe Buildr::MultiTest do
       }
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
-    lambda { project('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/)
+    expect { project('foo').test.invoke }.to raise_error(RuntimeError, /Tests failed/)
   end
 
   it 'should report failed test names' do
@@ -671,7 +671,7 @@ describe Buildr::MultiTest do
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
     project('foo').test.invoke rescue nil
-    project('foo').test.failed_tests.should include('FailingTest')
+    expect(project('foo').test.failed_tests).to include('FailingTest')
   end
 
   it 'should generate reports' do
@@ -682,7 +682,7 @@ describe Buildr::MultiTest do
       }
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ] }
-    lambda { project('foo').test.invoke }.should change {
+    expect { project('foo').test.invoke }.to change {
     File.exist?('reports/multitest/index.html') }.to(true)
   end
 
@@ -702,7 +702,7 @@ describe Buildr::MultiTest do
       }
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ], :options => {:testng => {:groups=>['included']}} }
-    lambda { project('foo').test.invoke }.should_not raise_error
+    expect { project('foo').test.invoke }.not_to raise_error
   end
 
   it 'should exclude classes using TestNG annotations marked with a specific group' do
@@ -723,6 +723,6 @@ describe Buildr::MultiTest do
       }
     JAVA
     define('foo') { test.using :multitest, :frameworks => [ Buildr::JUnit, Buildr::TestNG ], :options => {:testng => {:excludegroups=>['excluded']}} }
-    lambda { project('foo').test.invoke }.should_not raise_error
+    expect { project('foo').test.invoke }.not_to raise_error
   end
 end

--- a/spec/packaging/archive_spec.rb
+++ b/spec/packaging/archive_spec.rb
@@ -68,52 +68,52 @@ shared_examples_for 'ArchiveTask' do
   end
 
   it 'should point to archive file' do
-    archive(@archive).name.should eql(@archive)
+    expect(archive(@archive).name).to eql(@archive)
   end
 
   it 'should create file' do
-    lambda { archive(@archive).invoke }.should change { File.exist?(@archive) }.to(true)
+    expect { archive(@archive).invoke }.to change { File.exist?(@archive) }.to(true)
   end
 
   it 'should create empty archive if no files included' do
     archive(@archive).invoke
-    inspect_archive { |archive| archive.should be_empty }
+    inspect_archive { |archive| expect(archive).to be_empty }
   end
 
   it 'should raise error when include() is called with nil values' do
-    lambda { archive(@archive).include(nil) }.should raise_error
-    lambda { archive(@archive).include([nil]) }.should raise_error
+    expect { archive(@archive).include(nil) }.to raise_error /called with nil values/
+    expect { archive(@archive).include([nil]) }.to raise_error /values should not include nil/
   end
 
   it 'should create empty archive if called #clean method' do
     archive(@archive).include(@files).clean.invoke
-    inspect_archive { |archive| archive.should be_empty }
+    inspect_archive { |archive| expect(archive).to be_empty }
   end
 
   it 'should archive all included files' do
     archive(@archive).include(@files).invoke
-    inspect_archive { |archive| @files.each { |f| archive[File.basename(f)].should eql(content_for(f)) } }
-    inspect_archive.size.should eql(@files.size)
+    inspect_archive { |archive| @files.each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) } }
+    expect(inspect_archive.size).to eql(@files.size)
   end
 
   it 'should archive file tasks' do
     tasks = @files.map { |fn| file(fn) }
     archive(@archive).include(tasks).invoke
-    inspect_archive { |archive| @files.each { |f| archive[File.basename(f)].should eql(content_for(f)) } }
-    inspect_archive.size.should eql(@files.size)
+    inspect_archive { |archive| @files.each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) } }
+    expect(inspect_archive.size).to eql(@files.size)
   end
 
   it 'should invoke and archive file tasks' do
     file = file('included') { write 'included' }
-    lambda { archive(@archive).include(file).invoke }.should change { File.exist?(file.to_s) }.to(true)
-    inspect_archive.keys.should include('included')
+    expect { archive(@archive).include(file).invoke }.to change { File.exist?(file.to_s) }.to(true)
+    expect(inspect_archive.keys).to include('included')
   end
 
   it 'should archive artifacts' do
     write 'library-1.0.txt', 'library-1.0'
     artifact("org.example:library:txt:1.0").from 'library-1.0.txt'
     archive(@archive).include("org.example:library:txt:1.0").invoke
-    inspect_archive.keys.should include('library-1.0.txt')
+    expect(inspect_archive.keys).to include('library-1.0.txt')
   end
 
   it 'should archive project artifacts' do
@@ -122,42 +122,42 @@ shared_examples_for 'ArchiveTask' do
       package(:zip)
     end
     archive(@archive).include(project('p1')).invoke
-    inspect_archive.keys.should include('p1-1.0.zip')
+    expect(inspect_archive.keys).to include('p1-1.0.zip')
   end
 
   it 'should include entry for directory' do
     archive(@archive).include(@dir).invoke
-    inspect_archive { |archive| @files.each { |f| archive['test/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['test/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should not archive any excluded files' do
     archive(@archive).include(@files).exclude(@files.last).invoke
     inspect_archive do |archive|
-      archive.keys.should include(File.basename(@files.first))
-      archive.keys.should_not include(File.basename(@files.last))
+      expect(archive.keys).to include(File.basename(@files.first))
+      expect(archive.keys).not_to include(File.basename(@files.last))
     end
   end
 
   it 'should not archive any excluded files in included directories' do
     archive(@archive).include(@dir).exclude(@files.last).invoke
     inspect_archive do |archive|
-      archive.keys.should include('test/' + File.basename(@files.first))
-      archive.keys.should_not include('test/' + File.basename(@files.last))
+      expect(archive.keys).to include('test/' + File.basename(@files.first))
+      expect(archive.keys).not_to include('test/' + File.basename(@files.last))
     end
   end
 
   it 'should not archive any excluded files when using :from/:as' do
     archive(@archive).include(:from=>@dir).exclude(@files.last).invoke
     inspect_archive do |archive|
-      archive.keys.should include(File.basename(@files.first))
-      archive.keys.should_not include(File.basename(@files.last))
+      expect(archive.keys).to include(File.basename(@files.first))
+      expect(archive.keys).not_to include(File.basename(@files.last))
     end
   end
 
   it 'should raise error when using :from with nil value' do
-    lambda {
+    expect {
       archive(@archive).include(:from=>nil)
-    }.should raise_error
+    }.to raise_error /Unrecognized option from/
   end
 
   it 'should exclude entire directory and all its children' do
@@ -165,7 +165,7 @@ shared_examples_for 'ArchiveTask' do
     write "#{@dir}/sub/test"
     archive(@archive).include(@dir).exclude("#{@dir}/sub").invoke
     inspect_archive do |archive|
-      archive.keys.select { |file| file =~ /sub/ }.should be_empty
+      expect(archive.keys.select { |file| file =~ /sub/ }).to be_empty
     end
   end
 
@@ -174,104 +174,104 @@ shared_examples_for 'ArchiveTask' do
     write "test/file.swf"
     archive(@archive).include(@dir).exclude('**/*.swf').invoke
     inspect_archive do |archive|
-      archive.keys.should include('test/file.txt')
-      archive.keys.should_not include('test/file.swf')
+      expect(archive.keys).to include('test/file.txt')
+      expect(archive.keys).not_to include('test/file.swf')
     end
   end
 
   it 'should archive files into specified path' do
     archive(@archive).include(@files, :path=>'code').invoke
-    inspect_archive { |archive| @files.each { |f| archive['code/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['code/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should include entry for directory' do
     archive(@archive).include(@dir).invoke
-    inspect_archive { |archive| @files.each { |f| archive['test/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['test/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should archive files into specified path' do
     archive(@archive).include(@files, :path=>'code').invoke
-    inspect_archive { |archive| @files.each { |f| archive['code/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['code/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should archive directories into specified path' do
     archive(@archive).include(@dir, :path=>'code').invoke
-    inspect_archive { |archive| @files.each { |f| archive['code/test/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['code/test/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should understand . in path' do
-    archive(@archive).path('.').should == archive(@archive).path('')
-    archive(@archive).path('foo').path('.').should == archive(@archive).path('foo')
+    expect(archive(@archive).path('.')).to eq(archive(@archive).path(''))
+    expect(archive(@archive).path('foo').path('.')).to eq(archive(@archive).path('foo'))
   end
 
   it 'should understand .. in path' do
-    archive(@archive).path('..').should == archive(@archive).path('')
-    archive(@archive).path('foo').path('..').should == archive(@archive).path('')
-    archive(@archive).path('foo/bar').path('..').should == archive(@archive).path('foo')
+    expect(archive(@archive).path('..')).to eq(archive(@archive).path(''))
+    expect(archive(@archive).path('foo').path('..')).to eq(archive(@archive).path(''))
+    expect(archive(@archive).path('foo/bar').path('..')).to eq(archive(@archive).path('foo'))
   end
 
   it 'should understand leading / in path' do
-    archive(@archive).path('/').should == archive(@archive).path('')
-    archive(@archive).path('foo/bar').path('/').should == archive(@archive).path('')
+    expect(archive(@archive).path('/')).to eq(archive(@archive).path(''))
+    expect(archive(@archive).path('foo/bar').path('/')).to eq(archive(@archive).path(''))
   end
 
   it 'should archive file into specified name' do
     archive(@archive).include(@files.first, :as=>'test/sample').invoke
-    inspect_archive { |archive| @files.each { |f| archive['test/sample'].should eql(content_for(@files.first)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['test/sample']).to eql(content_for(@files.first)) } }
   end
 
   it 'should archive directory into specified alias, without using "."' do
     archive(@archive).include(@dir, :as=>'.').invoke
-    inspect_archive { |archive| archive.keys.should_not include(".") }
+    inspect_archive { |archive| expect(archive.keys).not_to include(".") }
   end
 
   it 'should archive directories into specified alias, even if it has the same name' do
     archive(@archive).include(@dir, :as=>File.basename(@dir)).invoke
     inspect_archive { |archive|
-      archive.keys.should_not include "#{File.basename(@dir)}"
+      expect(archive.keys).not_to include "#{File.basename(@dir)}"
     }
   end
 
   it 'should archive file into specified name/path' do
     archive(@archive).include(@files.first, :as=>'test/sample', :path=>'path').invoke
-    inspect_archive { |archive| @files.each { |f| archive['path/test/sample'].should eql(content_for(@files.first)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['path/test/sample']).to eql(content_for(@files.first)) } }
   end
 
   it 'should archive files starting with dot' do
     write 'test/.config', '# configuration'
     archive(@archive).include('test').invoke
-    inspect_archive { |archive| @files.each { |f| archive['test/.config'].should eql('# configuration') } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['test/.config']).to eql('# configuration') } }
   end
 
   it 'should archive directory into specified name' do
     archive(@archive).include(@dir, :as=>'code').invoke
-    inspect_archive { |archive| @files.each { |f| archive['code/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['code/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should archive directory into specified name/path' do
     archive(@archive).include(@dir, :as=>'code', :path=>'path').invoke
-    inspect_archive { |archive| @files.each { |f| archive['path/code/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['path/code/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should archive directory contents' do
     archive(@archive).include(@dir, :as=>'.').invoke
-    inspect_archive { |archive| @files.each { |f| archive[File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should archive directory contents into specified path' do
     archive(@archive).include(@dir, :as=>'.', :path=>'path').invoke
-    inspect_archive { |archive| @files.each { |f| archive['path/' + File.basename(f)].should eql(content_for(f)) } }
+    inspect_archive { |archive| @files.each { |f| expect(archive['path/' + File.basename(f)]).to eql(content_for(f)) } }
   end
 
   it 'should not allow two files with the :as argument' do
-    lambda { archive(@archive).include(@files.first, @files.last, :as=>'test/sample') }.should raise_error(RuntimeError, /one file/)
+    expect { archive(@archive).include(@files.first, @files.last, :as=>'test/sample') }.to raise_error(RuntimeError, /one file/)
   end
 
   it 'should expand another archive file' do
     create_for_merge do |src|
       archive(@archive).merge(src)
       archive(@archive).invoke
-      inspect_archive { |archive| @files.each { |f| archive[File.basename(f)].should eql(content_for(f)) } }
+      inspect_archive { |archive| @files.each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) } }
     end
   end
 
@@ -280,8 +280,8 @@ shared_examples_for 'ArchiveTask' do
       archive(@archive).merge(src).include(File.basename(@files.first))
       archive(@archive).invoke
       inspect_archive do |archive|
-        archive[File.basename(@files.first)].should eql(content_for(@files.first))
-        archive[File.basename(@files.last)].should be_nil
+        expect(archive[File.basename(@files.first)]).to eql(content_for(@files.first))
+        expect(archive[File.basename(@files.last)]).to be_nil
       end
     end
   end
@@ -291,8 +291,8 @@ shared_examples_for 'ArchiveTask' do
       archive(@archive).merge(src).exclude(File.basename(@files.first))
       archive(@archive).invoke
       inspect_archive do |archive|
-        @files[1..-1].each { |f| archive[File.basename(f)].should eql(content_for(f)) }
-        archive[File.basename(@files.first)].should be_nil
+        @files[1..-1].each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) }
+        expect(archive[File.basename(@files.first)]).to be_nil
       end
     end
   end
@@ -303,7 +303,7 @@ shared_examples_for 'ArchiveTask' do
     zip(qualify(@archive, "src")).include(@dir).tap do |task|
       archive(@archive).merge(task).exclude('test/*')
       archive(@archive).invoke
-      inspect_archive.should be_empty
+      expect(inspect_archive).to be_empty
     end
   end
 
@@ -311,7 +311,7 @@ shared_examples_for 'ArchiveTask' do
     create_for_merge do |src|
       archive(@archive).path('test').merge(src)
       archive(@archive).invoke
-      inspect_archive { |archive| @files.each { |f| archive['test/' + File.basename(f)].should eql(content_for(f)) } }
+      inspect_archive { |archive| @files.each { |f| expect(archive['test/' + File.basename(f)]).to eql(content_for(f)) } }
     end
   end
 
@@ -319,7 +319,7 @@ shared_examples_for 'ArchiveTask' do
     create_for_merge do |src|
       archive(@archive).merge(src, :path=>'test')
       archive(@archive).invoke
-      inspect_archive { |archive| @files.each { |f| archive['test/' + File.basename(f)].should eql(content_for(f)) } }
+      inspect_archive { |archive| @files.each { |f| expect(archive['test/' + File.basename(f)]).to eql(content_for(f)) } }
     end
   end
 
@@ -327,7 +327,7 @@ shared_examples_for 'ArchiveTask' do
     create_for_merge do |src|
       archive(@archive).merge(src, :path=>'/')
       archive(@archive).invoke
-      inspect_archive { |archive| @files.each { |f| archive[File.basename(f)].should eql(content_for(f)) } }
+      inspect_archive { |archive| @files.each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) } }
     end
   end
 
@@ -335,7 +335,7 @@ shared_examples_for 'ArchiveTask' do
     create_for_merge do |src|
       archive(@archive).include(src, :merge=>true)
       archive(@archive).invoke
-      inspect_archive { |archive| @files.each { |f| archive[File.basename(f)].should eql(content_for(f)) } }
+      inspect_archive { |archive| @files.each { |f| expect(archive[File.basename(f)]).to eql(content_for(f)) } }
     end
   end
 
@@ -345,7 +345,7 @@ shared_examples_for 'ArchiveTask' do
     # all included files newer.
     File.utime Time.now - 100, Time.now - 100, @archive
     archive(@archive).include(@files).invoke
-    File.stat(@archive).mtime.should be_within(10).of(Time.now)
+    expect(File.stat(@archive).mtime).to be_within(10).of(Time.now)
   end
 
   it 'should update if a file in a subdir is more recent' do
@@ -356,12 +356,12 @@ shared_examples_for 'ArchiveTask' do
     write test3, '/* Original */'
 
     create_without_task { |archive| archive.include(:from => @dir) }
-    inspect_archive { |archive| archive["subdir/test3.css"].should eql('/* Original */') }
+    inspect_archive { |archive| expect(archive["subdir/test3.css"]).to eql('/* Original */') }
 
     write test3, '/* Refreshed */'
     File.utime(Time.now + 100, Time.now + 100, test3)
     archive(@archive).include(:from => @dir).invoke
-    inspect_archive { |archive| archive["subdir/test3.css"].should eql('/* Refreshed */') }
+    inspect_archive { |archive| expect(archive["subdir/test3.css"]).to eql('/* Refreshed */') }
    end
 
   it 'should do nothing if all files are uptodate' do
@@ -369,7 +369,7 @@ shared_examples_for 'ArchiveTask' do
     # By touching all files in the past, there's nothing new to update.
     (@files + [@archive]).each { |f| File.utime Time.now - 100, Time.now - 100, f }
     archive(@archive).include(@files).invoke
-    File.stat(@archive).mtime.should be_within(10).of(Time.now - 100)
+    expect(File.stat(@archive).mtime).to be_within(10).of(Time.now - 100)
   end
 
   it 'should update if one of the files is recent' do
@@ -378,19 +378,19 @@ shared_examples_for 'ArchiveTask' do
     write @files.first, '/* Refreshed */'
     File.utime(Time.now - 100, Time.now - 100, @archive) # Touch archive file to some point in the past.
     archive(@archive).include(@files).invoke
-    inspect_archive { |archive| archive[File.basename(@files.first)].should eql('/* Refreshed */') }
+    inspect_archive { |archive| expect(archive[File.basename(@files.first)]).to eql('/* Refreshed */') }
   end
 
   it 'should create new archive when updating' do
     create_without_task { |archive| archive.include(@files) }
     File.utime(Time.now - 100, Time.now - 100, @archive) # Touch archive file to some point in the past.
     archive(@archive).include(@files[1..-1]).invoke
-    inspect_archive.size.should be(@files.size - 1)
+    expect(inspect_archive.size).to be(@files.size - 1)
   end
 
   it 'should not accept invalid options' do
     archive(@archive).include(@files)
-    lambda { archive(@archive).with :option=>true }.should raise_error
+    expect { archive(@archive).with :option=>true }.to raise_error /does not support the option option/
   end
 
   it 'should invoke paths supplied in from parameters' do
@@ -408,8 +408,8 @@ shared_examples_for 'ArchiveTask' do
     a.include(:from => f2)
     a.invoke
     contents = inspect_archive
-    contents["folder1/somefile1.ext"].should_not be_nil
-    contents["folder2/somefile2.ext"].should_not be_nil
+    expect(contents["folder1/somefile1.ext"]).not_to be_nil
+    expect(contents["folder2/somefile2.ext"]).not_to be_nil
   end
 end
 
@@ -443,7 +443,7 @@ describe TarTask do
 
       tar('foo.tgz').include('src/main/bin/*').invoke
       unzip('target' => 'foo.tgz').extract
-      (File.stat('target/hello').mode & 0777).should == 0777
+      expect(File.stat('target/hello').mode & 0777).to eq(0777)
     end
 
     it 'should preserve file permissions when merging zip files' do
@@ -460,7 +460,7 @@ describe TarTask do
       bar.merge(foo)
       bar.invoke
       unzip('target' => 'bar.tgz').extract
-      (File.stat('target/hello').mode & 0777).should == 0777
+      expect(File.stat('target/hello').mode & 0777).to eq(0777)
     end
   end
 
@@ -544,7 +544,7 @@ describe "ZipTask" do
     archive(@archive).include(@dir)
     archive(@archive).invoke
     inspect_archive do |archive|
-      archive.keys.should include('test/EmptyDir1/')
+      expect(archive.keys).to include('test/EmptyDir1/')
     end
   end
 
@@ -552,21 +552,21 @@ describe "ZipTask" do
     archive(@archive).include(Dir["#{@dir}/*"])
     archive(@archive).invoke
     inspect_archive do |archive|
-      archive.keys.should include('EmptyDir1/')
+      expect(archive.keys).to include('EmptyDir1/')
     end
   end
 
   it 'should work with path object' do
     archive(@archive).path('code').include(@files)
     archive(@archive).invoke
-    inspect_archive { |archive| archive.keys.should include('code/') }
+    inspect_archive { |archive| expect(archive.keys).to include('code/') }
   end
 
   it 'should have path object that includes empty dirs' do
     archive(@archive).path('code').include(Dir["#{@dir}/*"])
     archive(@archive).invoke
     inspect_archive do |archive|
-      archive.keys.should include('code/EmptyDir1/')
+      expect(archive.keys).to include('code/EmptyDir1/')
     end
   end
 
@@ -582,7 +582,7 @@ describe "ZipTask" do
 
       zip('foo.zip').include('src/main/bin/*').invoke
       unzip('target' => 'foo.zip').extract
-      (File.stat('target/hello').mode & 0777).should == 0777
+      expect(File.stat('target/hello').mode & 0777).to eq(0777)
     end
 
     it 'should preserve file permissions when merging zip files' do
@@ -599,7 +599,7 @@ describe "ZipTask" do
       bar.merge(foo)
       bar.invoke
       unzip('target' => 'bar.zip').extract
-      (File.stat('target/hello').mode & 0777).should == 0777
+      expect(File.stat('target/hello').mode & 0777).to eq(0777)
     end
   end
 
@@ -643,41 +643,41 @@ describe Unzip do
       File.utime(Time.now - 10, Time.now - 10, @target)
       unzip(@target=>@zip).target.invoke
     end
-    File.stat(@target).mtime.should be_within(2).of(Time.now)
+    expect(File.stat(@target).mtime).to be_within(2).of(Time.now)
   end
 
   it 'should expand files' do
     with_zip do
       unzip(@target=>@zip).target.invoke
-      @files.each { |f| File.read(File.join(@target, File.basename(f))).should eql(content_for(f)) }
+      @files.each { |f| expect(File.read(File.join(@target, File.basename(f)))).to eql(content_for(f)) }
     end
   end
 
   it 'should expand files from a tar.gz file' do
     with_tar do
       unzip(@target=>@targz).target.invoke
-      @files.each { |f| File.read(File.join(@target, File.basename(f))).should eql(content_for(f)) }
+      @files.each { |f| expect(File.read(File.join(@target, File.basename(f)))).to eql(content_for(f)) }
     end
   end
 
   it 'should expand files from a .tgz file' do
     with_tar_too do
       unzip(@target=>@targz2).target.invoke
-      @files.each { |f| File.read(File.join(@target, File.basename(f))).should eql(content_for(f)) }
+      @files.each { |f| expect(File.read(File.join(@target, File.basename(f)))).to eql(content_for(f)) }
     end
   end
 
   it 'should expand all files' do
     with_zip do
       unzip(@target=>@zip).target.invoke
-      FileList[File.join(@target, '*')].size.should be(@files.size)
+      expect(FileList[File.join(@target, '*')].size).to be(@files.size)
     end
   end
 
   it 'should expand all files from a .tar.gz file' do
     with_tar do
       unzip(@target=>@targz).target.invoke
-      FileList[File.join(@target, '*')].size.should be(@files.size)
+      expect(FileList[File.join(@target, '*')].size).to be(@files.size)
     end
   end
 
@@ -685,8 +685,8 @@ describe Unzip do
     with_zip do
       only = File.basename(@files.first)
       unzip(@target=>@zip).include(only).target.invoke
-      FileList[File.join(@target, '*')].should include(File.expand_path(only, @target))
-      FileList[File.join(@target, '*')].size.should be(1)
+      expect(FileList[File.join(@target, '*')]).to include(File.expand_path(only, @target))
+      expect(FileList[File.join(@target, '*')].size).to be(1)
     end
   end
 
@@ -694,8 +694,8 @@ describe Unzip do
     with_tar do
       only = File.basename(@files.first)
       unzip(@target=>@targz).include(only).target.invoke
-      FileList[File.join(@target, '*')].should include(File.expand_path(only, @target))
-      FileList[File.join(@target, '*')].size.should be(1)
+      expect(FileList[File.join(@target, '*')]).to include(File.expand_path(only, @target))
+      expect(FileList[File.join(@target, '*')].size).to be(1)
     end
   end
 
@@ -703,8 +703,8 @@ describe Unzip do
     with_zip do
       except = File.basename(@files.first)
       unzip(@target=>@zip).exclude(except).target.invoke
-      FileList[File.join(@target, '*')].should_not include(File.expand_path(except, @target))
-      FileList[File.join(@target, '*')].size.should be(@files.size - 1)
+      expect(FileList[File.join(@target, '*')]).not_to include(File.expand_path(except, @target))
+      expect(FileList[File.join(@target, '*')].size).to be(@files.size - 1)
     end
   end
 
@@ -712,8 +712,8 @@ describe Unzip do
     with_tar do
       except = File.basename(@files.first)
       unzip(@target=>@targz).exclude(except).target.invoke
-      FileList[File.join(@target, '*')].should_not include(File.expand_path(except, @target))
-      FileList[File.join(@target, '*')].size.should be(@files.size - 1)
+      expect(FileList[File.join(@target, '*')]).not_to include(File.expand_path(except, @target))
+      expect(FileList[File.join(@target, '*')].size).to be(@files.size - 1)
     end
   end
 
@@ -721,19 +721,19 @@ describe Unzip do
     with_zip @files, :path=>'test/path' do
       only = File.basename(@files.first)
       unzip(@target=>@zip).include(only).target.invoke
-      FileList[File.join(@target, '*')].should be_empty
+      expect(FileList[File.join(@target, '*')]).to be_empty
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@zip).include('test/path/' + only).target.invoke
-      FileList[File.join(@target, 'test/path/*')].size.should be(1)
+      expect(FileList[File.join(@target, 'test/path/*')].size).to be(1)
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@zip).include('test/**/*').target.invoke
-      FileList[File.join(@target, 'test/path/*')].size.should be(2)
+      expect(FileList[File.join(@target, 'test/path/*')].size).to be(2)
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@zip).include('test/*').target.invoke
-      FileList[File.join(@target, 'test/path/*')].size.should be(2)
+      expect(FileList[File.join(@target, 'test/path/*')].size).to be(2)
     end
   end
 
@@ -741,15 +741,15 @@ describe Unzip do
     with_tar @files, :path=>'test/path' do
       only = File.basename(@files.first)
       unzip(@target=>@targz).include(only).target.invoke
-      FileList[File.join(@target, '*')].should be_empty
+      expect(FileList[File.join(@target, '*')]).to be_empty
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@targz).include('test/path/' + only).target.invoke
-      FileList[File.join(@target, 'test/path/*')].size.should be(1)
+      expect(FileList[File.join(@target, 'test/path/*')].size).to be(1)
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@targz).include('test/**/*').target.invoke
-      FileList[File.join(@target, 'test/path/*')].size.should be(2)
+      expect(FileList[File.join(@target, 'test/path/*')].size).to be(2)
     end
   end
 
@@ -757,19 +757,19 @@ describe Unzip do
     with_zip @files, :path=>'test/path' do
       only = File.basename(@files.first)
       unzip(@target=>@zip).tap { |unzip| unzip.from_path('test').include(only) }.target.invoke
-      FileList[File.join(@target, '*')].should be_empty
+      expect(FileList[File.join(@target, '*')]).to be_empty
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@zip).tap { |unzip| unzip.from_path('test').include('test/*') }.target.invoke
-      FileList[File.join(@target, 'path/*')].should be_empty
+      expect(FileList[File.join(@target, 'path/*')]).to be_empty
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@zip).tap { |unzip| unzip.from_path('test').include('path/*' + only) }.target.invoke
-      FileList[File.join(@target, 'path/*')].size.should be(1)
+      expect(FileList[File.join(@target, 'path/*')].size).to be(1)
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@zip).tap { |unzip| unzip.from_path('test').include('path/*') }.target.invoke
-      FileList[File.join(@target, 'path/*')].size.should be(2)
+      expect(FileList[File.join(@target, 'path/*')].size).to be(2)
     end
   end
 
@@ -777,19 +777,19 @@ describe Unzip do
     with_tar @files, :path=>'test/path' do
       only = File.basename(@files.first)
       unzip(@target=>@targz).tap { |unzip| unzip.from_path('test').include(only) }.target.invoke
-      FileList[File.join(@target, '*')].should be_empty
+      expect(FileList[File.join(@target, '*')]).to be_empty
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@targz).tap { |unzip| unzip.from_path('test').include('test/*') }.target.invoke
-      FileList[File.join(@target, 'path/*')].should be_empty
+      expect(FileList[File.join(@target, 'path/*')]).to be_empty
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@targz).tap { |unzip| unzip.from_path('test').include('path/*' + only) }.target.invoke
-      FileList[File.join(@target, 'path/*')].size.should be(1)
+      expect(FileList[File.join(@target, 'path/*')].size).to be(1)
 
       Rake::Task.clear ; rm_rf @target
       unzip(@target=>@targz).tap { |unzip| unzip.from_path('test').include('path/*') }.target.invoke
-      FileList[File.join(@target, 'path/*')].size.should be(2)
+      expect(FileList[File.join(@target, 'path/*')].size).to be(2)
     end
   end
 
@@ -797,8 +797,8 @@ describe Unzip do
     with_zip @files, :path=>'test' do
       except = File.basename(@files.first)
       unzip(@target=>@zip).tap { |unzip| unzip.from_path('test').exclude(except) }.target.invoke
-      FileList[File.join(@target, '*')].should include(File.join(@target, File.basename(@files[1])))
-      FileList[File.join(@target, '*')].size.should be(@files.size - 1)
+      expect(FileList[File.join(@target, '*')]).to include(File.join(@target, File.basename(@files[1])))
+      expect(FileList[File.join(@target, '*')].size).to be(@files.size - 1)
     end
   end
 
@@ -806,8 +806,8 @@ describe Unzip do
     with_tar @files, :path=>'test' do
       except = File.basename(@files.first)
       unzip(@target=>@targz).tap { |unzip| unzip.from_path('test').exclude(except) }.target.invoke
-      FileList[File.join(@target, '*')].should include(File.join(@target, File.basename(@files[1])))
-      FileList[File.join(@target, '*')].size.should be(@files.size - 1)
+      expect(FileList[File.join(@target, '*')]).to include(File.join(@target, File.basename(@files[1])))
+      expect(FileList[File.join(@target, '*')].size).to be(@files.size - 1)
     end
   end
 
@@ -818,7 +818,7 @@ describe Unzip do
     zip(@zip).include(@files, :path => 'src').include(lib_files, :path => 'lib').invoke
 
     unzip(@target=>@zip).tap { |unzip| unzip.from_path('lib') }.target.invoke
-    FileList[File.join(@target, '**/*')].should have(2).files
+    expect(FileList[File.join(@target, '**/*')].size).to eq(2)
   end
 
   it "should handle relative paths without any includes or excludes with a tar.gz file" do
@@ -828,24 +828,24 @@ describe Unzip do
     tar(@targz).include(@files, :path => 'src').include(lib_files, :path => 'lib').invoke
 
     unzip(@target=>@targz).tap { |unzip| unzip.from_path('lib') }.target.invoke
-    FileList[File.join(@target, '**/*')].should have(2).files
+    expect(FileList[File.join(@target, '**/*')].size).to eq(2)
   end
 
   it 'should return itself from root method' do
     task = unzip(@target=>@zip)
-    task.root.should be(task)
-    task.from_path('foo').root.should be(task)
+    expect(task.root).to be(task)
+    expect(task.from_path('foo').root).to be(task)
   end
 
   it 'should return target task from target method' do
     task = unzip(@target=>@zip)
-    task.target.should be(file(@target))
-    task.from_path('foo').target.should be(file(@target))
+    expect(task.target).to be(file(@target))
+    expect(task.from_path('foo').target).to be(file(@target))
   end
 
   it 'should alias from_path as path' do
     task = unzip(@target=>@zip)
-    task.from_path('foo').should be(task.path('foo'))
+    expect(task.from_path('foo')).to be(task.path('foo'))
   end
 
 end

--- a/spec/packaging/artifact_namespace_spec.rb
+++ b/spec/packaging/artifact_namespace_spec.rb
@@ -28,64 +28,64 @@ describe Buildr::ArtifactNamespace do
 
   describe '.root' do
     it 'should return the top level namespace' do
-      Buildr::ArtifactNamespace.root.should be_root
+      expect(Buildr::ArtifactNamespace.root).to be_root
     end
 
     it 'should yield the namespace if a block is given' do
       flag = false
-      Buildr::ArtifactNamespace.root { |ns| flag = true; ns.should be_root }
-      flag.should == true
+      Buildr::ArtifactNamespace.root { |ns| flag = true; expect(ns).to be_root }
+      expect(flag).to eq(true)
     end
 
     it 'should return the root when used outside of a project definition' do
-      artifact_ns.should be_root
+      expect(artifact_ns).to be_root
     end
 
     it 'should yield to a block when used outside of a project definition' do
       flag = false
-      artifact_ns {|ns| flag = true; ns.should be_root}
-      flag.should == true
+      artifact_ns {|ns| flag = true; expect(ns).to be_root}
+      expect(flag).to eq(true)
     end
   end
 
   describe '.instance' do
     it 'should return the top level namespace when invoked outside a project definition' do
-      artifact_ns.should be_root
+      expect(artifact_ns).to be_root
     end
 
     it 'should return the namespace for the receiving project' do
       define('foo') { }
-      project('foo').artifact_ns.name.should == 'foo'
+      expect(project('foo').artifact_ns.name).to eq('foo')
     end
 
     it 'should return the current project namespace when invoked inside a project' do
       define 'foo' do
-        artifact_ns.should_not be_root
-        artifact_ns.name.should == 'foo'
+        expect(artifact_ns).not_to be_root
+        expect(artifact_ns.name).to eq('foo')
         task :doit do
-          artifact_ns.should_not be_root
-          artifact_ns.name.should == 'foo'
+          expect(artifact_ns).not_to be_root
+          expect(artifact_ns.name).to eq('foo')
         end.invoke
       end
     end
 
     it 'should return the root namespace if given :root' do
-      artifact_ns(:root).should be_root
+      expect(artifact_ns(:root)).to be_root
     end
 
     it 'should return the namespace for the given name' do
-      artifact_ns(:foo).name.should == 'foo'
-      artifact_ns('foo:bar').name.should == 'foo:bar'
-      artifact_ns(['foo', 'bar', 'baz']).name.should == 'foo:bar:baz'
+      expect(artifact_ns(:foo).name).to eq('foo')
+      expect(artifact_ns('foo:bar').name).to eq('foo:bar')
+      expect(artifact_ns(['foo', 'bar', 'baz']).name).to eq('foo:bar:baz')
       abc_module do
-        artifact_ns(A::B::C).name.should == 'A::B::C'
+        expect(artifact_ns(A::B::C).name).to eq('A::B::C')
       end
-      artifact_ns(:root).should be_root
-      artifact_ns(:current).should be_root
+      expect(artifact_ns(:root)).to be_root
+      expect(artifact_ns(:current)).to be_root
       define 'foo' do
-        artifact_ns(:current).name.should == 'foo'
+        expect(artifact_ns(:current).name).to eq('foo')
         define 'baz' do
-          artifact_ns(:current).name.should == 'foo:baz'
+          expect(artifact_ns(:current).name).to eq('foo:baz')
         end
       end
     end
@@ -93,14 +93,14 @@ describe Buildr::ArtifactNamespace do
 
   describe '#parent' do
     it 'should be nil for root namespace' do
-      artifact_ns(:root).parent.should be_nil
+      expect(artifact_ns(:root).parent).to be_nil
     end
 
     it 'should be the parent namespace for nested modules' do
       abc_module do
-        artifact_ns(A::B::C).parent.should == artifact_ns(A::B)
-        artifact_ns(A::B).parent.should == artifact_ns(A)
-        artifact_ns(A).parent.should == artifact_ns(:root)
+        expect(artifact_ns(A::B::C).parent).to eq(artifact_ns(A::B))
+        expect(artifact_ns(A::B).parent).to eq(artifact_ns(A))
+        expect(artifact_ns(A).parent).to eq(artifact_ns(:root))
       end
     end
 
@@ -108,25 +108,25 @@ describe Buildr::ArtifactNamespace do
       define 'a' do
         define 'b' do
           define 'c' do
-            artifact_ns.parent.should == artifact_ns(parent)
+            expect(artifact_ns.parent).to eq(artifact_ns(parent))
           end
-          artifact_ns.parent.should == artifact_ns(parent)
+          expect(artifact_ns.parent).to eq(artifact_ns(parent))
         end
-        artifact_ns.parent.should == artifact_ns(:root)
+        expect(artifact_ns.parent).to eq(artifact_ns(:root))
       end
     end
   end
 
   describe '#parent=' do
     it 'should reject to set parent for root namespace' do
-      lambda { artifact_ns(:root).parent = :foo }.should raise_error(Exception, /cannot set parent/i)
+      expect { artifact_ns(:root).parent = :foo }.to raise_error(Exception, /cannot set parent/i)
     end
 
     it 'should allow to set parent' do
       artifact_ns(:bar).parent = :foo
-      artifact_ns(:bar).parent.should == artifact_ns(:foo)
+      expect(artifact_ns(:bar).parent).to eq(artifact_ns(:foo))
       artifact_ns(:bar).parent = artifact_ns(:baz)
-      artifact_ns(:bar).parent.should == artifact_ns(:baz)
+      expect(artifact_ns(:bar).parent).to eq(artifact_ns(:baz))
     end
 
     it 'should allow to set parent to :current' do
@@ -138,9 +138,9 @@ describe Buildr::ArtifactNamespace do
         end
         define 'a' do
           define 'b' do
-            mod.stuff.parent.should == artifact_ns
+            expect(mod.stuff.parent).to eq(artifact_ns)
           end
-          mod.stuff.parent.should == artifact_ns
+          expect(mod.stuff.parent).to eq(artifact_ns)
         end
       end
     end
@@ -151,14 +151,14 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns.need 'a:b:c:1'
         # referenced by spec
-        artifact_ns['a:b:c'].should_not be_selected
+        expect(artifact_ns['a:b:c']).not_to be_selected
 
         # referenced by name
-        artifact_ns[:b].should_not be_selected
-        artifact_ns[:b].should be_satisfied_by('a:b:c:1')
-        artifact_ns[:b].should_not be_satisfied_by('a:b:c:2')
-        artifact_ns[:b].should_not be_satisfied_by('d:b:c:1')
-        artifact_ns[:b].version.should == '1'
+        expect(artifact_ns[:b]).not_to be_selected
+        expect(artifact_ns[:b]).to be_satisfied_by('a:b:c:1')
+        expect(artifact_ns[:b]).not_to be_satisfied_by('a:b:c:2')
+        expect(artifact_ns[:b]).not_to be_satisfied_by('d:b:c:1')
+        expect(artifact_ns[:b].version).to eq('1')
       end
     end
 
@@ -166,14 +166,14 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns.need 'a:b:c:d:1'
         # referenced by spec
-        artifact_ns['a:b:c:d:'].should_not be_selected
+        expect(artifact_ns['a:b:c:d:']).not_to be_selected
 
         # referenced by name
-        artifact_ns[:b].should_not be_selected
-        artifact_ns[:b].should be_satisfied_by('a:b:c:d:1')
-        artifact_ns[:b].should_not be_satisfied_by('a:b:c:d:2')
-        artifact_ns[:b].should_not be_satisfied_by('d:b:c:d:1')
-        artifact_ns[:b].version.should == '1'
+        expect(artifact_ns[:b]).not_to be_selected
+        expect(artifact_ns[:b]).to be_satisfied_by('a:b:c:d:1')
+        expect(artifact_ns[:b]).not_to be_satisfied_by('a:b:c:d:2')
+        expect(artifact_ns[:b]).not_to be_satisfied_by('d:b:c:d:1')
+        expect(artifact_ns[:b].version).to eq('1')
       end
     end
 
@@ -181,30 +181,30 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns.need 'thing -> a:b:c:2.1 -> ~>2.0'
         # referenced by spec
-        artifact_ns['a:b:c'].should_not be_selected
+        expect(artifact_ns['a:b:c']).not_to be_selected
 
         # referenced by name
-        artifact_ns.key?(:b).should be_false
-        artifact_ns[:thing].should_not be_selected
-        artifact_ns[:thing].should be_satisfied_by('a:b:c:2.5')
-        artifact_ns[:thing].should_not be_satisfied_by('a:b:c:3')
-        artifact_ns[:thing].version.should == '2.1'
+        expect(artifact_ns.key?(:b)).to be_falsey
+        expect(artifact_ns[:thing]).not_to be_selected
+        expect(artifact_ns[:thing]).to be_satisfied_by('a:b:c:2.5')
+        expect(artifact_ns[:thing]).not_to be_satisfied_by('a:b:c:3')
+        expect(artifact_ns[:thing].version).to eq('2.1')
       end
     end
 
     it 'should accept a hash :name -> requirement_spec' do
       define 'one' do
         artifact_ns.need :thing => 'a:b:c:2.1 -> ~>2.0'
-        artifact_ns[:thing].should be_satisfied_by('a:b:c:2.5')
-        artifact_ns[:thing].should_not be_satisfied_by('a:b:c:3')
-        artifact_ns[:thing].version.should == '2.1'
+        expect(artifact_ns[:thing]).to be_satisfied_by('a:b:c:2.5')
+        expect(artifact_ns[:thing]).not_to be_satisfied_by('a:b:c:3')
+        expect(artifact_ns[:thing].version).to eq('2.1')
       end
 
       define 'two' do
         artifact_ns.need :thing => 'a:b:c:(~>2.0 | 2.1)'
-        artifact_ns[:thing].should be_satisfied_by('a:b:c:2.5')
-        artifact_ns[:thing].should_not be_satisfied_by('a:b:c:3')
-        artifact_ns[:thing].version.should == '2.1'
+        expect(artifact_ns[:thing]).to be_satisfied_by('a:b:c:2.5')
+        expect(artifact_ns[:thing]).not_to be_satisfied_by('a:b:c:3')
+        expect(artifact_ns[:thing].version).to eq('2.1')
       end
     end
 
@@ -212,12 +212,12 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns.need :things => ['foo:bar:jar:1.0',
                                      'foo:baz:jar:2.0',]
-        artifact_ns['foo:bar:jar'].should_not be_selected
-        artifact_ns['foo:baz:jar'].should_not be_selected
-        artifact_ns[:bar, :baz].should == [nil, nil]
-        artifact_ns[:things].map(&:unversioned_spec).should include('foo:bar:jar', 'foo:baz:jar')
+        expect(artifact_ns['foo:bar:jar']).not_to be_selected
+        expect(artifact_ns['foo:baz:jar']).not_to be_selected
+        expect(artifact_ns[:bar, :baz]).to eq([nil, nil])
+        expect(artifact_ns[:things].map(&:unversioned_spec)).to include('foo:bar:jar', 'foo:baz:jar')
         artifact_ns.alias :baz, 'foo:baz:jar'
-        artifact_ns[:baz].should == artifact_ns['foo:baz:jar']
+        expect(artifact_ns[:baz]).to eq(artifact_ns['foo:baz:jar'])
       end
     end
 
@@ -226,22 +226,22 @@ describe Buildr::ArtifactNamespace do
         artifact_ns.use :a => 'foo:bar:jar:1.5'
         artifact_ns.use :b => 'foo:baz:jar:2.0'
         define 'two' do
-          artifact_ns[:a].requirement.should be_nil
-          artifact_ns[:a].should be_selected
+          expect(artifact_ns[:a].requirement).to be_nil
+          expect(artifact_ns[:a]).to be_selected
 
           artifact_ns.need :c => 'foo:bat:jar:3.0'
-          artifact_ns['foo:bat:jar'].should_not be_selected
-          artifact_ns[:c].should_not be_selected
+          expect(artifact_ns['foo:bat:jar']).not_to be_selected
+          expect(artifact_ns[:c]).not_to be_selected
 
           artifact_ns.need :one => 'foo:bar:jar:>=1.0'
-          artifact_ns[:one].version.should == '1.5'
-          artifact_ns[:one].should be_selected
-          artifact_ns[:a].requirement.should be_nil
+          expect(artifact_ns[:one].version).to eq('1.5')
+          expect(artifact_ns[:one]).to be_selected
+          expect(artifact_ns[:a].requirement).to be_nil
 
           artifact_ns.need :two => 'foo:baz:jar:>2'
-          artifact_ns[:two].version.should be_nil
-          artifact_ns[:two].should_not be_selected
-          artifact_ns[:b].requirement.should be_nil
+          expect(artifact_ns[:two].version).to be_nil
+          expect(artifact_ns[:two]).not_to be_selected
+          expect(artifact_ns[:b].requirement).to be_nil
         end
       end
     end
@@ -251,27 +251,27 @@ describe Buildr::ArtifactNamespace do
     it 'should register the artifact on namespace' do
       define 'one' do
         artifact_ns.use :thing => 'a:b:c:1'
-        artifact_ns[:thing].requirement.should be_nil
-        artifact_ns[:thing].version.should == '1'
-        artifact_ns[:thing].id.should == 'b'
+        expect(artifact_ns[:thing].requirement).to be_nil
+        expect(artifact_ns[:thing].version).to eq('1')
+        expect(artifact_ns[:thing].id).to eq('b')
         define 'one' do
           artifact_ns.use :thing => 'a:d:c:2'
-          artifact_ns[:thing].requirement.should be_nil
-          artifact_ns[:thing].version.should == '2'
-          artifact_ns[:thing].id.should == 'd'
+          expect(artifact_ns[:thing].requirement).to be_nil
+          expect(artifact_ns[:thing].version).to eq('2')
+          expect(artifact_ns[:thing].id).to eq('d')
 
           artifact_ns.use :copied => artifact_ns.parent[:thing]
-          artifact_ns[:copied].should_not == artifact_ns.parent[:thing]
-          artifact_ns[:copied].requirement.should be_nil
-          artifact_ns[:copied].version.should == '1'
-          artifact_ns[:copied].id.should == 'b'
+          expect(artifact_ns[:copied]).not_to eq(artifact_ns.parent[:thing])
+          expect(artifact_ns[:copied].requirement).to be_nil
+          expect(artifact_ns[:copied].version).to eq('1')
+          expect(artifact_ns[:copied].id).to eq('b')
 
           artifact_ns.use :aliased => :copied
-          artifact_ns[:aliased].should == artifact_ns[:copied]
+          expect(artifact_ns[:aliased]).to eq(artifact_ns[:copied])
 
-          lambda { artifact_ns.use :invalid => :unknown }.should raise_error(NameError, /undefined/i)
+          expect { artifact_ns.use :invalid => :unknown }.to raise_error(NameError, /undefined/i)
         end
-        artifact_ns[:copied].should be_nil
+        expect(artifact_ns[:copied]).to be_nil
       end
     end
 
@@ -279,40 +279,40 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns.use :foo => 'a:b:c:1'
         artifact_ns.use :bar => 'a:b:c:2'
-        artifact_ns[:foo].version.should == '1'
-        artifact_ns[:bar].version.should == '2'
+        expect(artifact_ns[:foo].version).to eq('1')
+        expect(artifact_ns[:bar].version).to eq('2')
         # unversioned references the last version set.
-        artifact_ns['a:b:c'].version.should == '2'
+        expect(artifact_ns['a:b:c'].version).to eq('2')
       end
     end
 
     it 'should complain if namespace requirement is not satisfied' do
       define 'one' do
         artifact_ns.need :bar => 'foo:bar:baz:~>1.5'
-        lambda { artifact_ns.use :bar => '1.4' }.should raise_error(Exception, /unsatisfied/i)
+        expect { artifact_ns.use :bar => '1.4' }.to raise_error(Exception, /unsatisfied/i)
       end
     end
 
     it 'should be able to register a group' do
       specs = ['its:me:here:1', 'its:you:there:2']
       artifact_ns.use :them => specs
-      artifact_ns[:them].map(&:to_spec).should == specs
-      artifact_ns['its:me:here'].should_not be_nil
-      artifact_ns[:you].should be_nil
+      expect(artifact_ns[:them].map(&:to_spec)).to eq(specs)
+      expect(artifact_ns['its:me:here']).not_to be_nil
+      expect(artifact_ns[:you]).to be_nil
     end
 
     it 'should be able to assign sub namespaces' do
       artifact_ns(:foo).bar = "foo:bar:baz:0"
       artifact_ns(:moo).foo = artifact_ns(:foo)
-      artifact_ns(:moo).foo.should == artifact_ns(:foo)
-      artifact_ns(:moo).foo_bar.should == artifact_ns(:foo).bar
+      expect(artifact_ns(:moo).foo).to eq(artifact_ns(:foo))
+      expect(artifact_ns(:moo).foo_bar).to eq(artifact_ns(:foo).bar)
     end
 
     it 'should handle symbols with dashes and periods' do
       [:'a-b', :'a.b'].each do |symbol|
         artifact_ns.use symbol => 'a:b:c:1'
-        artifact_ns[symbol].version.should == '1'
-        artifact_ns[symbol].id.should == 'b'
+        expect(artifact_ns[symbol].version).to eq('1')
+        expect(artifact_ns[symbol].id).to eq('b')
       end
     end
 
@@ -321,7 +321,7 @@ describe Buildr::ArtifactNamespace do
         ns.bar = 'a:b:c:1'
       end
       foo.use :bar => '2.0'
-      foo.bar.version.should == '2.0'
+      expect(foo.bar.version).to eq('2.0')
     end
   end
 
@@ -333,11 +333,11 @@ describe Buildr::ArtifactNamespace do
           artifact_ns.use 'foo:two:baz:1.0'
 
           specs = artifact_ns.values.map(&:to_spec)
-          specs.should include('foo:two:baz:1.0')
-          specs.should_not include('foo:one:baz:1.0')
+          expect(specs).to include('foo:two:baz:1.0')
+          expect(specs).not_to include('foo:one:baz:1.0')
 
           specs = artifact_ns.values(true).map(&:to_spec)
-          specs.should include('foo:two:baz:1.0', 'foo:one:baz:1.0')
+          expect(specs).to include('foo:two:baz:1.0', 'foo:one:baz:1.0')
         end
       end
     end
@@ -351,12 +351,12 @@ describe Buildr::ArtifactNamespace do
           artifact_ns.use :foo_baz => 'foo:two:baz:1.0'
 
           specs = artifact_ns.values_at('one').map(&:to_spec)
-          specs.should include('foo:one:baz:1.0')
-          specs.should_not include('foo:two:baz:1.0')
+          expect(specs).to include('foo:one:baz:1.0')
+          expect(specs).not_to include('foo:two:baz:1.0')
 
           specs = artifact_ns.values_at('foo_baz').map(&:to_spec)
-          specs.should include('foo:two:baz:1.0')
-          specs.should_not include('foo:one:baz:1.0')
+          expect(specs).to include('foo:two:baz:1.0')
+          expect(specs).not_to include('foo:one:baz:1.0')
         end
       end
     end
@@ -368,12 +368,12 @@ describe Buildr::ArtifactNamespace do
           artifact_ns.use :older => 'foo:one:baz:1.0'
 
           specs = artifact_ns.values_at('foo:one:baz').map(&:to_spec)
-          specs.should include('foo:one:baz:1.0')
-          specs.should_not include('foo:one:baz:2.0')
+          expect(specs).to include('foo:one:baz:1.0')
+          expect(specs).not_to include('foo:one:baz:2.0')
         end
         specs = artifact_ns.values_at('foo:one:baz').map(&:to_spec)
-        specs.should include('foo:one:baz:2.0')
-        specs.should_not include('foo:one:baz:1.0')
+        expect(specs).to include('foo:one:baz:2.0')
+        expect(specs).not_to include('foo:one:baz:1.0')
       end
     end
 
@@ -384,8 +384,8 @@ describe Buildr::ArtifactNamespace do
           artifact_ns.use :older => 'foo:one:baz:1.0'
 
           specs = artifact_ns.values_at('foo:one:baz:>1.0').map(&:to_spec)
-          specs.should include('foo:one:baz:2.0')
-          specs.should_not include('foo:one:baz:1.0')
+          expect(specs).to include('foo:one:baz:2.0')
+          expect(specs).not_to include('foo:one:baz:1.0')
         end
       end
     end
@@ -396,7 +396,7 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns[:foo] = 'group:foo:jar:1'
         artifact_ns[:bar] = 'group:bar:jar:1'
-        artifact_ns.artifacts.map{|a| a.to_spec}.should include('group:foo:jar:1', 'group:bar:jar:1')
+        expect(artifact_ns.artifacts.map{|a| a.to_spec}).to include('group:foo:jar:1', 'group:bar:jar:1')
       end
     end
   end
@@ -406,7 +406,7 @@ describe Buildr::ArtifactNamespace do
       define 'one' do
         artifact_ns[:foo] = 'group:foo:jar:1'
         artifact_ns[:bar] = 'group:bar:jar:1'
-        artifact_ns.keys.should include('foo', 'bar')
+        expect(artifact_ns.keys).to include('foo', 'bar')
       end
     end
   end
@@ -417,8 +417,8 @@ describe Buildr::ArtifactNamespace do
         artifact_ns[:foo] = 'group:foo:jar:1'
         artifact_ns[:bar] = 'group:bar:jar:1'
         artifact_ns.delete :bar
-        artifact_ns.artifacts.map{|a| a.to_spec}.should include('group:foo:jar:1')
-        artifact_ns[:foo].to_spec.should eql('group:foo:jar:1')
+        expect(artifact_ns.artifacts.map{|a| a.to_spec}).to include('group:foo:jar:1')
+        expect(artifact_ns[:foo].to_spec).to eql('group:foo:jar:1')
       end
     end
   end
@@ -429,7 +429,7 @@ describe Buildr::ArtifactNamespace do
         artifact_ns[:foo] = 'group:foo:jar:1'
         artifact_ns[:bar] = 'group:bar:jar:1'
         artifact_ns.clear
-        artifact_ns.artifacts.should be_empty
+        expect(artifact_ns.artifacts).to be_empty
       end
     end
   end
@@ -437,86 +437,86 @@ describe Buildr::ArtifactNamespace do
   describe '#method_missing' do
     it 'should use cool_aid! to create a requirement' do
       define 'foo' do
-        artifact_ns.cool_aid!('cool:aid:jar:2').should be_kind_of(ArtifactNamespace::ArtifactRequirement)
-        artifact_ns[:cool_aid].version.should == '2'
-        artifact_ns[:cool_aid].should_not be_selected
+        expect(artifact_ns.cool_aid!('cool:aid:jar:2')).to be_kind_of(ArtifactNamespace::ArtifactRequirement)
+        expect(artifact_ns[:cool_aid].version).to eq('2')
+        expect(artifact_ns[:cool_aid]).not_to be_selected
         define 'bar' do
           artifact_ns.cool_aid! 'cool:aid:man:3', '>2'
-          artifact_ns[:cool_aid].version.should == '3'
-          artifact_ns[:cool_aid].requirement.should be_satisfied_by('2.5')
-          artifact_ns[:cool_aid].should_not be_selected
+          expect(artifact_ns[:cool_aid].version).to eq('3')
+          expect(artifact_ns[:cool_aid].requirement).to be_satisfied_by('2.5')
+          expect(artifact_ns[:cool_aid]).not_to be_selected
         end
       end
     end
 
     it 'should use cool_aid= as shorhand for [:cool_aid]=' do
       artifact_ns.cool_aid = 'cool:aid:jar:1'
-      artifact_ns[:cool_aid].should be_selected
+      expect(artifact_ns[:cool_aid]).to be_selected
     end
 
     it 'should use cool_aid as shorthand for [:cool_aid]' do
       artifact_ns.need :cool_aid => 'cool:aid:jar:1'
-      artifact_ns.cool_aid.should_not be_selected
+      expect(artifact_ns.cool_aid).not_to be_selected
     end
 
     it 'should use cool_aid? to test if artifact has been defined and selected' do
       artifact_ns.need :cool_aid => 'cool:aid:jar:>1'
-      artifact_ns.should_not have_cool_aid
-      artifact_ns.should_not have_unknown
+      expect(artifact_ns.has_cool_aid?).to be_falsey
+      expect(artifact_ns.has_unknown?).to be_falsey
       artifact_ns.cool_aid = '2'
-      artifact_ns.should have_cool_aid
+      expect(artifact_ns.has_cool_aid?).to be_truthy
     end
   end
 
   describe '#ns' do
     it 'should create a sub namespace' do
       artifact_ns.ns :foo
-      artifact_ns[:foo].should be_kind_of(ArtifactNamespace)
-      artifact_ns(:foo).should_not === artifact_ns.foo
-      artifact_ns.foo.parent.should == artifact_ns
+      expect(artifact_ns[:foo]).to be_kind_of(ArtifactNamespace)
+      expect(artifact_ns(:foo)).not_to be === artifact_ns.foo
+      expect(artifact_ns.foo.parent).to eq(artifact_ns)
     end
 
     it 'should take any use arguments' do
       artifact_ns.ns :foo, :bar => 'foo:bar:jar:0', :baz => 'foo:baz:jar:0'
-      artifact_ns.foo.bar.should be_selected
-      artifact_ns.foo[:baz].should be_selected
+      expect(artifact_ns.foo.bar).to be_selected
+      expect(artifact_ns.foo[:baz]).to be_selected
     end
 
     it 'should access sub artifacts using with foo_bar like syntax' do
       artifact_ns.ns :foo, :bar => 'foo:bar:jar:0', :baz => 'foo:baz:jar:0'
-      artifact_ns[:foo_baz].should be_selected
-      artifact_ns.foo_bar.should be_selected
+      expect(artifact_ns[:foo_baz]).to be_selected
+      expect(artifact_ns.foo_bar).to be_selected
 
       artifact_ns.foo.ns :bat, 'bat:man:jar:>1'
       batman = artifact_ns.foo.bat.man
-      batman.should be_selected
+      expect(batman).to be_selected
       artifact_ns[:foo_bat_man] = '3'
-      artifact_ns[:foo_bat_man].should == batman
-      artifact_ns[:foo_bat_man].version.should == '3'
+      expect(artifact_ns[:foo_bat_man]).to eq(batman)
+      expect(artifact_ns[:foo_bat_man].version).to eq('3')
     end
 
     it 'should include sub artifacts when calling #values' do
       artifact_ns.ns :bat, 'bat:man:jar:>1'
-      artifact_ns.values.should_not be_empty
-      artifact_ns.values.first.unversioned_spec.should == 'bat:man:jar'
+      expect(artifact_ns.values).not_to be_empty
+      expect(artifact_ns.values.first.unversioned_spec).to eq('bat:man:jar')
     end
 
     it 'should reopen a sub-namespace' do
       artifact_ns.ns :bat, 'bat:man:jar:>1'
       bat = artifact_ns[:bat]
-      bat.should == artifact_ns.ns(:bat)
+      expect(bat).to eq(artifact_ns.ns(:bat))
     end
 
     it 'should fail reopening if not a sub-namespace' do
       artifact_ns.foo = 'foo:bar:baz:0'
-      lambda { artifact_ns.ns(:foo) }.should raise_error(TypeError, /not a sub/i)
+      expect { artifact_ns.ns(:foo) }.to raise_error(TypeError, /not a sub/i)
     end
 
     it 'should clone artifacts when assigned' do
       artifact_ns(:foo).bar = "foo:bar:jar:0"
       artifact_ns(:moo).ns :muu, :miu => artifact_ns(:foo).bar
-      artifact_ns(:moo).muu.miu.should_not == artifact_ns(:foo).bar
-      artifact_ns(:moo).muu.miu.to_spec.should == artifact_ns(:foo).bar.to_spec
+      expect(artifact_ns(:moo).muu.miu).not_to eq(artifact_ns(:foo).bar)
+      expect(artifact_ns(:moo).muu.miu.to_spec).to eq(artifact_ns(:foo).bar.to_spec)
     end
 
     it 'should clone parent artifacts by name' do
@@ -524,17 +524,17 @@ describe Buildr::ArtifactNamespace do
         artifact_ns.bar = "foo:bar:jar:0"
         define 'moo' do
           artifact_ns.ns(:muu).use :bar
-          artifact_ns.muu_bar.should be_selected
-          artifact_ns.muu.bar.should_not == artifact_ns.bar
+          expect(artifact_ns.muu_bar).to be_selected
+          expect(artifact_ns.muu.bar).not_to eq(artifact_ns.bar)
         end
       end
     end
   end
 
   it 'should be an Enumerable' do
-    artifact_ns.should be_kind_of(Enumerable)
+    expect(artifact_ns).to be_kind_of(Enumerable)
     artifact_ns.use 'foo:bar:baz:1.0'
-    artifact_ns.map(&:artifact).should include(artifact('foo:bar:baz:1.0'))
+    expect(artifact_ns.map(&:artifact)).to include(artifact('foo:bar:baz:1.0'))
   end
 
 end # ArtifactNamespace
@@ -545,7 +545,7 @@ describe Buildr::ArtifactNamespace::ArtifactRequirement do
     foo = artifact_ns do |ns|
       ns.bar = 'a:b:c:1.0'
     end
-    foo.bar.should be_kind_of(ArtifactNamespace::ArtifactRequirement)
+    expect(foo.bar).to be_kind_of(ArtifactNamespace::ArtifactRequirement)
   end
 
   it 'should handle version as string' do
@@ -553,7 +553,7 @@ describe Buildr::ArtifactNamespace::ArtifactRequirement do
       ns.bar = 'a:b:c:1.0'
     end
     foo.bar.version = '2.0'
-    foo.bar.version.should == '2.0'
+    expect(foo.bar.version).to eq('2.0')
   end
 
   it 'should handle version string directly' do
@@ -561,7 +561,7 @@ describe Buildr::ArtifactNamespace::ArtifactRequirement do
       ns.bar = 'a:b:c:1.0'
     end
     foo.bar = '2.0'
-    foo.bar.version.should == '2.0'
+    expect(foo.bar.version).to eq('2.0')
   end
 
 end # ArtifactRequirement
@@ -576,7 +576,7 @@ describe Buildr do
         artifact_ns.use 'some:other:jar:1.0'
         artifact_ns.use 'bat:man:jar:1.0'
         compile.with :cool, :other, :'bat:man:jar'
-        compile.dependencies.map(&:to_spec).should include('cool:aid:jar:1.0', 'some:other:jar:1.0', 'bat:man:jar:1.0')
+        expect(compile.dependencies.map(&:to_spec)).to include('cool:aid:jar:1.0', 'some:other:jar:1.0', 'bat:man:jar:1.0')
       end
     end
 
@@ -584,7 +584,7 @@ describe Buildr do
       artifact_ns(:moo).muu = 'moo:muu:jar:1.0'
       define 'foo' do
         compile.with artifact_ns(:moo)
-        compile.dependencies.map(&:to_spec).should include('moo:muu:jar:1.0')
+        expect(compile.dependencies.map(&:to_spec)).to include('moo:muu:jar:1.0')
       end
     end
   end
@@ -594,7 +594,7 @@ describe Buildr do
       define 'foo' do
         artifact_ns.use :cool => 'cool:aid:jar:1.0'
         define 'bar' do
-          artifact(:cool).should == artifact_ns[:cool].artifact
+          expect(artifact(:cool)).to eq(artifact_ns[:cool].artifact)
         end
       end
     end
@@ -603,7 +603,7 @@ describe Buildr do
       define 'foo' do
         artifact_ns.use 'cool:aid:jar:1.0'
         define 'bar' do
-          artifact(:'cool:aid:jar').should == artifact_ns[:aid].artifact
+          expect(artifact(:'cool:aid:jar')).to eq(artifact_ns[:aid].artifact)
         end
       end
     end
@@ -612,7 +612,7 @@ describe Buildr do
       define 'foo' do
         artifact_ns.use 'cool:aid:jar:1.0'
         define 'bar' do
-          lambda { artifact(:cool) }.should raise_error(IndexError, /artifact/)
+          expect { artifact(:cool) }.to raise_error(IndexError, /artifact/)
         end
       end
     end
@@ -666,13 +666,13 @@ describe "Extension using ArtifactNamespace" do
           options.xmlbeans.add_listener &method(:selected_xmlbeans)
           options.stax_api.add_listener do |stax|
             # Now using a proc
-            stax.should be_selected
-            stax.version.should == '1.6180'
+            expect(stax).to be_selected
+            expect(stax.version).to eq('1.6180')
             options[:math] = :golden # customize our options for this version
             # In this example we set the stax version when running outside
             # a project definition. This means we have no access to the project
             # namespace unless we had a reference to the project or knew it's name
-            Buildr.artifact_ns(:current).name.should == 'root'
+            expect(Buildr.artifact_ns(:current).name).to eq('root')
           end
         end
 
@@ -682,12 +682,12 @@ describe "Extension using ArtifactNamespace" do
         # by a user. This allows extension author to selectively perform
         # some action by inspecting the requirement state.
         def selected_xmlbeans(xmlbeans)
-          xmlbeans.should be_selected
-          xmlbeans.version.should == '3.1415'
+          expect(xmlbeans).to be_selected
+          expect(xmlbeans.version).to eq('3.1415')
           options[:math] = :pi
           # This example just sets xmlbeans for foo:bar project
           # So the currently running namespace should have the foo:bar name
-          Buildr.artifact_ns(:current).name.should == 'foo:bar'
+          expect(Buildr.artifact_ns(:current).name).to eq('foo:bar')
         end
 
         # Suppose we invoke an ant task here or something else.
@@ -697,7 +697,7 @@ describe "Extension using ArtifactNamespace" do
           lambda { ant('thing') { |ant| ant.classpath classpath, :math => options[:math] } }
 
           # We are not a Project instance, hence we have no artifact_ns
-          lambda { artifact_ns }.should raise_error(NameError)
+          expect { artifact_ns }.to raise_error(NameError)
 
           # Extension authors may NOT rely project's namespaces.
           # However the ruby-way gives you power and at the same time
@@ -719,13 +719,13 @@ describe "Extension using ArtifactNamespace" do
           name = Buildr.artifact_ns(:current).name
           case name
           when 'foo:bar'
-            options[:math].should == :pi
-            requires.xmlbeans.version.should == '3.1415'
-            requires.stax_api.version.should == '1.0.1'
+            expect(options[:math]).to eq(:pi)
+            expect(requires.xmlbeans.version).to eq('3.1415')
+            expect(requires.stax_api.version).to eq('1.0.1')
           when 'foo:baz'
-            options[:math].should == :golden
-            requires.xmlbeans.version.should == '2.3.0'
-            requires.stax_api.version.should == '1.6180'
+            expect(options[:math]).to eq(:golden)
+            expect(requires.xmlbeans.version).to eq('2.3.0')
+            expect(requires.stax_api.version).to eq('1.6180')
           else
             fail "This example expects foo:bar or foo:baz projects not #{name.inspect}"
           end
@@ -745,14 +745,14 @@ describe "Extension using ArtifactNamespace" do
         end
       end
 
-      project('foo:bar').example.requires.should_not == project('foo:baz').example.requires
-      project('foo:bar').example.requires.xmlbeans.should_not == project('foo:baz').example.requires.xmlbeans
+      expect(project('foo:bar').example.requires).not_to eq(project('foo:baz').example.requires)
+      expect(project('foo:bar').example.requires.xmlbeans).not_to eq(project('foo:baz').example.requires.xmlbeans)
 
       # current namespace outside a project is :root, see the stax callback
       project('foo:baz').example.options.stax_api = '1.6180'
       # we call the task outside the project, see #doit
-      lambda { task('foo:bar:run').invoke }.should run_task('foo:bar:example')
-      lambda { task('foo:baz:example').invoke }.should run_task('foo:baz:example')
+      expect { task('foo:bar:run').invoke }.to run_task('foo:bar:example')
+      expect { task('foo:baz:example').invoke }.to run_task('foo:baz:example')
     end
   end
 end

--- a/spec/packaging/artifact_spec.rb
+++ b/spec/packaging/artifact_spec.rb
@@ -29,120 +29,120 @@ describe Artifact do
 
 
   it 'should act as one' do
-    @artifact.should respond_to(:to_spec)
+    expect(@artifact).to respond_to(:to_spec)
   end
 
   it 'should have an artifact identifier' do
-    @artifact.id.should eql('library')
+    expect(@artifact.id).to eql('library')
   end
 
   it 'should have a group identifier' do
-    @artifact.group.should eql('com.example')
+    expect(@artifact.group).to eql('com.example')
   end
 
   it 'should have a version number' do
-    @artifact.version.should eql('2.0')
+    expect(@artifact.version).to eql('2.0')
   end
 
   it 'should know if it is a snapshot' do
-    @artifact.should_not be_snapshot
-    @classified.should_not be_snapshot
-    @snapshot.should be_snapshot
+    expect(@artifact).not_to be_snapshot
+    expect(@classified).not_to be_snapshot
+    expect(@snapshot).to be_snapshot
   end
 
   it 'should have a file type' do
-    @artifact.type.should eql(:jar)
+    expect(@artifact.type).to eql(:jar)
   end
 
   it 'should understand classifier' do
-    @artifact.classifier.should be_nil
-    @classified.classifier.should eql('all')
+    expect(@artifact.classifier).to be_nil
+    expect(@classified.classifier).to eql('all')
   end
 
   it 'should return hash specification' do
-    @artifact.to_hash.should == @spec
-    @artifact.to_spec_hash.should == @spec
-    @classified.to_hash.should == @spec.merge(:classifier=>'all')
+    expect(@artifact.to_hash).to eq(@spec)
+    expect(@artifact.to_spec_hash).to eq(@spec)
+    expect(@classified.to_hash).to eq(@spec.merge(:classifier=>'all'))
   end
 
   it 'should return string specification' do
-    @artifact.to_spec.should eql('com.example:library:jar:2.0')
-    @classified.to_spec.should eql('com.example:library:jar:all:2.0')
+    expect(@artifact.to_spec).to eql('com.example:library:jar:2.0')
+    expect(@classified.to_spec).to eql('com.example:library:jar:all:2.0')
   end
 
   it 'should have associated POM artifact' do
-    @artifact.pom.to_hash.should == @artifact.to_hash.merge(:type=>:pom)
+    expect(@artifact.pom.to_hash).to eq(@artifact.to_hash.merge(:type=>:pom))
   end
 
   it 'should have one POM artifact for all classifiers' do
-    @classified.pom.to_hash.should == @classified.to_hash.merge(:type=>:pom).except(:classifier)
+    expect(@classified.pom.to_hash).to eq(@classified.to_hash.merge(:type=>:pom).except(:classifier))
   end
 
   it 'should have associated sources artifact' do
-    @artifact.sources_artifact.to_hash.should == @artifact.to_hash.merge(:classifier=>'sources')
+    expect(@artifact.sources_artifact.to_hash).to eq(@artifact.to_hash.merge(:classifier=>'sources'))
   end
 
   it 'should have associated javadoc artifact' do
-    @artifact.javadoc_artifact.to_hash.should == @artifact.to_hash.merge(:classifier=>'javadoc')
+    expect(@artifact.javadoc_artifact.to_hash).to eq(@artifact.to_hash.merge(:classifier=>'javadoc'))
   end
 
   it 'should download file if file does not exist' do
-    lambda { @artifact.invoke }.should raise_error(Exception, /No remote repositories/)
-    lambda { @classified.invoke }.should raise_error(Exception, /No remote repositories/)
+    expect { @artifact.invoke }.to raise_error(Exception, /No remote repositories/)
+    expect { @classified.invoke }.to raise_error(Exception, /No remote repositories/)
   end
 
   it 'should not download file if file exists' do
     write repositories.locate(@artifact)
-    lambda { @artifact.invoke }.should_not raise_error
+    expect { @artifact.invoke }.not_to raise_error
     write repositories.locate(@classified)
-    lambda { @classified.invoke }.should_not raise_error
+    expect { @classified.invoke }.not_to raise_error
   end
 
   it 'should handle lack of POM gracefully' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).twice { |*args| raise URI::NotFoundError if args[0].to_s.end_with?('.pom') }
-    lambda { @artifact.invoke }.should_not raise_error
+    expect(URI).to receive(:download).twice { |*args| raise URI::NotFoundError if args[0].to_s.end_with?('.pom') }
+    expect { @artifact.invoke }.not_to raise_error
   end
 
   it 'should pass if POM provided' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
     @artifact.pom.enhance { |task| write task.name, @artifact.pom_xml.call }
     write repositories.locate(@artifact)
-    lambda { @artifact.invoke }.should_not raise_error
+    expect { @artifact.invoke }.not_to raise_error
   end
 
   it 'should pass if POM not required' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
     class << @artifact ; def pom() ; end ; end
     write repositories.locate(@artifact)
-    lambda { @artifact.invoke }.should_not raise_error
+    expect { @artifact.invoke }.not_to raise_error
   end
 
   it 'should not download file if dry-run' do
     dryrun do
-      lambda { @artifact.invoke }.should_not raise_error
-      lambda { @classified.invoke }.should_not raise_error
+      expect { @artifact.invoke }.not_to raise_error
+      expect { @classified.invoke }.not_to raise_error
     end
   end
 
   it 'should resolve to path in local repository' do
-    @artifact.to_s.should == File.join(repositories.local, 'com/example/library/2.0/library-2.0.jar')
-    @classified.to_s.should == File.join(repositories.local, 'com/example/library/2.0/library-2.0-all.jar')
+    expect(@artifact.to_s).to eq(File.join(repositories.local, 'com/example/library/2.0/library-2.0.jar'))
+    expect(@classified.to_s).to eq(File.join(repositories.local, 'com/example/library/2.0/library-2.0-all.jar'))
   end
 
   it 'should return a list of all registered artifact specifications' do
     define('foo', :version=>'1.0') { package :jar }
-    Artifact.list.should include(@artifact.to_spec)
-    Artifact.list.should include(@classified.to_spec)
-    Artifact.list.should include('foo:foo:jar:1.0')
+    expect(Artifact.list).to include(@artifact.to_spec)
+    expect(Artifact.list).to include(@classified.to_spec)
+    expect(Artifact.list).to include('foo:foo:jar:1.0')
   end
 
   it 'should accept user-defined string content' do
     a = artifact(@spec)
     a.content 'foo'
     install a
-    lambda { install.invoke }.should change { File.exist?(a.to_s) && File.exist?(repositories.locate(a)) }.to(true)
-    read(repositories.locate(a)).should eql('foo')
+    expect { install.invoke }.to change { File.exist?(a.to_s) && File.exist?(repositories.locate(a)) }.to(true)
+    expect(read(repositories.locate(a))).to eql('foo')
   end
 end
 
@@ -157,29 +157,29 @@ describe Repositories, 'local' do
   it 'should default to .m2 path' do
     # For convenience, sandbox actually sets the local repository to a temp directory
     repositories.local = nil
-    repositories.local.should eql(File.expand_path('.m2/repository', ENV['HOME']))
+    expect(repositories.local).to eql(File.expand_path('.m2/repository', ENV['HOME']))
   end
 
   it 'should be settable' do
     repositories.local = '.m2/local'
-    repositories.local.should eql(File.expand_path('.m2/local'))
+    expect(repositories.local).to eql(File.expand_path('.m2/local'))
   end
 
   it 'should reset to default' do
     repositories.local = '.m2/local'
     repositories.local = nil
-    repositories.local.should eql(File.expand_path('~/.m2/repository'))
+    expect(repositories.local).to eql(File.expand_path('~/.m2/repository'))
   end
 
   it 'should locate file from string specification' do
     repositories.local = nil
-    repositories.locate('com.example:library:jar:2.0').should eql(
+    expect(repositories.locate('com.example:library:jar:2.0')).to eql(
       File.expand_path('~/.m2/repository/com/example/library/2.0/library-2.0.jar'))
   end
 
   it 'should locate file from hash specification' do
     repositories.local = nil
-    repositories.locate(:group=>'com.example', :id=>'library', :version=>'2.0').should eql(
+    expect(repositories.locate(:group=>'com.example', :id=>'library', :version=>'2.0')).to eql(
       File.expand_path('~/.m2/repository/com/example/library/2.0/library-2.0.jar'))
   end
 
@@ -188,7 +188,7 @@ describe Repositories, 'local' do
     repositories:
       local: my_repo
     YAML
-    repositories.local.should eql(File.expand_path('my_repo'))
+    expect(repositories.local).to eql(File.expand_path('my_repo'))
   end
 
   it 'should not override custom install methods defined when extending an object' do
@@ -205,7 +205,7 @@ describe Repositories, 'local' do
     task.result = "maybe"
     task.extend ActsAsArtifact
     task.install
-    task.result.should be_true
+    expect(task.result).to be_truthy
   end
 end
 
@@ -220,70 +220,70 @@ describe Repositories, 'remote' do
   end
 
   it 'should be empty initially' do
-    repositories.remote.should be_empty
+    expect(repositories.remote).to be_empty
   end
 
   it 'should be settable' do
     repositories.remote = @repos.first
-    repositories.remote.should eql([@repos.first])
+    expect(repositories.remote).to eql([@repos.first])
   end
 
   it 'should be settable from array' do
     repositories.remote = @repos
-    repositories.remote.should eql(@repos)
+    expect(repositories.remote).to eql(@repos)
   end
 
   it 'should add and return repositories in order' do
     @repos.each { |url| repositories.remote << url }
-    repositories.remote.should eql(@repos)
+    expect(repositories.remote).to eql(@repos)
   end
 
   it 'should be used to download artifact' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).twice.and_return { |uri, target, options| write target }
-    lambda { artifact('com.example:library:jar:2.0').invoke }.
-      should change { File.exist?(File.join(repositories.local, 'com/example/library/2.0/library-2.0.jar')) }.to(true)
+    expect(URI).to receive(:download).twice { |uri, target, options| write target }
+    expect { artifact('com.example:library:jar:2.0').invoke }.
+      to change { File.exist?(File.join(repositories.local, 'com/example/library/2.0/library-2.0.jar')) }.to(true)
   end
 
   it 'should lookup in array order' do
     repositories.remote = [ 'http://buildr.apache.org/repository/noexist', 'http://example.org' ]
     order = ['com', 'org']
-    URI.stub(:download) do |uri, target, options|
+    allow(URI).to receive(:download) do |uri, target, options|
       order.shift if order.first && uri.to_s[order.first]
       fail URI::NotFoundError unless order.empty?
       write target
     end
-    lambda { artifact('com.example:library:jar:2.0').invoke }.should change { order.empty? }
+    expect { artifact('com.example:library:jar:2.0').invoke }.to change { order.empty? }
   end
 
   it 'should fail if artifact not found' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).once.ordered.and_return { fail URI::NotFoundError }
-    lambda { artifact('com.example:library:jar:2.0').invoke }.should raise_error(RuntimeError, /Failed to download/)
-    File.exist?(File.join(repositories.local, 'com/example/library/2.0/library-2.0.jar')).should be_false
+    expect(URI).to receive(:download).once.ordered { fail URI::NotFoundError }
+    expect { artifact('com.example:library:jar:2.0').invoke }.to raise_error(RuntimeError, /Failed to download/)
+    expect(File.exist?(File.join(repositories.local, 'com/example/library/2.0/library-2.0.jar'))).to be_falsey
   end
 
   it 'should support artifact classifier' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).once.and_return { |uri, target, options| write target }
-    lambda { artifact('com.example:library:jar:all:2.0').invoke }.
-      should change { File.exist?(File.join(repositories.local, 'com/example/library/2.0/library-2.0-all.jar')) }.to(true)
+    expect(URI).to receive(:download).once { |uri, target, options| write target }
+    expect { artifact('com.example:library:jar:all:2.0').invoke }.
+      to change { File.exist?(File.join(repositories.local, 'com/example/library/2.0/library-2.0-all.jar')) }.to(true)
   end
 
   it 'should deal well with repositories URL that lack the last slash' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist/base'
     uri = nil
-    URI.should_receive(:download).twice.and_return { |_uri, args| uri = _uri }
+    expect(URI).to receive(:download).twice { |_uri, args| uri = _uri }
     artifact('group:id:jar:1.0').invoke
-    uri.to_s.should eql('http://buildr.apache.org/repository/noexist/base/group/id/1.0/id-1.0.pom')
+    expect(uri.to_s).to eql('http://buildr.apache.org/repository/noexist/base/group/id/1.0/id-1.0.pom')
   end
 
   it 'should deal well with repositories URL that have the last slash' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist/base/'
     uri = nil
-    URI.should_receive(:download).twice.and_return { |_uri, args| uri = _uri }
+    expect(URI).to receive(:download).twice { |_uri, args| uri = _uri }
     artifact('group:id:jar:1.0').invoke
-    uri.to_s.should eql('http://buildr.apache.org/repository/noexist/base/group/id/1.0/id-1.0.pom')
+    expect(uri.to_s).to eql('http://buildr.apache.org/repository/noexist/base/group/id/1.0/id-1.0.pom')
   end
 
   it 'should resolve m2-style deployed snapshots' do
@@ -303,14 +303,11 @@ describe Repositories, 'remote' do
     </metadata>
     XML
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).twice.with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom)$/), anything()).
-      and_return { fail URI::NotFoundError }
-    URI.should_receive(:download).twice.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)).
-      and_return { |uri, target, options| target.write(metadata) }
-    URI.should_receive(:download).twice.with(uri(/2.1-SNAPSHOT\/library-2.1-20071012.190008-8.(jar|pom)$/), /2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom).(\d){1,}$/).
-      and_return { |uri, target, options| write target }
-    lambda { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.
-      should change { File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar')) }.to(true)
+    #expect(URI).to receive(:download).twice.with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom)$/), anything()) { fail URI::NotFoundError }
+    expect(URI).to receive(:download).twice.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), anything()) { |uri, target, options| target.write(metadata) }
+    expect(URI).to receive(:download).twice.with(uri(/2.1-SNAPSHOT\/library-2.1-20071012.190008-8.(jar|pom)$/), /2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom).(\d){1,}$/) { |uri, target, options| write target }
+    expect { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.
+      to change { File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar')) }.to(true)
   end
 
   it 'should resolve m2-style deployed snapshots with classifiers' do
@@ -330,13 +327,11 @@ describe Repositories, 'remote' do
     </metadata>
     XML
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).once.with(uri(/2.1-SNAPSHOT\/library-2.1-20071012.190008-8-classifier.jar$/), anything()).
-      and_return { |uri, target, options| write target }
-    URI.should_receive(:download).once.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)).
-      and_return { |uri, target, options| target.write(metadata) }
+    expect(URI).to receive(:download).once.with(uri(/2.1-SNAPSHOT\/library-2.1-20071012.190008-8-classifier.jar$/), anything()) { |uri, target, options| write target }
+    expect(URI).to receive(:download).once.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), anything()) { |uri, target, options| target.write(metadata) }
     puts repositories.local
-    lambda { artifact('com.example:library:jar:classifier:2.1-SNAPSHOT').invoke}.
-      should change {File.exists?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT-classifier.jar')) }.to(true)
+    expect { artifact('com.example:library:jar:classifier:2.1-SNAPSHOT').invoke}.
+      to change {File.exists?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT-classifier.jar')) }.to(true)
   end
 
   it 'should fail resolving m2-style deployed snapshots if a timestamp is missing' do
@@ -355,14 +350,12 @@ describe Repositories, 'remote' do
     </metadata>
     XML
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).once.with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom)$/), anything()).
-      and_return { fail URI::NotFoundError }
-    URI.should_receive(:download).once.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)).
-      and_return { |uri, target, options| target.write(metadata) }
-    lambda {
-      lambda { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.should raise_error(RuntimeError, /Failed to download/)
-    }.should show_error "No timestamp provided for the snapshot com.example:library:jar:2.1-SNAPSHOT"
-    File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar')).should be_false
+    expect(URI).to receive(:download).once.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), anything()) { |uri, target, options| target.write(metadata) }
+    expect(URI).to receive(:download).once.with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom)$/), anything()) { fail URI::NotFoundError }
+    expect {
+      expect { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.to raise_error(RuntimeError, /Failed to download/)
+    }.to show_error "No timestamp provided for the snapshot com.example:library:jar:2.1-SNAPSHOT"
+    expect(File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar'))).to be_falsey
   end
 
   it 'should fail resolving m2-style deployed snapshots if a build number is missing' do
@@ -381,24 +374,20 @@ describe Repositories, 'remote' do
     </metadata>
     XML
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).once.with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom)$/), anything()).
-      and_return { fail URI::NotFoundError }
-    URI.should_receive(:download).once.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)).
-      and_return { |uri, target, options| target.write(metadata) }
-    lambda {
-      lambda { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.should raise_error(RuntimeError, /Failed to download/)
-    }.should show_error "No build number provided for the snapshot com.example:library:jar:2.1-SNAPSHOT"
-    File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar')).should be_false
+    expect(URI).to receive(:download).once.with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), anything()) { |uri, target, options| target.write(metadata) }
+    expect(URI).to receive(:download).once.with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.(jar|pom)$/), anything()) { fail URI::NotFoundError }
+    expect {
+      expect { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.to raise_error(RuntimeError, /Failed to download/)
+    }.to show_error "No build number provided for the snapshot com.example:library:jar:2.1-SNAPSHOT"
+    expect(File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar'))).to be_falsey
   end
 
   it 'should handle missing maven metadata by reporting the artifact unavailable' do
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.jar$/), anything()).
-      and_return { fail URI::NotFoundError }
-    URI.should_receive(:download).with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)).
-      and_return { fail URI::NotFoundError }
-    lambda { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.should raise_error(RuntimeError, /Failed to download/)
-    File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar')).should be_false
+    expect(URI).to receive(:download).with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), anything()) { fail URI::NotFoundError }
+    expect(URI).to receive(:download).with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.jar$/), anything()) { fail URI::NotFoundError }
+    expect { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.to raise_error(RuntimeError, /Failed to download/)
+    expect(File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar'))).to be_falsey
   end
 
   it 'should handle missing m2 snapshots by reporting the artifact unavailable' do
@@ -418,14 +407,11 @@ describe Repositories, 'remote' do
     </metadata>
     XML
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.jar$/), anything()).
-      and_return { fail URI::NotFoundError }
-    URI.should_receive(:download).with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)).
-      and_return { |uri, target, options| target.write(metadata) }
-    URI.should_receive(:download).with(uri(/2.1-SNAPSHOT\/library-2.1-20071012.190008-8.jar$/), anything()).
-      and_return { fail URI::NotFoundError }
-    lambda { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.should raise_error(RuntimeError, /Failed to download/)
-    File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar')).should be_false
+    expect(URI).to receive(:download).with(uri(/2.1-SNAPSHOT\/maven-metadata.xml$/), duck_type(:write)) { |uri, target, options| target.write(metadata) }
+    expect(URI).to receive(:download).with(uri(/2.1-SNAPSHOT\/library-2.1-SNAPSHOT.jar$/), anything()) { fail URI::NotFoundError }
+    expect(URI).to receive(:download).with(uri(/2.1-SNAPSHOT\/library-2.1-20071012.190008-8.jar$/), anything()) { fail URI::NotFoundError }
+    expect { artifact('com.example:library:jar:2.1-SNAPSHOT').invoke }.to raise_error(RuntimeError, /Failed to download/)
+    expect(File.exist?(File.join(repositories.local, 'com/example/library/2.1-SNAPSHOT/library-2.1-SNAPSHOT.jar'))).to be_falsey
   end
 
   it 'should load with all repositories specified in settings file' do
@@ -435,7 +421,7 @@ describe Repositories, 'remote' do
       - http://buildr.apache.org/repository/noexist
       - http://example.org
     YAML
-    repositories.remote.should include('http://buildr.apache.org/repository/noexist', 'http://example.org')
+    expect(repositories.remote).to include('http://buildr.apache.org/repository/noexist', 'http://example.org')
   end
 
   it 'should load with all repositories specified in build.yaml file' do
@@ -445,7 +431,7 @@ describe Repositories, 'remote' do
       - http://buildr.apache.org/repository/noexist
       - http://example.org
     YAML
-    repositories.remote.should include('http://buildr.apache.org/repository/noexist', 'http://example.org')
+    expect(repositories.remote).to include('http://buildr.apache.org/repository/noexist', 'http://example.org')
   end
 
   it 'should load with all repositories specified in settings and build.yaml files' do
@@ -459,7 +445,7 @@ describe Repositories, 'remote' do
       remote:
       - http://example.org
     YAML
-    repositories.remote.should include('http://buildr.apache.org/repository/noexist', 'http://example.org')
+    expect(repositories.remote).to include('http://buildr.apache.org/repository/noexist', 'http://example.org')
   end
 end
 
@@ -467,19 +453,19 @@ end
 describe Repositories, 'release_to' do
   it 'should accept URL as first argument' do
     repositories.release_to = 'http://buildr.apache.org/repository/noexist'
-    repositories.release_to.should == { :url=>'http://buildr.apache.org/repository/noexist' }
+    expect(repositories.release_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist' })
   end
 
   it 'should accept hash with options' do
     repositories.release_to = { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' }
-    repositories.release_to.should == { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' }
+    expect(repositories.release_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' })
   end
 
   it 'should allow the hash to be manipulated' do
     repositories.release_to = 'http://buildr.apache.org/repository/noexist'
-    repositories.release_to.should == { :url=>'http://buildr.apache.org/repository/noexist' }
+    expect(repositories.release_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist' })
     repositories.release_to[:username] = 'john'
-    repositories.release_to.should == { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' }
+    expect(repositories.release_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' })
   end
 
   it 'should load URL from settings file' do
@@ -487,7 +473,7 @@ describe Repositories, 'release_to' do
     repositories:
       release_to: http://john:secret@buildr.apache.org/repository/noexist
     YAML
-    repositories.release_to.should == { :url=>'http://john:secret@buildr.apache.org/repository/noexist' }
+    expect(repositories.release_to).to eq({ :url=>'http://john:secret@buildr.apache.org/repository/noexist' })
   end
 
   it 'should load URL from build settings file' do
@@ -495,7 +481,7 @@ describe Repositories, 'release_to' do
     repositories:
       release_to: http://john:secret@buildr.apache.org/repository/noexist
     YAML
-    repositories.release_to.should == { :url=>'http://john:secret@buildr.apache.org/repository/noexist' }
+    expect(repositories.release_to).to eq({ :url=>'http://john:secret@buildr.apache.org/repository/noexist' })
   end
 
   it 'should load URL, username and password from settings file' do
@@ -506,26 +492,26 @@ describe Repositories, 'release_to' do
         username: john
         password: secret
     YAML
-    repositories.release_to.should == { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john', :password=>'secret' }
+    expect(repositories.release_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist', :username=>'john', :password=>'secret' })
   end
 end
 
 describe Repositories, 'snapshot_to' do
   it 'should accept URL as first argument' do
     repositories.snapshot_to = 'http://buildr.apache.org/repository/noexist'
-    repositories.snapshot_to.should == { :url=>'http://buildr.apache.org/repository/noexist' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist' })
   end
 
   it 'should accept hash with options' do
     repositories.snapshot_to = { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' }
-    repositories.snapshot_to.should == { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' })
   end
 
   it 'should allow the hash to be manipulated' do
     repositories.snapshot_to = 'http://buildr.apache.org/repository/noexist'
-    repositories.snapshot_to.should == { :url=>'http://buildr.apache.org/repository/noexist' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist' })
     repositories.snapshot_to[:username] = 'john'
-    repositories.snapshot_to.should == { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist', :username=>'john' })
   end
 
   it 'should load URL from settings file' do
@@ -533,7 +519,7 @@ describe Repositories, 'snapshot_to' do
     repositories:
       snapshot_to: http://john:secret@buildr.apache.org/repository/noexist
     YAML
-    repositories.snapshot_to.should == { :url=>'http://john:secret@buildr.apache.org/repository/noexist' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://john:secret@buildr.apache.org/repository/noexist' })
   end
 
   it 'should load URL from build settings file' do
@@ -541,7 +527,7 @@ describe Repositories, 'snapshot_to' do
     repositories:
       snapshot_to: http://john:secret@buildr.apache.org/repository/noexist
     YAML
-    repositories.snapshot_to.should == { :url=>'http://john:secret@buildr.apache.org/repository/noexist' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://john:secret@buildr.apache.org/repository/noexist' })
   end
 
   it 'should load URL, username and password from settings file' do
@@ -552,7 +538,7 @@ describe Repositories, 'snapshot_to' do
         username: john
         password: secret
     YAML
-    repositories.snapshot_to.should == { :url=>'http://buildr.apache.org/repository/noexist', :username=>'john', :password=>'secret' }
+    expect(repositories.snapshot_to).to eq({ :url=>'http://buildr.apache.org/repository/noexist', :username=>'john', :password=>'secret' })
   end
 end
 
@@ -564,46 +550,46 @@ describe Buildr, '#artifact' do
   end
 
   it 'should accept hash specification' do
-    artifact(:group=>'com.example', :id=>'library', :type=>'jar', :version=>'2.0').should respond_to(:invoke)
+    expect(artifact(:group=>'com.example', :id=>'library', :type=>'jar', :version=>'2.0')).to respond_to(:invoke)
   end
 
   it 'should reject partial hash specifier' do
-    lambda { artifact(@spec.merge(:group=>nil)) }.should raise_error
-    lambda { artifact(@spec.merge(:id=>nil)) }.should raise_error
-    lambda { artifact(@spec.merge(:version=>nil)) }.should raise_error
+    expect { artifact(@spec.merge(:group=>nil)) }.to raise_error /Missing group identifier/
+    expect { artifact(@spec.merge(:id=>nil)) }.to raise_error /Missing artifact identifier/
+    expect { artifact(@spec.merge(:version=>nil)) }.to raise_error /Missing version/
   end
 
   it 'should complain about invalid key' do
-    lambda { artifact(@spec.merge(:error=>true)) }.should raise_error(ArgumentError, /no such option/i)
+    expect { artifact(@spec.merge(:error=>true)) }.to raise_error(ArgumentError, /no such option/i)
   end
 
   it 'should use JAR type by default' do
-    artifact(@spec.merge(:type=>nil)).should respond_to(:invoke)
+    expect(artifact(@spec.merge(:type=>nil))).to respond_to(:invoke)
   end
 
   it 'should accept string specification' do
-    artifact('com.example:library:jar:2.0').should respond_to(:invoke)
+    expect(artifact('com.example:library:jar:2.0')).to respond_to(:invoke)
   end
 
   it 'should reject partial string specifier' do
     artifact('com.example:library::2.0')
-    lambda { artifact('com.example:library:jar') }.should raise_error
-    lambda { artifact('com.example:library:jar:') }.should raise_error
-    lambda { artifact('com.example:library::2.0') }.should_not raise_error
-    lambda { artifact('com.example::jar:2.0') }.should raise_error
-    lambda { artifact(':library:jar:2.0') }.should raise_error
+    expect { artifact('com.example:library:jar') }.to raise_error /Missing version/
+    expect { artifact('com.example:library:jar:') }.to raise_error /Missing version/
+    expect { artifact('com.example:library::2.0') }.not_to raise_error 
+    expect { artifact('com.example::jar:2.0') }.to raise_error /Missing artifact identifier/
+    expect { artifact(':library:jar:2.0') }.to raise_error /Missing group identifier/
   end
 
   it 'should create a task naming the artifact in the local repository' do
     file = File.join(repositories.local, 'com', 'example', 'library', '2.0', 'library-2.0.jar')
-    Rake::Task.task_defined?(file).should be_false
-    artifact('com.example:library:jar:2.0').name.should eql(file)
+    expect(Rake::Task.task_defined?(file)).to be_falsey
+    expect(artifact('com.example:library:jar:2.0').name).to eql(file)
   end
 
   it 'should use from method to install artifact from existing file' do
     write 'test.jar'
     artifact = artifact('group:id:jar:1.0').from('test.jar')
-    lambda { artifact.invoke }.should change { File.exist?(artifact.to_s) }.to(true)
+    expect { artifact.invoke }.to change { File.exist?(artifact.to_s) }.to(true)
   end
 
   it 'should use from method to install artifact from a file task' do
@@ -613,7 +599,7 @@ describe Buildr, '#artifact' do
     end
     write 'test.jar'
     artifact = artifact('group:id:jar:1.0').from(test_jar)
-    lambda { artifact.invoke }.should change { File.exist?(artifact.to_s) }.to(true)
+    expect { artifact.invoke }.to change { File.exist?(artifact.to_s) }.to(true)
   end
 
   it 'should invoke the artifact associated file task if the file doesnt exist' do
@@ -646,15 +632,15 @@ describe Buildr, '#artifact' do
         j2ee: geronimo-spec:geronimo-spec-j2ee:jar:1.4-rc4
     YAML
     Buildr.application.send(:load_artifact_ns)
-    artifact(:j2ee).to_s.pathmap('%f').should == 'geronimo-spec-j2ee-1.4-rc4.jar'
+    expect(artifact(:j2ee).to_s.pathmap('%f')).to eq('geronimo-spec-j2ee-1.4-rc4.jar')
   end
 
   it 'should try to download snapshot artifact' do
     run_with_repo
     snapshot = artifact(@snapshot_spec)
 
-    URI.should_receive(:download).at_least(:twice).and_return { |uri, target, options| write target }
-    FileUtils.should_receive(:mv).at_least(:twice)
+    expect(URI).to receive(:download).at_least(:twice) { |uri, target, options| write target }
+    expect(FileUtils).to receive(:mv).at_least(:twice)
     snapshot.invoke
   end
 
@@ -663,7 +649,7 @@ describe Buildr, '#artifact' do
     snapshot = artifact(@snapshot_spec)
     write snapshot.to_s
     Buildr.application.options.work_offline = true
-    URI.should_receive(:download).exactly(0).times
+    expect(URI).to receive(:download).exactly(0).times
     snapshot.invoke
   end
 
@@ -671,7 +657,7 @@ describe Buildr, '#artifact' do
     run_with_repo
     snapshot = artifact(@snapshot_spec)
     Buildr.application.options.work_offline = true
-    URI.should_receive(:download).exactly(2).times
+    expect(URI).to receive(:download).exactly(2).times
     snapshot.invoke
   end
 
@@ -681,8 +667,8 @@ describe Buildr, '#artifact' do
     write snapshot.to_s
     Buildr.application.options.update_snapshots = true
 
-    URI.should_receive(:download).at_least(:twice).and_return { |uri, target, options| write target }
-    FileUtils.should_receive(:mv).at_least(:twice)
+    expect(URI).to receive(:download).at_least(:twice) { |uri, target, options| write target }
+    expect(FileUtils).to receive(:mv).at_least(:twice)
     snapshot.invoke
   end
 
@@ -692,7 +678,7 @@ describe Buildr, '#artifact' do
     write snapshot.to_s
     time = Time.at((Time.now - (60 * 60 * 24) - 10 ).to_i)
     File.utime(time, time, snapshot.to_s)
-    URI.should_receive(:download).at_least(:once).and_return { |uri, target, options| write target }
+    expect(URI).to receive(:download).at_least(:once) { |uri, target, options| write target }
     snapshot.invoke
   end
 
@@ -706,33 +692,33 @@ end
 describe Buildr, '#artifacts' do
   it 'should return a list of artifacts from all its arguments' do
     specs = [ 'saxon:saxon:jar:8.4', 'saxon:saxon-dom:jar:8.4', 'saxon:saxon-xpath:jar:8.4' ]
-    artifacts(*specs).should eql(specs.map { |spec| artifact(spec) })
+    expect(artifacts(*specs)).to eql(specs.map { |spec| artifact(spec) })
   end
 
   it 'should accept nested arrays' do
     specs = [ 'saxon:saxon:jar:8.4', 'saxon:saxon-dom:jar:8.4', 'saxon:saxon-xpath:jar:8.4' ]
-    artifacts([[specs[0]]], [[specs[1]], specs[2]]).should eql(specs.map { |spec| artifact(spec) })
+    expect(artifacts([[specs[0]]], [[specs[1]], specs[2]])).to eql(specs.map { |spec| artifact(spec) })
   end
 
   it 'should accept struct' do
     specs = struct(:main=>'saxon:saxon:jar:8.4', :dom=>'saxon:saxon-dom:jar:8.4', :xpath=>'saxon:saxon-xpath:jar:8.4')
-    artifacts(specs).should eql(specs.values.map { |spec| artifact(spec) })
+    expect(artifacts(specs)).to eql(specs.values.map { |spec| artifact(spec) })
   end
 
   it 'should ignore duplicates' do
-    artifacts('saxon:saxon:jar:8.4', 'saxon:saxon:jar:8.4').size.should be(1)
+    expect(artifacts('saxon:saxon:jar:8.4', 'saxon:saxon:jar:8.4').size).to be(1)
   end
 
   it 'should accept and return existing tasks' do
-    artifacts(task('foo'), task('bar')).should eql([task('foo'), task('bar')])
+    expect(artifacts(task('foo'), task('bar'))).to eql([task('foo'), task('bar')])
   end
 
   it 'should accept filenames and expand them' do
-    artifacts('test').map(&:to_s).should eql([File.expand_path('test')])
+    expect(artifacts('test').map(&:to_s)).to eql([File.expand_path('test')])
   end
 
   it 'should accept filenames and return filenames' do
-    artifacts('c:test').first.should be_kind_of(String)
+    expect(artifacts('c:test').first).to be_kind_of(String)
   end
 
   it 'should accept any object responding to :to_spec' do
@@ -740,7 +726,7 @@ describe Buildr, '#artifacts' do
     class << obj
       def to_spec; "org.example:artifact:jar:1.1"; end
     end
-    artifacts(obj).size.should be(1)
+    expect(artifacts(obj).size).to be(1)
   end
 
   it 'should accept project and return all its packaging tasks' do
@@ -749,15 +735,15 @@ describe Buildr, '#artifacts' do
       package :war, :id=>'webapp'
     end
     foobar = project('foobar')
-    artifacts(foobar).should eql([
+    expect(artifacts(foobar)).to eql([
       task(foobar.path_to('target/code-1.0.jar')),
       task(foobar.path_to('target/webapp-1.0.war'))
     ])
   end
 
   it 'should complain about an invalid specification' do
-    lambda { artifacts(5) }.should raise_error
-    lambda { artifacts('group:no:version:') }.should raise_error
+    expect { artifacts(5) }.to raise_error /Invalid artifact specification/
+    expect { artifacts('group:no:version:') }.to raise_error /Missing version/
   end
 end
 
@@ -765,31 +751,31 @@ end
 describe Buildr, '#group' do
   it 'should accept list of artifact identifiers' do
     list = group('saxon', 'saxon-dom', 'saxon-xpath', :under=>'saxon', :version=>'8.4')
-    list.should include(artifact('saxon:saxon:jar:8.4'))
-    list.should include(artifact('saxon:saxon-dom:jar:8.4'))
-    list.should include(artifact('saxon:saxon-xpath:jar:8.4'))
-    list.size.should be(3)
+    expect(list).to include(artifact('saxon:saxon:jar:8.4'))
+    expect(list).to include(artifact('saxon:saxon-dom:jar:8.4'))
+    expect(list).to include(artifact('saxon:saxon-xpath:jar:8.4'))
+    expect(list.size).to be(3)
   end
 
   it 'should accept array with artifact identifiers' do
     list = group(%w{saxon saxon-dom saxon-xpath}, :under=>'saxon', :version=>'8.4')
-    list.should include(artifact('saxon:saxon:jar:8.4'))
-    list.should include(artifact('saxon:saxon-dom:jar:8.4'))
-    list.should include(artifact('saxon:saxon-xpath:jar:8.4'))
-    list.size.should be(3)
+    expect(list).to include(artifact('saxon:saxon:jar:8.4'))
+    expect(list).to include(artifact('saxon:saxon-dom:jar:8.4'))
+    expect(list).to include(artifact('saxon:saxon-xpath:jar:8.4'))
+    expect(list.size).to be(3)
   end
 
   it 'should accept a type' do
     list = group('struts-bean', 'struts-html', :under=>'struts', :type=>'tld', :version=>'1.1')
-    list.should include(artifact('struts:struts-bean:tld:1.1'))
-    list.should include(artifact('struts:struts-html:tld:1.1'))
-    list.size.should be(2)
+    expect(list).to include(artifact('struts:struts-bean:tld:1.1'))
+    expect(list).to include(artifact('struts:struts-html:tld:1.1'))
+    expect(list.size).to be(2)
   end
 
   it 'should accept a classifier' do
     list = group('camel-core', :under=>'org.apache.camel', :version=>'2.2.0', :classifier=>'spring3')
-    list.should include(artifact('org.apache.camel:camel-core:jar:spring3:2.2.0'))
-    list.size.should be(1)
+    expect(list).to include(artifact('org.apache.camel:camel-core:jar:spring3:2.2.0'))
+    expect(list.size).to be(1)
   end
 
 end
@@ -802,18 +788,18 @@ describe Buildr, '#install' do
   end
 
   it 'should return the install task' do
-    install.should be(task('install'))
+    expect(install).to be(task('install'))
   end
 
   it 'should accept artifacts to install' do
     install artifact(@spec)
-    lambda { install @file }.should raise_error(ArgumentError)
+    expect { install @file }.to raise_error(ArgumentError)
   end
 
   it 'should install artifact when install task is run' do
     write @file
     install artifact(@spec).from(@file)
-    lambda { install.invoke }.should change { File.exist?(artifact(@spec).to_s) }.to(true)
+    expect { install.invoke }.to change { File.exist?(artifact(@spec).to_s) }.to(true)
   end
 
   it 'should re-install artifact when "from" is newer' do
@@ -821,7 +807,7 @@ describe Buildr, '#install' do
     write artifact(@spec).to_s # install a version of the artifact
     old_mtime = File.mtime(artifact(@spec).to_s)
     sleep 1; write @file       # make sure the "from" file has newer modification time
-    lambda { install.invoke }.should change { modified?(old_mtime, @spec) }.to(true)
+    expect { install.invoke }.to change { modified?(old_mtime, @spec) }.to(true)
   end
 
   it 'should re-install snapshot artifact when "from" is newer' do
@@ -829,7 +815,7 @@ describe Buildr, '#install' do
     write artifact(@snapshot_spec).to_s # install a version of the artifact
     old_mtime = File.mtime(artifact(@snapshot_spec).to_s)
     sleep 1; write @file       # make sure the "from" file has newer modification time
-    lambda { install.invoke }.should change { modified?(old_mtime, @snapshot_spec) }.to(true)
+    expect { install.invoke }.to change { modified?(old_mtime, @snapshot_spec) }.to(true)
   end
 
   it 'should download snapshot to temporary location' do
@@ -838,9 +824,9 @@ describe Buildr, '#install' do
     same_time = Time.new
     download_file = "#{Dir.tmpdir}/#{File.basename(snapshot.name)}#{same_time.to_i}"
 
-    Time.should_receive(:new).twice.and_return(same_time)
-    URI.should_receive(:download).at_least(:twice).and_return { |uri, target, options| write target }
-    FileUtils.should_receive(:mv).at_least(:twice)
+    expect(Time).to receive(:new).twice.and_return(same_time)
+    expect(URI).to receive(:download).at_least(:twice) { |uri, target, options| write target }
+    expect(FileUtils).to receive(:mv).at_least(:twice)
     snapshot.invoke
   end
 
@@ -848,7 +834,7 @@ describe Buildr, '#install' do
     pom = artifact(@spec).pom
     write @file
     install artifact(@spec).from(@file)
-    lambda { install.invoke }.should change { File.exist?(repositories.locate(pom)) }.to(true)
+    expect { install.invoke }.to change { File.exist?(repositories.locate(pom)) }.to(true)
   end
 
   it 'should not install POM alongside artifact if artifact has classifier' do
@@ -857,7 +843,7 @@ describe Buildr, '#install' do
     write @file
     p method(:install)
     install artifact(@spec).from(@file)
-    lambda { install.invoke }.should_not change { File.exist?(repositories.locate(pom)) }.to(true)
+    expect { install.invoke }.not_to change { File.exist?(repositories.locate(pom)) }
   end
 
   it 'should reinstall POM alongside artifact' do
@@ -867,7 +853,7 @@ describe Buildr, '#install' do
     sleep 1
 
     install artifact(@spec).from(@file)
-    lambda { install.invoke }.should change { File.mtime(repositories.locate(pom)) }
+    expect { install.invoke }.to change { File.mtime(repositories.locate(pom)) }
   end
 end
 
@@ -880,20 +866,20 @@ describe Buildr, '#upload' do
   end
 
   it 'should return the upload task' do
-    upload.should be(task('upload'))
+    expect(upload).to be(task('upload'))
   end
 
   it 'should accept artifacts to upload' do
     upload artifact(@spec)
-    lambda { upload @file }.should raise_error(ArgumentError)
+    expect { upload @file }.to raise_error(ArgumentError)
   end
 
   it 'should upload artifact when upload task is run' do
     write @file
     upload artifact(@spec).from(@file)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/group/id/1.0/id-1.0.jar'), artifact(@spec).to_s, anything)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/group/id/1.0/id-1.0.pom'), artifact(@spec).pom.to_s, anything)
     upload.invoke
   end
@@ -906,9 +892,9 @@ describe ActsAsArtifact, '#upload' do
     # Prevent artifact from downloading anything.
     write repositories.locate(artifact)
     write repositories.locate(artifact.pom)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/com/example/library/2.0/library-2.0.pom'), artifact.pom.to_s, anything)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/com/example/library/2.0/library-2.0.jar'), artifact.to_s, anything)
     verbose(false) { artifact.upload(:url=>'sftp://buildr.apache.org/repository/noexist/base') }
   end
@@ -917,7 +903,7 @@ describe ActsAsArtifact, '#upload' do
     artifact = artifact('com.example:library:jar:all:2.0')
     # Prevent artifact from downloading anything.
     write repositories.locate(artifact)
-    URI.should_receive(:upload).exactly(:once).
+    expect(URI).to receive(:upload).exactly(:once).
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/com/example/library/2.0/library-2.0-all.jar'), artifact.to_s, anything)
     verbose(false) { artifact.upload(:url=>'sftp://buildr.apache.org/repository/noexist/base') }
   end
@@ -927,7 +913,7 @@ describe ActsAsArtifact, '#upload' do
     # Prevent artifact from downloading anything.
     write repositories.locate(artifact)
     write repositories.locate(artifact.pom)
-    lambda { artifact.upload }.should raise_error(Exception, /where to upload/)
+    expect { artifact.upload }.to raise_error(Exception, /where to upload/)
   end
 
   it 'should accept repositories.release_to setting' do
@@ -935,10 +921,10 @@ describe ActsAsArtifact, '#upload' do
     # Prevent artifact from downloading anything.
     write repositories.locate(artifact)
     write repositories.locate(artifact.pom)
-    URI.should_receive(:upload).at_least(:once)
+    expect(URI).to receive(:upload).at_least(:once)
     repositories.release_to = 'sftp://buildr.apache.org/repository/noexist/base'
     artifact.upload
-    lambda { artifact.upload }.should_not raise_error
+    expect { artifact.upload }.not_to raise_error
   end
 
   it 'should use repositories.release_to setting even for snapshots when snapshot_to is not set' do
@@ -946,13 +932,13 @@ describe ActsAsArtifact, '#upload' do
     # Prevent artifact from downloading anything.
     write repositories.locate(artifact)
     write repositories.locate(artifact.pom)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/com/example/library/2.0-SNAPSHOT/library-2.0-SNAPSHOT.pom'), artifact.pom.to_s, anything)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/com/example/library/2.0-SNAPSHOT/library-2.0-SNAPSHOT.jar'), artifact.to_s, anything)
     repositories.release_to = 'sftp://buildr.apache.org/repository/noexist/base'
     artifact.upload
-    lambda { artifact.upload }.should_not raise_error
+    expect { artifact.upload }.not_to raise_error
   end
 
   it 'should use repositories.snapshot_to setting when snapshot_to is set' do
@@ -960,14 +946,14 @@ describe ActsAsArtifact, '#upload' do
     # Prevent artifact from downloading anything.
     write repositories.locate(artifact)
     write repositories.locate(artifact.pom)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/snapshot/com/example/library/2.0-SNAPSHOT/library-2.0-SNAPSHOT.pom'), artifact.pom.to_s, anything)
-    URI.should_receive(:upload).once.
+    expect(URI).to receive(:upload).once.
       with(URI.parse('sftp://buildr.apache.org/repository/noexist/snapshot/com/example/library/2.0-SNAPSHOT/library-2.0-SNAPSHOT.jar'), artifact.to_s, anything)
     repositories.release_to = 'sftp://buildr.apache.org/repository/noexist/base'
     repositories.snapshot_to = 'sftp://buildr.apache.org/repository/noexist/snapshot'
     artifact.upload
-    lambda { artifact.upload }.should_not raise_error
+    expect { artifact.upload }.not_to raise_error
   end
 
   it 'should complain when only a snapshot repo is set but the artifact is not a snapshot' do
@@ -976,7 +962,7 @@ describe ActsAsArtifact, '#upload' do
     write repositories.locate(artifact)
     write repositories.locate(artifact.pom)
     repositories.snapshot_to = 'sftp://buildr.apache.org/repository/noexist/snapshot'
-    lambda { artifact.upload }.should raise_error(Exception, /where to upload/)
+    expect { artifact.upload }.to raise_error(Exception, /where to upload/)
   end
 
 
@@ -993,19 +979,19 @@ describe Rake::Task, ' artifacts' do
   it 'should download all specified artifacts' do
     artifact 'group:id:jar:1.0'
     repositories.remote = 'http://buildr.apache.org/repository/noexist'
-    URI.should_receive(:download).twice.and_return { |uri, target, options| write target }
+    expect(URI).to receive(:download).twice { |uri, target, options| write target }
     task('artifacts').invoke
   end
 
   it 'should fail if failed to download an artifact' do
     artifact 'group:id:jar:1.0'
-    lambda { task('artifacts').invoke }.should raise_error(RuntimeError, /No remote repositories/)
+    expect { task('artifacts').invoke }.to raise_error(RuntimeError, /No remote repositories/)
   end
 
   it 'should succeed if artifact already exists' do
     write repositories.locate(artifact('group:id:jar:1.0'))
     suppress_stdout do
-      lambda { task('artifacts').invoke }.should_not raise_error
+      expect { task('artifacts').invoke }.not_to raise_error
     end
   end
 end
@@ -1023,13 +1009,13 @@ describe Rake::Task, ' artifacts:sources' do
 
   it 'should download sources for all specified artifacts' do
     artifact 'group:id:jar:1.0'
-    URI.stub(:download).and_return { |uri, target| write target }
-    lambda { task('artifacts:sources').invoke }.should change { File.exist?('home/.m2/repository/group/id/1.0/id-1.0-sources.jar') }.to(true)
+    allow(URI).to receive(:download) { |uri, target| write target }
+    expect { task('artifacts:sources').invoke }.to change { File.exist?('home/.m2/repository/group/id/1.0/id-1.0-sources.jar') }.to(true)
   end
 
   it "should not try to download sources for the project's artifacts" do
     define('foo', :version=>'1.0') { package(:jar) }
-    URI.should_not_receive(:download)
+    expect(URI).not_to receive(:download)
     task('artifacts:sources').invoke
   end
 
@@ -1037,15 +1023,15 @@ describe Rake::Task, ' artifacts:sources' do
 
     before do
       artifact 'group:id:jar:1.0'
-      URI.should_receive(:download).and_raise(URI::NotFoundError)
+      expect(URI).to receive(:download).and_raise(URI::NotFoundError)
     end
 
     it 'should not fail' do
-      lambda { task('artifacts:sources').invoke }.should_not raise_error
+      expect { task('artifacts:sources').invoke }.not_to raise_error
     end
 
     it 'should inform the user' do
-      lambda { task('artifacts:sources').invoke }.should show_info('Failed to download group:id:jar:sources:1.0. Skipping it.')
+      expect { task('artifacts:sources').invoke }.to show_info('Failed to download group:id:jar:sources:1.0. Skipping it.')
     end
   end
 end
@@ -1062,13 +1048,13 @@ describe Rake::Task, ' artifacts:javadoc' do
 
   it 'should download javadoc for all specified artifacts' do
     artifact 'group:id:jar:1.0'
-    URI.should_receive(:download).and_return { |uri, target| write target }
-    lambda { task('artifacts:javadoc').invoke }.should change { File.exist?('home/.m2/repository/group/id/1.0/id-1.0-javadoc.jar') }.to(true)
+    expect(URI).to receive(:download) { |uri, target| write target }
+    expect { task('artifacts:javadoc').invoke }.to change { File.exist?('home/.m2/repository/group/id/1.0/id-1.0-javadoc.jar') }.to(true)
   end
 
   it "should not try to download javadoc for the project's artifacts" do
     define('foo', :version=>'1.0') { package(:jar) }
-    URI.should_not_receive(:download)
+    expect(URI).not_to receive(:download)
     task('artifacts:javadoc').invoke
   end
 
@@ -1076,15 +1062,15 @@ describe Rake::Task, ' artifacts:javadoc' do
 
     before do
       artifact 'group:id:jar:1.0'
-      URI.should_receive(:download).and_raise(URI::NotFoundError)
+      expect(URI).to receive(:download).and_raise(URI::NotFoundError)
     end
 
     it 'should not fail' do
-      lambda { task('artifacts:javadoc').invoke }.should_not raise_error
+      expect { task('artifacts:javadoc').invoke }.not_to raise_error
     end
 
     it 'should inform the user' do
-      lambda { task('artifacts:javadoc').invoke }.should show_info('Failed to download group:id:jar:javadoc:1.0. Skipping it.')
+      expect { task('artifacts:javadoc').invoke }.to show_info('Failed to download group:id:jar:javadoc:1.0. Skipping it.')
     end
   end
 end
@@ -1152,33 +1138,33 @@ XML
 
   it 'should return a list of artifacts from all its arguments' do
     specs = [ 'saxon:saxon:jar:8.4', 'saxon:saxon-dom:jar:8.4', 'saxon:saxon-xpath:jar:8.4' ]
-    transitive(*specs).should eql(specs.map { |spec| artifact(spec) })
+    expect(transitive(*specs)).to eql(specs.map { |spec| artifact(spec) })
   end
 
   it 'should accept nested arrays' do
     specs = [ 'saxon:saxon:jar:8.4', 'saxon:saxon-dom:jar:8.4', 'saxon:saxon-xpath:jar:8.4' ]
-    transitive([[specs[0]]], [[specs[1]], specs[2]]).should eql(specs.map { |spec| artifact(spec) })
+    expect(transitive([[specs[0]]], [[specs[1]], specs[2]])).to eql(specs.map { |spec| artifact(spec) })
   end
 
   it 'should accept struct' do
     specs = struct(:main=>'saxon:saxon:jar:8.4', :dom=>'saxon:saxon-dom:jar:8.4', :xpath=>'saxon:saxon-xpath:jar:8.4')
-    transitive(specs).should eql(specs.values.map { |spec| artifact(spec) })
+    expect(transitive(specs)).to eql(specs.values.map { |spec| artifact(spec) })
   end
 
   it 'should ignore duplicates' do
-    transitive('saxon:saxon:jar:8.4', 'saxon:saxon:jar:8.4').size.should be(1)
+    expect(transitive('saxon:saxon:jar:8.4', 'saxon:saxon:jar:8.4').size).to be(1)
   end
 
   it 'should accept and return existing tasks' do
-    transitive(task('foo'), task('bar')).should eql([task('foo'), task('bar')])
+    expect(transitive(task('foo'), task('bar'))).to eql([task('foo'), task('bar')])
   end
 
   it 'should accept filenames and expand them' do
-    transitive('test').map(&:to_s).should eql([File.expand_path('test')])
+    expect(transitive('test').map(&:to_s)).to eql([File.expand_path('test')])
   end
 
   it 'should accept filenames and return file task' do
-    transitive('c:test').first.should be_kind_of(Rake::FileTask)
+    expect(transitive('c:test').first).to be_kind_of(Rake::FileTask)
   end
 
   it 'should accept project and return all its packaging tasks' do
@@ -1187,37 +1173,37 @@ XML
       package :war, :id=>'webapp'
     end
     foobar = project('foobar')
-    transitive(foobar).should eql([
+    expect(transitive(foobar)).to eql([
       task(foobar.path_to('target/code-1.0.jar')),
       task(foobar.path_to('target/webapp-1.0.war'))
     ])
   end
 
   it 'should complain about an invalid specification' do
-    lambda { transitive(5) }.should raise_error
-    lambda { transitive('group:no:version:') }.should raise_error
+    expect { transitive(5) }.to raise_error /Invalid artifact specification/
+    expect { transitive('group:no:version:') }.to raise_error /Missing version/
   end
 
   it 'should bring artifact and its dependencies' do
-    transitive(@complex).should eql(artifacts(@complex, @simple - [@provided]))
+    expect(transitive(@complex)).to eql(artifacts(@complex, @simple - [@provided]))
   end
 
   it 'should bring dependencies of POM without artifact itself' do
-    transitive(@complex.sub(/jar/, 'pom')).should eql(artifacts(@simple - [@provided]))
+    expect(transitive(@complex.sub(/jar/, 'pom'))).to eql(artifacts(@simple - [@provided]))
   end
 
   it 'should bring artifact and transitive depenencies' do
-    transitive(@transitive).should eql(artifacts(@transitive, @complex, @simple - [@provided]))
+    expect(transitive(@transitive)).to eql(artifacts(@transitive, @complex, @simple - [@provided]))
   end
 
   it 'should filter dependencies based on :scopes argument' do
     specs = [@complex, 'saxon:saxon-dom:jar:8.4']
-    transitive(@complex, :scopes => [:runtime]).should eql(specs.map { |spec| artifact(spec) })
+    expect(transitive(@complex, :scopes => [:runtime])).to eql(specs.map { |spec| artifact(spec) })
   end
 
   it 'should filter dependencies based on :optional argument' do
     specs = [@complex, 'saxon:saxon-dom:jar:8.4', 'jlib:jlib-optional:jar:1.4']
-    transitive(@complex, :scopes => [:runtime], :optional => true).should eql(specs.map { |spec| artifact(spec) })
+    expect(transitive(@complex, :scopes => [:runtime], :optional => true)).to eql(specs.map { |spec| artifact(spec) })
   end
 end
 

--- a/spec/packaging/packaging_helper.rb
+++ b/spec/packaging/packaging_helper.rb
@@ -19,7 +19,7 @@ shared_examples_for 'packaging' do
     packaging = @packaging
     package_type = @package_type || @packaging
     define 'foo', :version=>'1.0' do
-      package(packaging).type.should eql(package_type) rescue exit!
+      expect(package(packaging).type).to eql(package_type) rescue exit!
     end
   end
 
@@ -27,7 +27,7 @@ shared_examples_for 'packaging' do
     packaging = @packaging
     package_type = @package_type || @packaging
     define 'foo', :version=>'1.0' do
-      package(packaging).to_s.should match(/.#{package_type}$/)
+      expect(package(packaging).to_s).to match(/.#{package_type}$/)
     end
   end
 
@@ -37,27 +37,27 @@ shared_examples_for 'packaging' do
       package(packaging)
       package(packaging, :id=>'other')
     end
-    project('foo').packages.uniq.size.should eql(2)
+    expect(project('foo').packages.uniq.size).to eql(2)
   end
 
   it 'should complain if option not known' do
     packaging = @packaging
     define 'foo', :version=>'1.0' do
-      lambda { package(packaging, :unknown_option=>true) }.should raise_error(ArgumentError, /no such option/)
+      expect { package(packaging, :unknown_option=>true) }.to raise_error(ArgumentError, /no such option/)
     end
   end
 
   it 'should respond to with() and return self' do
     packaging = @packaging
     define 'foo', :version=>'1.0' do
-      package(packaging).with({}).should be(package(packaging))
+      expect(package(packaging).with({})).to be(package(packaging))
     end
   end
 
   it 'should respond to with() and complain if unknown option' do
     packaging = @packaging
     define 'foo', :version=>'1.0' do
-      lambda {  package(packaging).with(:unknown_option=>true) }.should raise_error(ArgumentError, /does not support the option/)
+      expect {  package(packaging).with(:unknown_option=>true) }.to raise_error(ArgumentError, /does not support the option/)
     end
   end
 end

--- a/spec/packaging/packaging_spec.rb
+++ b/spec/packaging/packaging_spec.rb
@@ -19,46 +19,46 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'packaging_helper'))
 describe Project, '#group' do
   it 'should default to project name' do
     desc 'My Project'
-    define('foo').group.should eql('foo')
+    expect(define('foo').group).to eql('foo')
   end
 
   it 'should be settable' do
-    define('foo', :group=>'bar').group.should eql('bar')
+    expect(define('foo', :group=>'bar').group).to eql('bar')
   end
 
   it 'should inherit from parent project' do
     define('foo', :group=>'groupie') { define 'bar' }
-    project('foo:bar').group.should eql('groupie')
+    expect(project('foo:bar').group).to eql('groupie')
   end
 end
 
 describe Project, '#version' do
   it 'should default to nil' do
-    define('foo').version.should be_nil
+    expect(define('foo').version).to be_nil
   end
 
   it 'should be settable' do
-    define('foo', :version=>'2.1').version.should eql('2.1')
+    expect(define('foo', :version=>'2.1').version).to eql('2.1')
   end
 
   it 'should inherit from parent project' do
     define('foo', :version=>'2.1') { define 'bar' }
-    project('foo:bar').version.should eql('2.1')
+    expect(project('foo:bar').version).to eql('2.1')
   end
 end
 
 describe Project, '#id' do
   it 'should be same as project name' do
-    define('foo').id.should eql('foo')
+    expect(define('foo').id).to eql('foo')
   end
 
   it 'should replace colons with dashes' do
     define('foo', :version=>'2.1') { define 'bar' }
-    project('foo:bar').id.should eql('foo-bar')
+    expect(project('foo:bar').id).to eql('foo-bar')
   end
 
   it 'should not be settable' do
-    lambda { define 'foo', :id=>'bar' }.should raise_error(NoMethodError)
+    expect { define 'foo', :id=>'bar' }.to raise_error(NoMethodError)
   end
 end
 
@@ -66,88 +66,88 @@ end
 describe Project, '#package' do
   it 'should default to id from project' do
     define('foo', :version=>'1.0') do
-      package(:jar).id.should eql('foo')
+      expect(package(:jar).id).to eql('foo')
     end
   end
 
   it 'should default to composed id for nested projects' do
     define('foo', :version=>'1.0') do
       define 'bar' do
-        package(:jar).id.should eql('foo-bar')
+        expect(package(:jar).id).to eql('foo-bar')
       end
     end
   end
 
   it 'should take id from option if specified' do
     define 'foo', :version=>'1.0' do
-      package(:jar, :id=>'bar').id.should eql('bar')
+      expect(package(:jar, :id=>'bar').id).to eql('bar')
       define 'bar' do
-        package(:jar, :id=>'baz').id.should eql('baz')
+        expect(package(:jar, :id=>'baz').id).to eql('baz')
       end
     end
   end
 
   it 'should default to group from project' do
     define 'foo', :version=>'1.0' do
-      package(:jar).group.should eql('foo')
+      expect(package(:jar).group).to eql('foo')
       define 'bar' do
-        package(:jar).group.should eql('foo')
+        expect(package(:jar).group).to eql('foo')
       end
     end
   end
 
   it 'should take group from option if specified' do
     define 'foo', :version=>'1.0' do
-      package(:jar, :group=>'foos').group.should eql('foos')
+      expect(package(:jar, :group=>'foos').group).to eql('foos')
       define 'bar' do
-        package(:jar, :group=>'bars').group.should eql('bars')
+        expect(package(:jar, :group=>'bars').group).to eql('bars')
       end
     end
   end
 
   it 'should default to version from project' do
     define 'foo', :version=>'1.0' do
-      package(:jar).version.should eql('1.0')
+      expect(package(:jar).version).to eql('1.0')
       define 'bar' do
-        package(:jar).version.should eql('1.0')
+        expect(package(:jar).version).to eql('1.0')
       end
     end
   end
 
   it 'should take version from option if specified' do
     define 'foo', :version=>'1.0' do
-      package(:jar, :version=>'1.1').version.should eql('1.1')
+      expect(package(:jar, :version=>'1.1').version).to eql('1.1')
       define 'bar' do
-        package(:jar, :version=>'1.2').version.should eql('1.2')
+        expect(package(:jar, :version=>'1.2').version).to eql('1.2')
       end
     end
   end
 
   it 'should accept package type as first argument' do
     define 'foo', :version=>'1.0' do
-      package(:war).type.should eql(:war)
+      expect(package(:war).type).to eql(:war)
       define 'bar' do
-        package(:jar).type.should eql(:jar)
+        expect(package(:jar).type).to eql(:jar)
       end
     end
   end
 
   it 'should support optional type' do
     define 'foo', :version=>'1.0' do
-      package.type.should eql(:zip)
-      package(:classifier=>'srcs').type.should eql(:zip)
+      expect(package.type).to eql(:zip)
+      expect(package(:classifier=>'srcs').type).to eql(:zip)
     end
     define 'bar', :version=>'1.0' do
       compile.using :javac
-      package(:classifier=>'srcs').type.should eql(:jar)
+      expect(package(:classifier=>'srcs').type).to eql(:jar)
     end
   end
 
   it 'should assume :zip package type unless specified' do
     define 'foo', :version=>'1.0' do
-      package.type.should eql(:zip)
+      expect(package.type).to eql(:zip)
       define 'bar' do
-        package.type.should eql(:zip)
+        expect(package.type).to eql(:zip)
       end
     end
   end
@@ -155,12 +155,12 @@ describe Project, '#package' do
   it 'should infer packaging type from compiler' do
     define 'foo', :version=>'1.0' do
       compile.using :javac
-      package.type.should eql(:jar)
+      expect(package.type).to eql(:jar)
     end
   end
 
   it 'should fail if packaging not supported' do
-    lambda { define('foo') { package(:weirdo) } }.should raise_error(RuntimeError, /Don't know how to create a package/)
+    expect { define('foo') { package(:weirdo) } }.to raise_error(RuntimeError, /Don't know how to create a package/)
   end
 
   it 'should call package_as_foo when using package(:foo)' do
@@ -174,8 +174,8 @@ describe Project, '#package' do
     end
     define('foo', :version => '1.0') do |project|
       package(:foo).invoke
-      package(:foo).should exist
-      package(:foo).should contain('foo')
+      expect(package(:foo)).to exist
+      expect(package(:foo)).to contain('foo')
     end
   end
 
@@ -186,8 +186,8 @@ describe Project, '#package' do
       end
     end
     define('foo', :version => '1.0') do
-      package(:sources).type.should eql(:jar)
-      package(:sources).classifier.should eql('sources')
+      expect(package(:sources).type).to eql(:jar)
+      expect(package(:sources).classifier).to eql('sources')
     end
   end
 
@@ -211,41 +211,41 @@ describe Project, '#package' do
 
     end
     define('foo', :version => '1.0') do
-      package(:foo).type.should eql(:zip)
-      package(:foo).classifier.should be_nil
-      package(:bar).type.should eql(:zip)
-      package(:bar).classifier.should eql('foobar')
-      package(:foo).equal?(package(:bar)).should be_false
+      expect(package(:foo).type).to eql(:zip)
+      expect(package(:foo).classifier).to be_nil
+      expect(package(:bar).type).to eql(:zip)
+      expect(package(:bar).classifier).to eql('foobar')
+      expect(package(:foo).equal?(package(:bar))).to be_falsey
     end
   end
 
   it 'should default to no classifier' do
     define 'foo', :version=>'1.0' do
-      package.classifier.should be_nil
+      expect(package.classifier).to be_nil
       define 'bar' do
-        package.classifier.should be_nil
+        expect(package.classifier).to be_nil
       end
     end
   end
 
   it 'should accept classifier from option' do
     define 'foo', :version=>'1.0' do
-      package(:classifier=>'srcs').classifier.should eql('srcs')
+      expect(package(:classifier=>'srcs').classifier).to eql('srcs')
       define 'bar' do
-        package(:classifier=>'docs').classifier.should eql('docs')
+        expect(package(:classifier=>'docs').classifier).to eql('docs')
       end
     end
   end
 
   it 'should return a file task' do
     define('foo', :version=>'1.0') { package(:jar) }
-    project('foo').package(:jar).should be_kind_of(Rake::FileTask)
+    expect(project('foo').package(:jar)).to be_kind_of(Rake::FileTask)
   end
 
   it 'should return a task that acts as artifact' do
     define('foo', :version=>'1.0') { package(:jar) }
-    project('foo').package(:jar).should respond_to(:to_spec)
-    project('foo').package(:jar).to_spec.should eql('foo:foo:jar:1.0')
+    expect(project('foo').package(:jar)).to respond_to(:to_spec)
+    expect(project('foo').package(:jar).to_spec).to eql('foo:foo:jar:1.0')
   end
 
   it 'should create different tasks for each spec' do
@@ -256,7 +256,7 @@ describe Project, '#package' do
       package(:jar, :classifier=>'srcs')
       package(:jar, :classifier=>'doc')
     end
-    project('foo').packages.uniq.size.should be(5)
+    expect(project('foo').packages.uniq.size).to be(5)
   end
 
   it 'should create different tasks for package with different ids' do
@@ -264,7 +264,7 @@ describe Project, '#package' do
       package(:jar, :id=>'bar')
       package(:jar)
     end
-    project('foo').packages.uniq.size.should be(2)
+    expect(project('foo').packages.uniq.size).to be(2)
   end
 
   it 'should create different tasks for package with classifier' do
@@ -272,7 +272,7 @@ describe Project, '#package' do
       package(:jar)
       package(:jar, :classifier=>'foo')
     end
-    project('foo').packages.uniq.size.should be(2)
+    expect(project('foo').packages.uniq.size).to be(2)
   end
 
   it 'should not create multiple packages for the same spec' do
@@ -283,7 +283,7 @@ describe Project, '#package' do
       package(:jar, :id=>'bar')
       package(:jar, :id=>'baz')
     end
-    project('foo').packages.uniq.size.should be(3)
+    expect(project('foo').packages.uniq.size).to be(3)
   end
 
   it 'should create different tasks for specs with matching type' do
@@ -292,20 +292,20 @@ describe Project, '#package' do
       package(:javadoc)
       package(:zip)
     end
-    project('foo').packages.uniq.size.should be(2)
+    expect(project('foo').packages.uniq.size).to be(2)
   end
 
   it 'should return the same task for subsequent calls' do
     define 'foo', :version=>'1.0' do
-      package.should eql(package)
-      package(:jar, :classifier=>'resources').should be(package(:jar, :classifier=>'resources'))
+      expect(package).to eql(package)
+      expect(package(:jar, :classifier=>'resources')).to be(package(:jar, :classifier=>'resources'))
     end
   end
 
   it 'should return a packaging task even if file already exists' do
     write 'target/foo-1.0.zip', ''
     define 'foo', :version=>'1.0' do
-      package.should be_kind_of(ZipTask)
+      expect(package).to be_kind_of(ZipTask)
     end
   end
 
@@ -314,14 +314,14 @@ describe Project, '#package' do
       package(:jar, :id=>'bar')
       package(:war)
     end
-    project('foo').packages.should eql(artifacts('foo:bar:jar:1.0', 'foo:foo:war:1.0'))
+    expect(project('foo').packages).to eql(artifacts('foo:bar:jar:1.0', 'foo:foo:war:1.0'))
   end
 
   it 'should create in target path' do
     define 'foo', :version=>'1.0' do
-      package(:war).should point_to_path('target/foo-1.0.war')
-      package(:jar, :id=>'bar').should point_to_path('target/bar-1.0.jar')
-      package(:zip, :classifier=>'srcs').should point_to_path('target/foo-1.0-srcs.zip')
+      expect(package(:war)).to point_to_path('target/foo-1.0.war')
+      expect(package(:jar, :id=>'bar')).to point_to_path('target/bar-1.0.jar')
+      expect(package(:zip, :classifier=>'srcs')).to point_to_path('target/foo-1.0-srcs.zip')
     end
   end
 
@@ -331,27 +331,27 @@ describe Project, '#package' do
       package(:jar, :id=>'bar')
       package(:jar, :classifier=>'srcs')
     end
-    project('foo').task('package').prerequisites.should include(*project('foo').packages)
+    expect(project('foo').task('package').prerequisites).to include(*project('foo').packages)
   end
 
   it 'should create task requiring a build' do
     define 'foo', :version=>'1.0' do
-      package(:war).prerequisites.should include(build)
-      package(:jar, :id=>'bar').prerequisites.should include(build)
-      package(:jar, :classifier=>'srcs').prerequisites.should include(build)
+      expect(package(:war).prerequisites).to include(build)
+      expect(package(:jar, :id=>'bar').prerequisites).to include(build)
+      expect(package(:jar, :classifier=>'srcs').prerequisites).to include(build)
     end
   end
 
   it 'should create a POM artifact in target directory' do
     define 'foo', :version=>'1.0' do
-      package.pom.should be(artifact('foo:foo:pom:1.0'))
-      package.pom.to_s.should point_to_path('target/foo-1.0.pom')
+      expect(package.pom).to be(artifact('foo:foo:pom:1.0'))
+      expect(package.pom.to_s).to point_to_path('target/foo-1.0.pom')
     end
   end
 
   it 'should create POM artifact ignoring classifier' do
     define 'foo', :version=>'1.0' do
-      package(:jar, :classifier=>'srcs').pom.should be(artifact('foo:foo:pom:1.0'))
+      expect(package(:jar, :classifier=>'srcs').pom).to be(artifact('foo:foo:pom:1.0'))
     end
   end
 
@@ -359,7 +359,7 @@ describe Project, '#package' do
     define('foo', :group=>'bar', :version=>'1.0') { package(:jar, :classifier=>'srcs') }
     pom = project('foo').packages.first.pom
     pom.invoke
-    read(pom.to_s).should eql(<<-POM
+    expect(read(pom.to_s)).to eql(<<-POM
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <modelVersion>4.0.0</modelVersion>
@@ -374,15 +374,15 @@ POM
   it 'should not require downloading artifact or POM' do
     #task('artifacts').instance_eval { @actions.clear }
     define('foo', :group=>'bar', :version=>'1.0') { package(:jar) }
-    lambda { task('artifacts').invoke }.should_not raise_error
+    expect { task('artifacts').invoke }.not_to raise_error
   end
 
   describe "existing package access" do
     it "should return the same instance for identical optionless invocations" do
       define 'foo', :version => '1.0' do
-        package(:zip).should equal(package(:zip))
+        expect(package(:zip)).to equal(package(:zip))
       end
-      project('foo').packages.size.should == 1
+      expect(project('foo').packages.size).to eq(1)
     end
 
     it "should return the exactly matching package identical invocations with options" do
@@ -390,9 +390,9 @@ POM
         package(:zip, :id => 'src')
         package(:zip, :id => 'bin')
       end
-      project('foo').package(:zip, :id => 'src').should equal(project('foo').packages.first)
-      project('foo').package(:zip, :id => 'bin').should equal(project('foo').packages.last)
-      project('foo').packages.size.should == 2
+      expect(project('foo').package(:zip, :id => 'src')).to equal(project('foo').packages.first)
+      expect(project('foo').package(:zip, :id => 'bin')).to equal(project('foo').packages.last)
+      expect(project('foo').packages.size).to eq(2)
     end
 
     it "should return the first of the same type for subsequent optionless invocations" do
@@ -400,9 +400,9 @@ POM
         package(:zip, :file => 'override.zip')
         package(:jar, :file => 'another.jar')
       end
-      project('foo').package(:zip).name.should == 'override.zip'
-      project('foo').package(:jar).name.should == 'another.jar'
-      project('foo').packages.size.should == 2
+      expect(project('foo').package(:zip).name).to eq('override.zip')
+      expect(project('foo').package(:jar).name).to eq('another.jar')
+      expect(project('foo').packages.size).to eq(2)
     end
   end
 end
@@ -410,24 +410,24 @@ end
 describe Project, '#package file' do
   it 'should be a file task' do
     define 'foo' do
-      package(:zip, :file=>'foo.zip').should be_kind_of(Rake::FileTask)
+      expect(package(:zip, :file=>'foo.zip')).to be_kind_of(Rake::FileTask)
     end
   end
 
   it 'should not require id, project or version' do
     define 'foo', :group=>nil do
-      lambda { package(:zip, :file=>'foo.zip') }.should_not raise_error
-      lambda { package(:zip, :file=>'bar.zip', :id=>'error') }.should raise_error
-      lambda { package(:zip, :file=>'bar.zip', :group=>'error') }.should raise_error
-      lambda { package(:zip, :file=>'bar.zip', :version=>'error') }.should raise_error
+      expect { package(:zip, :file=>'foo.zip') }.not_to raise_error
+      expect { package(:zip, :file=>'bar.zip', :id=>'error') }.to raise_error /no such option: id/
+      expect { package(:zip, :file=>'bar.zip', :group=>'error') }.to raise_error /no such option: group/
+      expect { package(:zip, :file=>'bar.zip', :version=>'error') }.to raise_error /no such option: version/
     end
   end
 
   it 'should not provide project or version' do
     define 'foo' do
       package(:zip, :file=>'foo.zip').tap do |pkg|
-        pkg.should_not respond_to(:group)
-        pkg.should_not respond_to(:version)
+        expect(pkg).not_to respond_to(:group)
+        expect(pkg).not_to respond_to(:version)
       end
     end
   end
@@ -436,31 +436,31 @@ describe Project, '#package file' do
     define 'foo', :version=>'1.0' do
       zip = package(:zip, :file=>'foo.zip')
       jar = package(:jar, :file=>'bar.jar')
-      zip.type.should eql(:zip)
-      jar.type.should eql(:jar)
+      expect(zip.type).to eql(:zip)
+      expect(jar.type).to eql(:jar)
     end
   end
 
   it 'should assume packaging type from extension if unspecified' do
     define 'foo', :version=>'1.0' do
-      package(:file=>'foo.zip').class.should be(Buildr::ZipTask)
+      expect(package(:file=>'foo.zip').class).to be(Buildr::ZipTask)
       define 'bar' do
-        package(:file=>'bar.jar').class.should be(Buildr::Packaging::Java::JarTask)
+        expect(package(:file=>'bar.jar').class).to be(Buildr::Packaging::Java::JarTask)
       end
     end
   end
 
   it 'should support different packaging types' do
     define 'foo', :version=>'1.0' do
-      package(:jar, :file=>'foo.jar').class.should be(Buildr::Packaging::Java::JarTask)
+      expect(package(:jar, :file=>'foo.jar').class).to be(Buildr::Packaging::Java::JarTask)
     end
     define 'bar' do
-      package(:type=>:war, :file=>'bar.war').class.should be(Buildr::Packaging::Java::WarTask)
+      expect(package(:type=>:war, :file=>'bar.war').class).to be(Buildr::Packaging::Java::WarTask)
     end
   end
 
   it 'should fail if packaging not supported' do
-    lambda { define('foo') { package(:weirdo, :file=>'foo.zip') } }.should raise_error(RuntimeError, /Don't know how to create a package/)
+    expect { define('foo') { package(:weirdo, :file=>'foo.zip') } }.to raise_error(RuntimeError, /Don't know how to create a package/)
   end
 
   it 'should create different tasks for each file' do
@@ -468,19 +468,19 @@ describe Project, '#package file' do
       package(:zip, :file=>'foo.zip')
       package(:jar, :file=>'foo.jar')
     end
-    project('foo').packages.uniq.size.should be(2)
+    expect(project('foo').packages.uniq.size).to be(2)
   end
 
   it 'should return the same task for subsequent calls' do
     define 'foo', :version=>'1.0' do
-      package(:zip, :file=>'foo.zip').should eql(package(:file=>'foo.zip'))
+      expect(package(:zip, :file=>'foo.zip')).to eql(package(:file=>'foo.zip'))
     end
   end
 
   it 'should point to specified file' do
     define 'foo', :version=>'1.0' do
-      package(:zip, :file=>'foo.zip').should point_to_path('foo.zip')
-      package(:zip, :file=>'target/foo-1.0.zip').should point_to_path('target/foo-1.0.zip')
+      expect(package(:zip, :file=>'foo.zip')).to point_to_path('foo.zip')
+      expect(package(:zip, :file=>'target/foo-1.0.zip')).to point_to_path('target/foo-1.0.zip')
     end
   end
 
@@ -488,12 +488,12 @@ describe Project, '#package file' do
     define 'foo', :version=>'1.0' do
       package(:zip, :file=>'foo.zip')
     end
-    project('foo').task('package').prerequisites.should include(*project('foo').packages)
+    expect(project('foo').task('package').prerequisites).to include(*project('foo').packages)
   end
 
   it 'should create task requiring a build' do
     define 'foo', :version=>'1.0' do
-      package(:zip, :file=>'foo.zip').prerequisites.should include(build)
+      expect(package(:zip, :file=>'foo.zip').prerequisites).to include(build)
     end
   end
 
@@ -501,18 +501,18 @@ describe Project, '#package file' do
     define 'foo', :version=>'1.0' do
       package(:zip, :file=>'foo.zip')
     end
-    lambda { project('foo').task('package').invoke }.should change { File.exist?('foo.zip') }.to(true)
+    expect { project('foo').task('package').invoke }.to change { File.exist?('foo.zip') }.to(true)
   end
 
   it 'should do nothing for installation/upload' do
     define 'foo', :version=>'1.0' do
       package(:zip, :file=>'foo.zip')
     end
-    lambda do
+    expect do
       task('install').invoke
       task('upload').invoke
       task('uninstall').invoke
-    end.should_not raise_error
+    end.not_to raise_error
   end
 
 end
@@ -525,8 +525,8 @@ describe Rake::Task, ' package' do
     end
     in_original_dir project('foo:bar').base_dir do
       task('package').invoke
-      project('foo').package.should_not exist
-      project('foo:bar').package.should exist
+      expect(project('foo').package).not_to exist
+      expect(project('foo:bar').package).to exist
     end
   end
 
@@ -536,8 +536,8 @@ describe Rake::Task, ' package' do
       define('bar') { package }
     end
     task('package').invoke
-    project('foo').package.should exist
-    project('foo:bar').package.should exist
+    expect(project('foo').package).to exist
+    expect(project('foo:bar').package).to exist
   end
 
   it 'should create package in target directory' do
@@ -546,7 +546,7 @@ describe Rake::Task, ' package' do
       define('bar') { package }
     end
     task('package').invoke
-    FileList['**/target/*.zip'].map.sort.should == ['bar/target/foo-bar-1.0.zip', 'target/foo-1.0.zip']
+    expect(FileList['**/target/*.zip'].map.sort).to eq(['bar/target/foo-bar-1.0.zip', 'target/foo-1.0.zip'])
   end
 end
 
@@ -558,8 +558,8 @@ describe Rake::Task, ' install' do
     end
     in_original_dir project('foo:bar').base_dir do
       task('install').invoke
-      artifacts('foo:foo:zip:1.0', 'foo:foo:pom:1.0').each { |t| t.should_not exist }
-      artifacts('foo:foo-bar:zip:1.0', 'foo:foo-bar:pom:1.0').each { |t| t.should exist }
+      artifacts('foo:foo:zip:1.0', 'foo:foo:pom:1.0').each { |t| expect(t).not_to exist }
+      artifacts('foo:foo-bar:zip:1.0', 'foo:foo-bar:pom:1.0').each { |t| expect(t).to exist }
     end
   end
 
@@ -569,7 +569,7 @@ describe Rake::Task, ' install' do
       define('bar') { package }
     end
     task('install').invoke
-    artifacts('foo:foo:zip:1.0', 'foo:foo:pom:1.0', 'foo:foo-bar:zip:1.0', 'foo:foo-bar:pom:1.0').each { |t| t.should exist }
+    artifacts('foo:foo:zip:1.0', 'foo:foo:pom:1.0', 'foo:foo-bar:zip:1.0', 'foo:foo-bar:pom:1.0').each { |t| expect(t).to exist }
   end
 
   it 'should create package in local repository' do
@@ -578,11 +578,11 @@ describe Rake::Task, ' install' do
       define('bar') { package }
     end
     task('install').invoke
-    FileList[repositories.local + '/**/*'].reject { |f| File.directory?(f) }.sort.should == [
+    expect(FileList[repositories.local + '/**/*'].reject { |f| File.directory?(f) }.sort).to eq([
       File.expand_path('foo/foo/1.0/foo-1.0.zip', repositories.local),
       File.expand_path('foo/foo/1.0/foo-1.0.pom', repositories.local),
       File.expand_path('foo/foo-bar/1.0/foo-bar-1.0.zip', repositories.local),
-      File.expand_path('foo/foo-bar/1.0/foo-bar-1.0.pom', repositories.local)].sort
+      File.expand_path('foo/foo-bar/1.0/foo-bar-1.0.pom', repositories.local)].sort)
   end
 end
 
@@ -595,9 +595,9 @@ describe Rake::Task, ' uninstall' do
     task('install').invoke
     in_original_dir project('foo:bar').base_dir do
       task('uninstall').invoke
-      FileList[repositories.local + '/**/*'].reject { |f| File.directory?(f) }.sort.should == [
+      expect(FileList[repositories.local + '/**/*'].reject { |f| File.directory?(f) }.sort).to eq([
         File.expand_path('foo/foo/1.0/foo-1.0.zip', repositories.local),
-        File.expand_path('foo/foo/1.0/foo-1.0.pom', repositories.local)].sort
+        File.expand_path('foo/foo/1.0/foo-1.0.pom', repositories.local)].sort)
     end
   end
 
@@ -608,7 +608,7 @@ describe Rake::Task, ' uninstall' do
     end
     task('install').invoke
     task('uninstall').invoke
-    FileList[repositories.local + '/**/*'].reject { |f| File.directory?(f) }.sort.should be_empty
+    expect(FileList[repositories.local + '/**/*'].reject { |f| File.directory?(f) }.sort).to be_empty
   end
 end
 
@@ -623,7 +623,7 @@ describe Rake::Task, ' upload' do
       define('bar') { package }
     end
     in_original_dir project('foo:bar').base_dir do
-      lambda { task('upload').invoke }.should run_task('foo:bar:upload').but_not('foo:upload')
+      expect { task('upload').invoke }.to run_task('foo:bar:upload').but_not('foo:upload')
     end
   end
 
@@ -632,7 +632,7 @@ describe Rake::Task, ' upload' do
       package
       define('bar') { package }
     end
-    lambda { task('upload').invoke }.should run_tasks('foo:upload', 'foo:bar:upload')
+    expect { task('upload').invoke }.to run_tasks('foo:upload', 'foo:bar:upload')
   end
 
   it 'should upload artifact and POM' do
@@ -640,7 +640,7 @@ describe Rake::Task, ' upload' do
     task('upload').invoke
     { 'remote/foo/foo/1.0/foo-1.0.jar'=>project('foo').package(:jar),
       'remote/foo/foo/1.0/foo-1.0.pom'=>project('foo').package(:jar).pom }.each do |upload, package|
-      read(upload).should eql(read(package))
+      expect(read(upload)).to eql(read(package))
     end
   end
 
@@ -653,11 +653,11 @@ describe Rake::Task, ' upload' do
       package(:jar)
       package(:sources)
     end
-     URI.should_receive(:upload).exactly(:once).
+     expect(URI).to receive(:upload).exactly(:once).
          with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/attached/foo/1.0/foo-1.0-sources.jar'), project("foo").package(:sources).to_s, anything)
-     URI.should_receive(:upload).exactly(:once).
+     expect(URI).to receive(:upload).exactly(:once).
          with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/attached/foo/1.0/foo-1.0.jar'), project("foo").package(:jar).to_s, anything)
-     URI.should_receive(:upload).exactly(:once).
+     expect(URI).to receive(:upload).exactly(:once).
         with(URI.parse('sftp://buildr.apache.org/repository/noexist/base/attached/foo/1.0/foo-1.0.pom'), project("foo").package(:jar).pom.to_s, anything)
      verbose(false) { project("foo").upload.invoke }
   end
@@ -667,8 +667,8 @@ describe Rake::Task, ' upload' do
     task('upload').invoke
     { 'remote/foo/foo/1.0/foo-1.0.jar'=>project('foo').package(:jar),
       'remote/foo/foo/1.0/foo-1.0.pom'=>project('foo').package(:jar).pom }.each do |upload, package|
-      read("#{upload}.md5").split.first.should eql(Digest::MD5.hexdigest(read(package, "rb")))
-      read("#{upload}.sha1").split.first.should eql(Digest::SHA1.hexdigest(read(package, "rb")))
+      expect(read("#{upload}.md5").split.first).to eql(Digest::MD5.hexdigest(read(package, "rb")))
+      expect(read("#{upload}.sha1").split.first).to eql(Digest::SHA1.hexdigest(read(package, "rb")))
     end
   end
 end
@@ -681,7 +681,7 @@ describe Packaging, 'zip' do
     define('foo', :version=>'1.0') { package(:zip) }
     project('foo').package(:zip).invoke
     Zip::File.open(project('foo').package(:zip).to_s) do |zip|
-      zip.entries.map(&:to_s).should_not include('META-INF/')
+      expect(zip.entries.map(&:to_s)).not_to include('META-INF/')
     end
   end
 end

--- a/spec/scala/bdd_spec.rb
+++ b/spec/scala/bdd_spec.rb
@@ -32,19 +32,19 @@ describe Buildr::Scala::Specs do
       }
     SCALA
     define 'foo'
-    project('foo').test.framework.should eql(:specs)
+    expect(project('foo').test.framework).to eql(:specs)
   end
 
   it 'should include Specs dependencies' do
     define('foo') { test.using(:specs) }
-    project('foo').test.compile.dependencies.should include(*artifacts(Scala::Specs.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(Scala::Specs.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(Scala::Specs.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(Scala::Specs.dependencies))
   end
 
   it 'should include ScalaCheck dependencies' do
     define('foo') { test.using(:specs) }
-    project('foo').test.compile.dependencies.should include(*artifacts(Scala::Check.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(Scala::Check.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(Scala::Check.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(Scala::Check.dependencies))
   end
 
   it 'should include public objects extending org.specs.Specification' do
@@ -60,7 +60,7 @@ describe Buildr::Scala::Specs do
       }
     SCALA
     define('foo').test.invoke
-    project('foo').test.tests.should include('com.example.MySpecs')
+    expect(project('foo').test.tests).to include('com.example.MySpecs')
   end
 
   it 'should include public objects extending org.specs.Specification even with companion classes' do
@@ -77,7 +77,7 @@ describe Buildr::Scala::Specs do
       class MySpecs extends org.specs.runner.JUnit4(MySpecs)
     SCALA
     define('foo').test.invoke
-    project('foo').test.tests.should include('com.example.MySpecs')
+    expect(project('foo').test.tests).to include('com.example.MySpecs')
   end
 
   it 'should pass when spec passes' do
@@ -91,7 +91,7 @@ describe Buildr::Scala::Specs do
         }
       }
     SCALA
-    lambda { define('foo').test.invoke }.should_not raise_error
+    expect { define('foo').test.invoke }.not_to raise_error
   end
 
   it 'should fail when spec fails' do
@@ -109,7 +109,7 @@ describe Buildr::Scala::Specs do
     SCALA
     define('foo')
     project('foo').test.invoke rescue
-    project('foo').test.failed_tests.should include('StringSpecs')
+    expect(project('foo').test.failed_tests).to include('StringSpecs')
   end
 end
 
@@ -128,19 +128,19 @@ describe Buildr::Scala::Specs2 do
       }
     SCALA
     define 'foo'
-    project('foo').test.framework.should eql(:specs2)
+    expect(project('foo').test.framework).to eql(:specs2)
   end
 
   it 'should include Specs2 dependencies' do
     define('foo') { test.using(:specs2) }
-    project('foo').test.compile.dependencies.should include(*artifacts(Scala::Specs2.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(Scala::Specs2.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(Scala::Specs2.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(Scala::Specs2.dependencies))
   end
 
   it 'should include ScalaCheck dependencies' do
     define('foo') { test.using(:specs2) }
-    project('foo').test.compile.dependencies.should include(*artifacts(Scala::Check.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(Scala::Check.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(Scala::Check.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(Scala::Check.dependencies))
   end
 
   it 'should include public objects extending org.specs2.mutable.Specification' do
@@ -155,9 +155,9 @@ describe Buildr::Scala::Specs2 do
         }
       }
     SCALA
-    define('foo').test.framework.should eql(:specs2)
+    expect(define('foo').test.framework).to eql(:specs2)
     project('foo').test.invoke
-    project('foo').test.tests.should include('com.example.MySpecs$')
+    expect(project('foo').test.tests).to include('com.example.MySpecs$')
   end
 
   it 'should include classes extending org.specs2.SpecificationWithJUnit' do
@@ -180,9 +180,9 @@ describe Buildr::Scala::Specs2 do
       }
     SCALA
     define('foo')
-    project('foo').test.framework.should eql(:specs2)
+    expect(project('foo').test.framework).to eql(:specs2)
     project('foo').test.invoke
-    project('foo').test.tests.should include('com.example.MySpecs')
+    expect(project('foo').test.tests).to include('com.example.MySpecs')
   end
 
   it 'should pass when spec passes' do
@@ -196,7 +196,7 @@ describe Buildr::Scala::Specs2 do
         }
       }
     SCALA
-    lambda { define('foo').test.invoke }.should_not raise_error
+    expect { define('foo').test.invoke }.not_to raise_error
   end
 
   it 'should fail when spec fails' do
@@ -213,7 +213,7 @@ describe Buildr::Scala::Specs2 do
     SCALA
     define('foo')
     project('foo').test.invoke rescue
-    project('foo').test.failed_tests.should include('StringSpecs$')
+    expect(project('foo').test.failed_tests).to include('StringSpecs$')
   end
 end
 

--- a/spec/scala/compiler_spec.rb
+++ b/spec/scala/compiler_spec.rb
@@ -17,7 +17,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers'))
 
 # need to test both with and without SCALA_HOME
-share_as :ScalacCompiler do
+shared_examples "ScalacCompiler" do
 
   it 'should identify itself from source directories' do
     write 'src/main/scala/com/example/Test.scala', 'package com.example; class Test { val i = 1 }'
@@ -118,7 +118,7 @@ if ENV['SCALA_HOME']
       ENV['SCALA_HOME'].should_not be_nil
     end
 
-    it_should_behave_like ScalacCompiler
+    it_should_behave_like "ScalacCompiler"
   end
 end
 
@@ -133,14 +133,14 @@ describe 'scala compiler (downloaded from repository)' do
     ENV['SCALA_HOME'].should be_nil
   end
 
-  it_should_behave_like ScalacCompiler
+  it_should_behave_like "ScalacCompiler"
 
   after :all do
     ENV['SCALA_HOME'] = old_home
   end
 end
 
-share_as :ScalacCompiler_CommonOptions do
+shared_examples :ScalacCompiler_CommonOptions do
 
   it 'should set warnings option to false by default' do
     compile_task.options.warnings.should be_false
@@ -270,7 +270,7 @@ end
 
 describe 'scala compiler 2.8 options' do
 
-  it_should_behave_like ScalacCompiler_CommonOptions
+  it_should_behave_like :ScalacCompiler_CommonOptions
 
   def compile_task
     @compile_task ||= define('foo').compile.using(:scalac)
@@ -293,7 +293,7 @@ end if Buildr::Scala.version?(2.8)
 
 describe 'scala compiler 2.9 options' do
 
-  it_should_behave_like ScalacCompiler_CommonOptions
+  it_should_behave_like :ScalacCompiler_CommonOptions
 
   def compile_task
     @compile_task ||= define('foo').compile.using(:scalac)
@@ -342,7 +342,7 @@ describe 'zinc compiler (enabled through Buildr.settings)' do
     Buildr.settings.build['scalac.incremental'] = nil
   end
 
-  it_should_behave_like ScalacCompiler
+  it_should_behave_like "ScalacCompiler"
 end
 
 describe 'zinc compiler (enabled through project.scala_options)' do

--- a/spec/scala/compiler_spec.rb
+++ b/spec/scala/compiler_spec.rb
@@ -21,30 +21,30 @@ shared_examples "ScalacCompiler" do
 
   it 'should identify itself from source directories' do
     write 'src/main/scala/com/example/Test.scala', 'package com.example; class Test { val i = 1 }'
-    define('foo').compile.compiler.should eql(:scalac)
+    expect(define('foo').compile.compiler).to eql(:scalac)
   end
 
   it 'should report the language as :scala' do
-    define('foo').compile.using(:scalac).language.should eql(:scala)
+    expect(define('foo').compile.using(:scalac).language).to eql(:scala)
   end
 
   it 'should set the target directory to target/classes' do
     define 'foo' do
-      lambda { compile.using(:scalac) }.should change { compile.target.to_s }.to(File.expand_path('target/classes'))
+      expect { compile.using(:scalac) }.to change { compile.target.to_s }.to(File.expand_path('target/classes'))
     end
   end
 
   it 'should not override existing target directory' do
     define 'foo' do
       compile.into('classes')
-      lambda { compile.using(:scalac) }.should_not change { compile.target }
+      expect { compile.using(:scalac) }.not_to change { compile.target }
     end
   end
 
   it 'should not change existing list of sources' do
     define 'foo' do
       compile.from('sources')
-      lambda { compile.using(:scalac) }.should_not change { compile.sources }
+      expect { compile.using(:scalac) }.not_to change { compile.sources }
     end
   end
 
@@ -55,8 +55,8 @@ shared_examples "ScalacCompiler" do
       package(:jar)
     end
     write 'src/test/DependencyTest.scala', 'class DependencyTest { var d: Dependency = _ }'
-    lambda { define('foo').compile.from('src/test').with(project('dependency')).invoke }.should run_task('foo:compile')
-    file('target/classes/DependencyTest.class').should exist
+    expect { define('foo').compile.from('src/test').with(project('dependency')).invoke }.to run_task('foo:compile')
+    expect(file('target/classes/DependencyTest.class')).to exist
   end
 
   def define_test1_project
@@ -69,15 +69,15 @@ shared_examples "ScalacCompiler" do
   it 'should compile a simple .scala file into a .class file' do
     define_test1_project
     task('test1:compile').invoke
-    file('target/classes/com/example/Test1.class').should exist
+    expect(file('target/classes/com/example/Test1.class')).to exist
   end
 
   it 'should package .class into a .jar file' do
     define_test1_project
     task('test1:package').invoke
-    file('target/test1-1.0.jar').should exist
+    expect(file('target/test1-1.0.jar')).to exist
     Zip::File.open(project('test1').package(:jar).to_s) do |zip|
-      zip.exist?('com/example/Test1.class').should be_true
+      expect(zip.exist?('com/example/Test1.class')).to be_truthy
     end
   end
 
@@ -88,10 +88,10 @@ shared_examples "ScalacCompiler" do
       package(:jar)
     end
     task('test1:package').invoke
-    file('target/test1-1.0.jar').should exist
+    expect(file('target/test1-1.0.jar')).to exist
     Zip::File.open(project('test1').package(:jar).to_s) do |zip|
-      zip.exist?('com/example/Foo.class').should be_true
-      zip.exist?('com/example/Bar.class').should be_true
+      expect(zip.exist?('com/example/Foo.class')).to be_truthy
+      expect(zip.exist?('com/example/Bar.class')).to be_truthy
     end
   end
 
@@ -102,10 +102,10 @@ shared_examples "ScalacCompiler" do
       package(:jar)
     end
     task('test1:package').invoke
-    file('target/test1-1.0.jar').should exist
+    expect(file('target/test1-1.0.jar')).to exist
     Zip::File.open(project('test1').package(:jar).to_s) do |zip|
-      zip.exist?('com/example/Foo.class').should be_true
-      zip.exist?('com/example/Bar.class').should be_true
+      expect(zip.exist?('com/example/Foo.class')).to be_truthy
+      expect(zip.exist?('com/example/Bar.class')).to be_truthy
     end
   end
 end
@@ -115,7 +115,7 @@ end
 if ENV['SCALA_HOME']
   describe 'scala compiler (installed in SCALA_HOME)' do
     it 'requires present SCALA_HOME' do
-      ENV['SCALA_HOME'].should_not be_nil
+      expect(ENV['SCALA_HOME']).not_to be_nil
     end
 
     it_should_behave_like "ScalacCompiler"
@@ -130,7 +130,7 @@ describe 'scala compiler (downloaded from repository)' do
   end
 
   it 'requires absent SCALA_HOME' do
-    ENV['SCALA_HOME'].should be_nil
+    expect(ENV['SCALA_HOME']).to be_nil
   end
 
   it_should_behave_like "ScalacCompiler"
@@ -143,108 +143,108 @@ end
 shared_examples :ScalacCompiler_CommonOptions do
 
   it 'should set warnings option to false by default' do
-    compile_task.options.warnings.should be_false
+    expect(compile_task.options.warnings).to be_falsey
   end
 
   it 'should set warnings option to true when running with --verbose option' do
     verbose true
-    compile_task.options.warnings.should be_true
+    expect(compile_task.options.warnings).to be_truthy
   end
 
   it 'should use -nowarn argument when warnings is false' do
     compile_task.using(:warnings=>false)
-    scalac_args.should include('-nowarn')
+    expect(scalac_args).to include('-nowarn')
   end
 
   it 'should not use -nowarn argument when warnings is true' do
     compile_task.using(:warnings=>true)
-    scalac_args.should_not include('-nowarn')
+    expect(scalac_args).not_to include('-nowarn')
   end
 
   it 'should not use -verbose argument by default' do
-    scalac_args.should_not include('-verbose')
+    expect(scalac_args).not_to include('-verbose')
   end
 
   it 'should use -verbose argument when running with --trace=scalac option' do
     Buildr.application.options.trace_categories = [:scalac]
-    scalac_args.should include('-verbose')
+    expect(scalac_args).to include('-verbose')
   end
 
   it 'should set debug option to true by default' do
-    compile_task.options.debug.should be_true
+    expect(compile_task.options.debug).to be_truthy
   end
 
   it 'should set debug option to false based on Buildr.options' do
     Buildr.options.debug = false
-    compile_task.options.debug.should be_false
+    expect(compile_task.options.debug).to be_falsey
   end
 
   it 'should set debug option to false based on debug environment variable' do
     ENV['debug'] = 'no'
-    compile_task.options.debug.should be_false
+    expect(compile_task.options.debug).to be_falsey
   end
 
   it 'should set debug option to false based on DEBUG environment variable' do
     ENV['DEBUG'] = 'no'
-    compile_task.options.debug.should be_false
+    expect(compile_task.options.debug).to be_falsey
   end
 
   it 'should set deprecation option to false by default' do
-    compile_task.options.deprecation.should be_false
+    expect(compile_task.options.deprecation).to be_falsey
   end
 
   it 'should use -deprecation argument when deprecation is true' do
     compile_task.using(:deprecation=>true)
-    scalac_args.should include('-deprecation')
+    expect(scalac_args).to include('-deprecation')
   end
 
   it 'should not use -deprecation argument when deprecation is false' do
     compile_task.using(:deprecation=>false)
-    scalac_args.should_not include('-deprecation')
+    expect(scalac_args).not_to include('-deprecation')
   end
 
   it 'should set optimise option to false by default' do
-    compile_task.options.optimise.should be_false
+    expect(compile_task.options.optimise).to be_falsey
   end
 
   it 'should use -optimise argument when deprecation is true' do
     compile_task.using(:optimise=>true)
-    scalac_args.should include('-optimise')
+    expect(scalac_args).to include('-optimise')
   end
 
   it 'should not use -optimise argument when deprecation is false' do
     compile_task.using(:optimise=>false)
-    scalac_args.should_not include('-optimise')
+    expect(scalac_args).not_to include('-optimise')
   end
 
   it 'should not set target option by default' do
-    compile_task.options.target.should be_nil
-    scalac_args.should_not include('-target')
+    expect(compile_task.options.target).to be_nil
+    expect(scalac_args).not_to include('-target')
   end
 
   it 'should use -target:xxx argument if target option set' do
     compile_task.using(:target=>'1.5')
-    scalac_args.should include('-target:jvm-1.5')
+    expect(scalac_args).to include('-target:jvm-1.5')
   end
 
   it 'should not set other option by default' do
-    compile_task.options.other.should be_nil
+    expect(compile_task.options.other).to be_nil
   end
 
   it 'should pass other argument if other option is string' do
     compile_task.using(:other=>'-unchecked')
-    scalac_args.should include('-unchecked')
+    expect(scalac_args).to include('-unchecked')
   end
 
   it 'should pass other argument if other option is array' do
     compile_task.using(:other=>['-unchecked', '-Xprint-types'])
-    scalac_args.should include('-unchecked', '-Xprint-types')
+    expect(scalac_args).to include('-unchecked', '-Xprint-types')
   end
 
   it 'should complain about options it doesn\'t know' do
     write 'source/Test.scala', 'class Test {}'
     compile_task.using(:unknown=>'option')
-    lambda { compile_task.from('source').invoke }.should raise_error(ArgumentError, /no such option/i)
+    expect { compile_task.from('source').invoke }.to raise_error(ArgumentError, /no such option/i)
   end
 
   it 'should inherit options from parent' do
@@ -252,10 +252,10 @@ shared_examples :ScalacCompiler_CommonOptions do
       compile.using(:warnings=>true, :debug=>true, :deprecation=>true, :target=>'1.4')
       define 'bar' do
         compile.using(:scalac)
-        compile.options.warnings.should be_true
-        compile.options.debug.should be_true
-        compile.options.deprecation.should be_true
-        compile.options.target.should eql('1.4')
+        expect(compile.options.warnings).to be_truthy
+        expect(compile.options.debug).to be_truthy
+        expect(compile.options.deprecation).to be_truthy
+        expect(compile.options.target).to eql('1.4')
       end
     end
   end
@@ -282,12 +282,12 @@ describe 'scala compiler 2.8 options' do
 
   it 'should use -g argument when debug option is true' do
     compile_task.using(:debug=>true)
-    scalac_args.should include('-g')
+    expect(scalac_args).to include('-g')
   end
 
   it 'should not use -g argument when debug option is false' do
     compile_task.using(:debug=>false)
-    scalac_args.should_not include('-g')
+    expect(scalac_args).not_to include('-g')
   end
 end if Buildr::Scala.version?(2.8)
 
@@ -306,17 +306,17 @@ describe 'scala compiler 2.9 options' do
   # these specs fail. Somehow the compiler is still in version 2.8
   it 'should use -g:vars argument when debug option is true' do
     compile_task.using(:debug=>true)
-    scalac_args.should include('-g:vars')
+    expect(scalac_args).to include('-g:vars')
   end
 
   it 'should use -g:whatever argument when debug option is \'whatever\'' do
     compile_task.using(:debug=>:whatever)
-    scalac_args.should include('-g:whatever')
+    expect(scalac_args).to include('-g:whatever')
   end
 
   it 'should not use -g argument when debug option is false' do
     compile_task.using(:debug=>false)
-    scalac_args.should_not include('-g')
+    expect(scalac_args).not_to include('-g')
   end
 
 end if Buildr::Scala.version?(2.9)
@@ -333,8 +333,8 @@ describe 'zinc compiler (enabled through Buildr.settings)' do
     project = define('foo')
     compile_task = project.compile.using(:scalac)
     compiler = compile_task.instance_eval { @compiler }
-    compiler.send(:zinc?).should eql(true)
-    compiler.should_receive(:compile_with_zinc).once
+    expect(compiler.send(:zinc?)).to eql(true)
+    expect(compiler).to receive(:compile_with_zinc).once
     compile_task.invoke
   end
 
@@ -353,8 +353,8 @@ describe 'zinc compiler (enabled through project.scala_options)' do
     project.scalac_options.incremental = true
     compile_task = project.compile.using(:scalac)
     compiler = compile_task.instance_eval { @compiler }
-    compiler.send(:zinc?).should eql(true)
-    compiler.should_receive(:compile_with_zinc).once
+    expect(compiler.send(:zinc?)).to eql(true)
+    expect(compiler).to receive(:compile_with_zinc).once
     compile_task.invoke
   end
 end

--- a/spec/scala/doc_spec.rb
+++ b/spec/scala/doc_spec.rb
@@ -27,8 +27,8 @@ describe "Scaladoc" do
       end
     end
 
-    project('foo').doc.options[:"doc-title"].should eql('foo')
-    project('foo:bar').doc.options[:"doc-title"].should eql('foo:bar')
+    expect(project('foo').doc.options[:"doc-title"]).to eql('foo')
+    expect(project('foo:bar').doc.options[:"doc-title"]).to eql('foo:bar')
   end
 
   it 'should pick -doc-title from project description by default, if available' do
@@ -36,7 +36,7 @@ describe "Scaladoc" do
     define 'foo' do
       compile.using(:scalac)
     end
-    project('foo').doc.options[:"doc-title"].should eql('My App')
+    expect(project('foo').doc.options[:"doc-title"]).to eql('My App')
   end
 
   it 'should not override explicit "doc-title" option' do
@@ -44,7 +44,7 @@ describe "Scaladoc" do
       compile.using(:scalac)
       doc.using "doc-title" => 'explicit'
     end
-    project('foo').doc.options[:"doc-title"].should eql('explicit')
+    expect(project('foo').doc.options[:"doc-title"]).to eql('explicit')
   end
 
 if Java.java.lang.System.getProperty("java.runtime.version") >= "1.6"
@@ -56,15 +56,15 @@ if Java.java.lang.System.getProperty("java.runtime.version") >= "1.6"
     end
     actual = Java.scala.tools.nsc.ScalaDoc.new
     scaladoc = Java.scala.tools.nsc.ScalaDoc.new
-    Java.scala.tools.nsc.ScalaDoc.should_receive(:new) do
+    expect(Java.scala.tools.nsc.ScalaDoc).to receive(:new) do
       scaladoc
     end
-    scaladoc.should_receive(:process) do |args|
+    expect(scaladoc).to receive(:process) do |args|
       # Convert Java Strings to Ruby Strings, if needed.
       xargs = args.map { |a| a.is_a?(String) ? a : a.toString }
-      xargs.should include("-doc-title")
-      xargs.should_not include("-windowtitle")
-      actual.process(args).should eql(true)
+      expect(xargs).to include("-doc-title")
+      expect(xargs).not_to include("-windowtitle")
+      expect(actual.process(args)).to eql(true)
     end
     project('foo').doc.invoke
   end unless Buildr::Scala.version?(2.7, "2.8.0")
@@ -85,15 +85,15 @@ describe "package(:scaladoc)" do
     end
 
     scaladoc = project('foo').package(:scaladoc)
-    scaladoc.should point_to_path('target/foo-1.0-scaladoc.jar')
+    expect(scaladoc).to point_to_path('target/foo-1.0-scaladoc.jar')
 
-    lambda {
+    expect {
       project('foo').task('package').invoke
-    }.should change { File.exist?('target/foo-1.0-scaladoc.jar') }.to(true)
+    }.to change { File.exist?('target/foo-1.0-scaladoc.jar') }.to(true)
 
-    scaladoc.should exist
-    scaladoc.should contain('index.html')
-    scaladoc.should contain('Foo.html')
+    expect(scaladoc).to exist
+    expect(scaladoc).to contain('index.html')
+    expect(scaladoc).to contain('Foo.html')
   end
 end
 

--- a/spec/scala/scala.rb
+++ b/spec/scala/scala.rb
@@ -26,6 +26,6 @@ describe 'scala' do
   end
 
   it "should provide the Scala version string" do
-    Scala.version_str.should eql(Buildr::Scala::SCALA_VERSION_FOR_SPECS)
+    expect(Scala.version_str).to eql(Buildr::Scala::SCALA_VERSION_FOR_SPECS)
   end
 end

--- a/spec/scala/tests_spec.rb
+++ b/spec/scala/tests_spec.rb
@@ -29,11 +29,11 @@ describe "scalatest version" do
   case
   when Buildr::Scala.version?(2.8)
     it 'should be 1.3 for scala 2.8' do
-      Scala::ScalaTest.dependencies.should include("org.scalatest:scalatest:jar:1.3")
+      expect(Scala::ScalaTest.dependencies).to include("org.scalatest:scalatest:jar:1.3")
     end
   when Buildr::Scala.version?(2.9)
     it 'should be 1.8 for scala 2.9' do
-      Scala::ScalaTest.dependencies.should include("org.scalatest:scalatest_2.9.2:jar:1.8")
+      expect(Scala::ScalaTest.dependencies).to include("org.scalatest:scalatest_2.9.2:jar:1.8")
     end
   end
 end
@@ -52,25 +52,25 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define 'foo'
-    project('foo').test.framework.should eql(:scalatest)
+    expect(project('foo').test.framework).to eql(:scalatest)
   end
 
   it 'should include Scalatest dependencies' do
     define('foo') { test.using(:scalatest) }
-    project('foo').test.compile.dependencies.should include(*artifacts(Scala::ScalaTest.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(Scala::ScalaTest.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(Scala::ScalaTest.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(Scala::ScalaTest.dependencies))
   end
 
   it 'should include JMock dependencies' do
     define('foo') { test.using(:scalatest) }
-    project('foo').test.compile.dependencies.should include(*artifacts(JMock.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(JMock.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(JMock.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(JMock.dependencies))
   end
 
   it 'should include ScalaCheck dependencies' do
     define('foo') { test.using(:scalatest) }
-    project('foo').test.compile.dependencies.should include(*artifacts(Scala::Check.dependencies))
-    project('foo').test.dependencies.should include(*artifacts(Scala::Check.dependencies))
+    expect(project('foo').test.compile.dependencies).to include(*artifacts(Scala::Check.dependencies))
+    expect(project('foo').test.dependencies).to include(*artifacts(Scala::Check.dependencies))
   end
 
   it 'should set current directory' do
@@ -105,7 +105,7 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define('foo').test.invoke
-    project('foo').test.tests.should include('com.example.MySuite')
+    expect(project('foo').test.tests).to include('com.example.MySuite')
   end
 
   it 'should ignore classes not extending org.scalatest.FunSuite' do
@@ -115,7 +115,7 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define('foo').test.invoke
-    project('foo').test.tests.should be_empty
+    expect(project('foo').test.tests).to be_empty
   end
 
   it 'should ignore inner classes' do
@@ -137,7 +137,7 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define('foo').test.invoke
-    project('foo').test.tests.should eql(['com.example.InnerClassTest'])
+    expect(project('foo').test.tests).to eql(['com.example.InnerClassTest'])
   end
 
   it 'should pass when ScalaTest test case passes' do
@@ -149,7 +149,7 @@ describe Buildr::Scala::ScalaTest do
         }
       }
     SCALA
-    lambda { define('foo').test.invoke }.should_not raise_error
+    expect { define('foo').test.invoke }.not_to raise_error
   end
 
   it 'should fail when ScalaTest test case fails' do
@@ -160,7 +160,7 @@ describe Buildr::Scala::ScalaTest do
         }
       }
     SCALA
-    lambda { define('foo').test.invoke }.should raise_error(RuntimeError, /Tests failed/) rescue nil
+    expect { define('foo').test.invoke }.to raise_error(RuntimeError, /Tests failed/) rescue nil
   end
 
   it 'should report failed test names' do
@@ -172,7 +172,7 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define('foo').test.invoke rescue
-    project('foo').test.failed_tests.should include('FailingSuite')
+    expect(project('foo').test.failed_tests).to include('FailingSuite')
   end
 
   it 'should report to reports/scalatest/TEST-TestSuiteName.xml' do
@@ -184,10 +184,10 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define 'foo' do
-      test.report_to.should be(file('reports/scalatest'))
+      expect(test.report_to).to be(file('reports/scalatest'))
     end
     project('foo').test.invoke
-    project('foo').file('reports/scalatest/TEST-PassingSuite.xml').should exist
+    expect(project('foo').file('reports/scalatest/TEST-PassingSuite.xml')).to exist
   end
 
   it 'should report to reports/scalatest/TEST-TestSuiteName.txt' do
@@ -199,10 +199,10 @@ describe Buildr::Scala::ScalaTest do
       }
     SCALA
     define 'foo' do
-      test.report_to.should be(file('reports/scalatest'))
+      expect(test.report_to).to be(file('reports/scalatest'))
     end
     project('foo').test.invoke
-    project('foo').file('reports/scalatest/TEST-PassingSuite.txt').should exist
+    expect(project('foo').file('reports/scalatest/TEST-PassingSuite.txt')).to exist
   end
 
   it 'should pass properties to Suite' do
@@ -249,7 +249,7 @@ describe Buildr::Scala::ScalaTest do
     SCALA
     define('foo')
     project('foo').test.invoke
-    project('foo').test.passed_tests.should include('MySuite')
+    expect(project('foo').test.passed_tests).to include('MySuite')
   end
 
   it 'should fail if ScalaCheck test case fails' do
@@ -285,7 +285,7 @@ describe Buildr::Scala::ScalaTest do
     SCALA
     define('foo')
     project('foo').test.invoke rescue
-    project('foo').test.failed_tests.should include('StringSuite')
+    expect(project('foo').test.failed_tests).to include('StringSuite')
   end
 
 end

--- a/spec/version_requirement_spec.rb
+++ b/spec/version_requirement_spec.rb
@@ -22,25 +22,25 @@ describe Buildr::VersionRequirement, '.create' do
   end
 
   it 'should complain on invalid input' do
-    lambda { create }.should raise_error(Exception)
-    lambda { create('%') }.should raise_error(Exception, /invalid character/)
-    lambda { create('1#{0}') }.should raise_error(Exception, /invalid character/)
-    lambda { create('1.0rc`exit`') }.should raise_error(Exception, /invalid character/)
-    lambda { create(1.0) }.should raise_error(Exception)
-    lambda { create('1.0') }.should_not raise_error(Exception)
-    lambda { create('1.0rc3') }.should_not raise_error(Exception)
+    expect { create }.to raise_error(Exception)
+    expect { create('%') }.to raise_error(Exception, /invalid character/)
+    expect { create('1#{0}') }.to raise_error(Exception, /invalid character/)
+    expect { create('1.0rc`exit`') }.to raise_error(Exception, /invalid character/)
+    expect { create(1.0) }.to raise_error(Exception)
+    expect { create('1.0') }.not_to raise_error
+    expect { create('1.0rc3') }.not_to raise_error
   end
 
   it 'should allow versions using hyphen' do
-    lambda { create('1.0-rc3') }.should_not raise_error(Exception)
+    expect { create('1.0-rc3') }.not_to raise_error
   end
 
   it 'should create a single version requirement' do
-    create('1.0').should_not be_composed
+    expect(create('1.0')).not_to be_composed
   end
 
   it 'should create a composed version requirement' do
-    create('1.0 | 2.1').should be_composed
+    expect(create('1.0 | 2.1')).to be_composed
   end
 end
 
@@ -111,35 +111,35 @@ end
 
 describe Buildr::VersionRequirement, '#default' do
   it 'should return nil if missing default requirement' do
-    Buildr::VersionRequirement.create('>1').default.should be_nil
-    Buildr::VersionRequirement.create('<1').default.should be_nil
-    Buildr::VersionRequirement.create('!1').default.should be_nil
-    Buildr::VersionRequirement.create('!<=1').default.should be_nil
+    expect(Buildr::VersionRequirement.create('>1').default).to be_nil
+    expect(Buildr::VersionRequirement.create('<1').default).to be_nil
+    expect(Buildr::VersionRequirement.create('!1').default).to be_nil
+    expect(Buildr::VersionRequirement.create('!<=1').default).to be_nil
   end
 
   it 'should return the last version with a = requirement' do
-    Buildr::VersionRequirement.create('1').default.should == '1'
-    Buildr::VersionRequirement.create('=1').default.should == '1'
-    Buildr::VersionRequirement.create('<=1').default.should == '1'
-    Buildr::VersionRequirement.create('>=1').default.should == '1'
-    Buildr::VersionRequirement.create('1 | 2 | 3').default.should == '3'
-    Buildr::VersionRequirement.create('1 2 | 3').default.should == '3'
-    Buildr::VersionRequirement.create('1 & 2 | 3').default.should == '3'
+    expect(Buildr::VersionRequirement.create('1').default).to eq('1')
+    expect(Buildr::VersionRequirement.create('=1').default).to eq('1')
+    expect(Buildr::VersionRequirement.create('<=1').default).to eq('1')
+    expect(Buildr::VersionRequirement.create('>=1').default).to eq('1')
+    expect(Buildr::VersionRequirement.create('1 | 2 | 3').default).to eq('3')
+    expect(Buildr::VersionRequirement.create('1 2 | 3').default).to eq('3')
+    expect(Buildr::VersionRequirement.create('1 & 2 | 3').default).to eq('3')
   end
 end
 
 describe Buildr::VersionRequirement, '#version?' do
   it 'should identify valid versions' do
-    Buildr::VersionRequirement.version?('1').should be_true
-    Buildr::VersionRequirement.version?('1a').should be_true
-    Buildr::VersionRequirement.version?('1.0').should be_true
-    Buildr::VersionRequirement.version?('11.0').should be_true
-    Buildr::VersionRequirement.version?(' 11.0 ').should be_true
-    Buildr::VersionRequirement.version?('11.0-alpha').should be_true
-    Buildr::VersionRequirement.version?('r09').should be_true # BUILDR-615: com.google.guava:guava:jar:r09
+    expect(Buildr::VersionRequirement.version?('1')).to be_truthy
+    expect(Buildr::VersionRequirement.version?('1a')).to be_truthy
+    expect(Buildr::VersionRequirement.version?('1.0')).to be_truthy
+    expect(Buildr::VersionRequirement.version?('11.0')).to be_truthy
+    expect(Buildr::VersionRequirement.version?(' 11.0 ')).to be_truthy
+    expect(Buildr::VersionRequirement.version?('11.0-alpha')).to be_truthy
+    expect(Buildr::VersionRequirement.version?('r09')).to be_truthy # BUILDR-615: com.google.guava:guava:jar:r09
 
-    Buildr::VersionRequirement.version?('a').should be_false
-    Buildr::VersionRequirement.version?('a1').should be_false
-    Buildr::VersionRequirement.version?('r').should be_false
+    expect(Buildr::VersionRequirement.version?('a')).to be_falsey
+    expect(Buildr::VersionRequirement.version?('a1')).to be_falsey
+    expect(Buildr::VersionRequirement.version?('r')).to be_falsey
   end
 end

--- a/spec/xpath_matchers.rb
+++ b/spec/xpath_matchers.rb
@@ -36,7 +36,7 @@ module RSpec
         "Did not find expected xpath #{@xpath}"
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         "Did find unexpected xpath #{@xpath}"
       end
 


### PR DESCRIPTION
I used the rspec upgrade tool to move to the latest version of rspec.

This changes all specs to follow the new DSL introduced with rspec 3.

I'm not sure this is for the better, feedback is welcome.
