### PR TITLE
java command: escape classpath entries in the pathing jar manifest

### DIFF
--- a/lib/buildr/java/commands.rb
+++ b/lib/buildr/java/commands.rb
@@ -73,7 +73,7 @@ module Java
               path = File.directory?(c) && !c.end_with?('/') ? "#{c}/" : c.to_s
               Buildr::Util.win_os? ? "/#{path}" : path
             end
-            manifest = Buildr::Packaging::Java::Manifest.new([{'Class-Path' => paths.join(" ")}])
+            manifest = Buildr::Packaging::Java::Manifest.new([{'Class-Path' => paths.map{|p| URI.encode(p)}.join(" ")}])
             tjar = Tempfile.new(['javacmd', '.jar'])
             Zip::ZipOutputStream.open(tjar.path) do |zos|
               zos.put_next_entry('META-INF/MANIFEST.MF')


### PR DESCRIPTION
Hi,

I noticed that the java command fails when using long classpaths on windows, while the classpath also has entries that contain spaces.

The issue is that the manifest in the pathing jar uses space as a separator between classpath entries, and entries aren't URI-encoded. A classpath entry with a space in it is incorrectly treated as 2 entries.

PR is for an older revision, as we use buildr 1.4 internally. It should be easy enough to merge though, as it's a one-liner fix.
