### PR TITLE
Change RSpec shared_context usage to avoid warnings

### DIFF
--- a/spec/core/build_spec.rb
+++ b/spec/core/build_spec.rb
@@ -16,7 +16,7 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers'))
 
-shared_examples_for 'local task' do
+RSpec.shared_examples 'local task' do
   it "should execute task for project in current directory" do
     define 'foobar'
     lambda { @task.invoke }.should run_task("foobar:#{@task.name}")
@@ -387,7 +387,7 @@ describe Release do
 end
 
 
-shared_examples_for 'a release process' do
+RSpec.shared_examples 'a release process' do
 
   describe '#make' do
     before do

--- a/spec/core/checks_spec.rb
+++ b/spec/core/checks_spec.rb
@@ -343,7 +343,7 @@ end
 
 describe Buildr::Checks::Expectation do
 
-  shared_examples_for 'all archive types' do
+  RSpec.shared_examples 'all archive types' do
 
     before do
       archive = @archive

--- a/spec/core/compile_spec.rb
+++ b/spec/core/compile_spec.rb
@@ -428,7 +428,7 @@ describe Buildr::CompileTask, '#invoke' do
 end
 
 
-shared_examples_for 'accessor task' do
+RSpec.shared_examples 'accessor task' do
   it 'should return a task' do
     define('foo').send(@task_name).should be_kind_of(Rake::Task)
   end

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -102,7 +102,7 @@ describe Project, '.shell' do
   end
 end
 
-shared_examples_for "shell provider" do
+RSpec.shared_examples "shell provider" do
 
   it 'should have launch method accepting shell task' do
     @instance.method(:launch).should_not be_nil

--- a/spec/ide/eclipse_spec.rb
+++ b/spec/ide/eclipse_spec.rb
@@ -382,7 +382,7 @@ MANIFEST
         write 'src/test/java/Test.java'
       end
 
-      shared_examples_for 'source' do
+      RSpec.shared_examples 'source' do
         it 'should ignore CVS and SVN files' do
           define('foo')
           classpath_sources('excluding').each do |excluding_attribute|

--- a/spec/java/packaging_spec.rb
+++ b/spec/java/packaging_spec.rb
@@ -53,7 +53,7 @@ describe Project, '#manifest' do
 end
 
 
-shared_examples_for 'package with manifest' do
+RSpec.shared_examples 'package with manifest' do
   before do
     @long_line = 'No line may be longer than 72 bytes (not characters), in its UTF8-encoded form. If a value would make the initial line longer than this, it should be continued on extra lines (each starting with a single SPACE).'
   end
@@ -347,7 +347,7 @@ describe Project, '#meta_inf' do
 end
 
 
-shared_examples_for 'package with meta_inf' do
+RSpec.shared_examples 'package with meta_inf' do
 
   def package_with_meta_inf(meta_inf = nil)
     packaging = @packaging
@@ -1258,7 +1258,7 @@ describe Packaging, 'test_jar' do
   end
 end
 
-shared_examples_for 'package_with_' do
+RSpec.shared_examples 'package_with_' do
 
   def prepare(options = {})
     packager = "package_with_#{@packaging}"

--- a/spec/java/test_coverage_helper.rb
+++ b/spec/java/test_coverage_helper.rb
@@ -53,7 +53,7 @@ module TestCoverageHelper
   end
 end
 
-shared_examples_for 'test coverage tool' do
+RSpec.shared_examples 'test coverage tool' do
   include TestCoverageHelper
 
   def toolname

--- a/spec/kotlin/compiler_spec.rb
+++ b/spec/kotlin/compiler_spec.rb
@@ -17,7 +17,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers'))
 
 # need to test both with and without KOTLIN_HOME
-share_as :KotlincCompiler do
+RSpec.shared_examples 'KotlincCompiler' do
 
   it 'should identify itself from source directories' do
     write 'src/main/kotlin/com/example/Test.kt', "package com.example\n class Test { }"
@@ -110,7 +110,7 @@ share_as :KotlincCompiler do
   end
 end
 
-share_as :KotlincCompiler_CommonOptions do
+RSpec.shared_examples 'KotlincCompiler_CommonOptions' do
 
   it 'should set warnings option to false by default' do
     compile_task.options.warnings.should be_false
