### PR TITLE
README.rdoc, website: Update links to rake, Antwrap

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,8 +28,8 @@ http://buildr.apache.org/
 === RTFM
 
 * Buildr documentation: http://buildr.apache.org
-* More about Rake: http://docs.rubyrake.org
-* Antwrap documentation: http://antwrap.rubyforge.org
+* More about Rake: https://github.com/ruby/rake
+* Antwrap documentation: https://rubygems.org/gems/Antwrap
 
 
 === Mailing list

--- a/doc/_layouts/default.html
+++ b/doc/_layouts/default.html
@@ -47,7 +47,7 @@
           <li>Reference
             <ol class="toc">
               <li><a href='rdoc/Buildr.html'>API</a></li>
-              <li><a href='http://docs.rubyrake.org'>Rake</a></li>
+              <li><a href='https://github.com/ruby/rake'>Rake</a></li>
               <li><a href='https://rubygems.org/gems/Antwrap'>Antwrap</a></li>
               <li><a href='http://cwiki.apache.org/confluence/display/BUILDR/Common+Problems+and+Solutions'>Troubleshooting</a></li>
             </ol>

--- a/doc/installing.textile
+++ b/doc/installing.textile
@@ -27,7 +27,7 @@ If you are running behind a proxy server, make sure the environment variable @HT
 
 <br>
 
-*In details:* The @gem install@ and @gem update@ commands install Buildr from a binary distribution provided through "RubyForge":http://rubyforge.org/projects/buildr. This distribution is maintained by contributors to this project, but is *not* an official Apache distribution.  You can obtain the official Apache distribution files from the "download page":download.html.
+*In details:* The @gem install@ and @gem update@ commands install Buildr from a binary distribution provided through "RubyGems":https://rubygems.org/gems/buildr. This distribution is maintained by contributors to this project, but is *not* an official Apache distribution.  You can obtain the official Apache distribution files from the "download page":download.html.
 
 Older versions of RubyGems are all kind of fail.  You want to avoid these unless you have the patience to install each Buildr dependency manually.  Get RubyGems 1.3.1 or later, and when using Debian packages (e.g. Ubuntu), make sure to get the unmolested RubyGems straight form the source.
 
@@ -287,7 +287,7 @@ h2(#more). Learning More
 
 For a quicker read (and much more humor), "Why’s (Poignant) Guide to Ruby":http://poignantguide.net/ruby/ is available online.  More resources are listed on the "ruby-lang web site":http://www.ruby-lang.org/en/documentation/.
 
-*Rake* Buildr is based on Rake, a Ruby build system that handles tasks and dependencies.  Check out the "Rake documentation":http://docs.rubyrake.org/ for more information.
+*Rake* Buildr is based on Rake, a Ruby build system that handles tasks and dependencies.  Check out the "Rake documentation":https://github.com/ruby/rake for more information.
 
 *AntWrap* Buildr uses AntWrap, for configuring and running Ant tasks.  You can learn more from the "Antwrap documentation":https://rubygems.org/gems/Antwrap.
 


### PR DESCRIPTION
This PR updates the **README.rdoc** document to have updated links to project pages. Also updated in the sidebar **on the website**.

This is necessary, since the links are taken-over and dead, respectively.

