### PR TITLE
Avoid redefining Ruby globals

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-RC_VERSION = ENV['RC_VERSION'] || ''
+RC_VERSION = ENV['RC_VERSION'] || '' unless defined?(RC_VERSION)
 
 desc 'Release the next version of buildr from existing staged repository'
 task 'release' do

--- a/rakelib/stage.rake
+++ b/rakelib/stage.rake
@@ -18,8 +18,8 @@ require 'digest/sha1'
 
 gpg_cmd = 'gpg2'
 
-STAGE_DATE = ENV['STAGE_DATE'] ||  Time.now.strftime('%Y-%m-%d')
-RC_VERSION = ENV['RC_VERSION'] || ''
+STAGE_DATE = ENV['STAGE_DATE'] ||  Time.now.strftime('%Y-%m-%d') unless defined?(STAGE_DATE)
+RC_VERSION = ENV['RC_VERSION'] || '' unless defined?(RC_VERSION)
 
 task 'prepare' do
   # Update source files to next release number.


### PR DESCRIPTION
This PR **avoids a Ruby warning** which is output when running `rake`.