### PR TITLE
Travis CI: try updating to newer versions and make this run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 jdk:
   - oraclejdk8
-  - oraclejdk7
 rvm:
   - 2.5.3
   - jruby-1.7.27

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 rvm:
-  - 2.3.1
-  - jruby-1.7.25
-  - jruby-9.0.5.0
+  - 2.5.3
+  - jruby-1.7.27
+  - jruby-9.2.4.0
 git:
   depth: 10
 scala:


### PR DESCRIPTION
This PR collects the experiments to make the build run in Travis.

- update to newest JRuby 1.7
- add latest JRuby
- update MRI Ruby to 2.5.3
