### PR TITLE
Drop deprecated Gem::Specification#has_rdoc= (no replacement) method

### DIFF
--- a/lib/buildr/packaging/gems.rb
+++ b/lib/buildr/packaging/gems.rb
@@ -65,7 +65,6 @@ module Buildr #:nodoc:
           spec.name = id
           spec.version = version.gsub('-','.') # RubyGems doesn't like '-' in version numbers
           spec.summary = full_comment
-          spec.has_rdoc = true
           spec.rdoc_options << '--title' << comment
           spec.require_path = 'lib'
         end


### PR DESCRIPTION
This PR avoids a warning about an upcoming method removal in RubyGems.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/olle/opensource/buildr/lib/buildr/packaging/gems.rb:68.
```