@@ -240,8 +240,8 @@ if Java.java.lang.System.getProperty("java.runtime.version") >= "1.8"
         @compile_task ||= define('foo').compile.using(:kotlinc)
       end
 
-      it_should_behave_like KotlincCompiler
-      it_should_behave_like KotlincCompiler_CommonOptions
+      it_should_behave_like 'KotlincCompiler'
+      it_should_behave_like 'KotlincCompiler_CommonOptions'
     end
   end
 
@@ -264,8 +264,8 @@ if Java.java.lang.System.getProperty("java.runtime.version") >= "1.8"
       compile_task.instance_eval { @compiler }.send(:kotlinc_args)
     end
 
-    it_should_behave_like KotlincCompiler
-    it_should_behave_like KotlincCompiler_CommonOptions
+    it_should_behave_like 'KotlincCompiler'
+    it_should_behave_like 'KotlincCompiler_CommonOptions'
 
     after :all do
       ENV['KOTLIN_HOME'] = old_home

--- a/spec/packaging/archive_spec.rb
+++ b/spec/packaging/archive_spec.rb
@@ -60,7 +60,7 @@ module ArchiveTaskHelpers
   end
 end
 
-shared_examples_for 'ArchiveTask' do
+RSpec.shared_examples 'ArchiveTask' do
   include ArchiveTaskHelpers
 
   before(:each) do

--- a/spec/packaging/packaging_helper.rb
+++ b/spec/packaging/packaging_helper.rb
@@ -14,7 +14,7 @@
 # the License.
 
 
-shared_examples_for 'packaging' do
+RSpec.shared_examples 'packaging' do
   it 'should create artifact of proper type' do
     packaging = @packaging
     package_type = @package_type || @packaging

--- a/spec/scala/compiler_spec.rb
+++ b/spec/scala/compiler_spec.rb
@@ -17,7 +17,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helpers'))
 
 # need to test both with and without SCALA_HOME
-share_as :ScalacCompiler do
+RSpec.shared_examples 'ScalacCompiler' do
 
   it 'should identify itself from source directories' do
     write 'src/main/scala/com/example/Test.scala', 'package com.example; class Test { val i = 1 }'
@@ -118,7 +118,7 @@ if ENV['SCALA_HOME']
       ENV['SCALA_HOME'].should_not be_nil
     end
 
-    it_should_behave_like ScalacCompiler
+    it_should_behave_like 'ScalacCompiler'
   end
 end
 
@@ -133,14 +133,14 @@ describe 'scala compiler (downloaded from repository)' do
     ENV['SCALA_HOME'].should be_nil
   end
 
-  it_should_behave_like ScalacCompiler
+  it_should_behave_like 'ScalacCompiler'
 
   after :all do
     ENV['SCALA_HOME'] = old_home
   end
 end
 
-share_as :ScalacCompiler_CommonOptions do
+RSpec.shared_examples 'ScalacCompiler_CommonOptions' do
 
   it 'should set warnings option to false by default' do
     compile_task.options.warnings.should be_false
@@ -275,7 +275,7 @@ end
 
 describe 'scala compiler 2.8 options' do
 
-  it_should_behave_like ScalacCompiler_CommonOptions
+  it_should_behave_like 'ScalacCompiler_CommonOptions'
 
   def compile_task
     @compile_task ||= define('foo').compile.using(:scalac)
@@ -298,7 +298,7 @@ end if Buildr::Scala.version?(2.8)
 
 describe 'scala compiler 2.9 options' do
 
-  it_should_behave_like ScalacCompiler_CommonOptions
+  it_should_behave_like 'ScalacCompiler_CommonOptions'
 
   def compile_task
     @compile_task ||= define('foo').compile.using(:scalac)
@@ -345,7 +345,7 @@ describe 'zinc compiler (enabled through Buildr.settings)' do
     compile_task.invoke
   end
 
-  it_should_behave_like ScalacCompiler
+  it_should_behave_like 'ScalacCompiler'
 
   after :each do
     Buildr.settings.build['scalac.incremental'] = nil


### PR DESCRIPTION
This PR changes RSpec usage of Shared Examples to work.

This is extracted from #34, hollowing that change out to be more focused.