### PR TITLE
Gemspec: drop rubyforge_project setting

### DIFF
--- a/buildr.gemspec
+++ b/buildr.gemspec
@@ -38,7 +38,6 @@ something that's simple and intuitive to use, so we only need to tell it what
 to do, and it takes care of the rest.  But also something we can easily extend
 for those one-off tasks, with a language that's a joy to use.
   TEXT
-  spec.rubyforge_project  = 'buildr'
 
   spec.platform       = $platform
 


### PR DESCRIPTION
This PR drops an old setting from the gemspec. 

 The Rubyforge service is defunct and the setting now means nothing.