### PR TITLE
BUILDR-454: Definition-level parent-child references-by-name fail in …

### DIFF
--- a/lib/buildr/core/project.rb
+++ b/lib/buildr/core/project.rb
@@ -220,6 +220,11 @@ module Buildr #:nodoc:
           # Enhance the project using the definition block.
           project.enhance { project.instance_exec project, &block } if block
 
+          # Mark the project as defined
+          project.enhance do |project|
+            project.send :define!
+          end
+
           # Top-level project? Invoke the project definition. Sub-project? We don't invoke
           # the project definiton yet (allow project calls to establish order of evaluation),
           # but must do so before the parent project's definition is done.
@@ -253,7 +258,7 @@ module Buildr #:nodoc:
         end
         project ||= @projects[name] # Not found in scope.
         raise "No such project #{name}" unless project
-        project.invoke unless no_invoke || Buildr.application.current_scope.join(":").to_s == project.name.to_s
+        project.invoke unless  project.defined? || no_invoke || Buildr.application.current_scope.join(":").to_s == project.name.to_s
         project
       end
 
@@ -614,7 +619,15 @@ module Buildr #:nodoc:
       @calledback ||= {}
     end
 
+    def defined?
+      @defined
+    end
+
   protected
+    def define!
+      @defined = true
+    end
+    
 
     # :call-seq:
     #   base_dir = dir

--- a/spec/core/project_spec.rb
+++ b/spec/core/project_spec.rb
@@ -83,6 +83,16 @@ describe Project do
     Buildr.define('foo') { define('bar') { project('baz:bar') } }
     lambda { project('foo') }.should raise_error(RuntimeError, /Circular dependency/)
   end
+
+  it 'should handle non-circular dependencies' do
+    Buildr.define "root" do
+      define "child" do
+        puts project('root')._('foo.resource')
+      end
+    end
+
+    lambda { project('root') }.should_not raise_error
+  end
 end
 
 describe Project, ' property' do
@@ -533,18 +543,13 @@ describe Buildr, '#project' do
     project('foo:bar').project('baz').should be(project('foo:baz'))
   end
 
-  it 'should fine a project from its parent by proximity' do
+  it 'should find a project from its parent by proximity' do
     define 'foo' do
       define('bar') { define 'baz' }
       define 'baz'
     end
     project('foo').project('baz').should be(project('foo:baz'))
     project('foo:bar').project('baz').should be(project('foo:bar:baz'))
-  end
-
-  it 'should invoke project before returning it' do
-    define('foo').should_receive(:invoke).once
-    project('foo')
   end
 
   it 'should fail if called without a project name' do


### PR DESCRIPTION
…1.4.0 but not in 1.3.5