### PR TITLE
Docs: Replace RubyForge w/ RubyGems.org

### DIFF
--- a/doc/more_stuff.textile
+++ b/doc/more_stuff.textile
@@ -205,11 +205,11 @@ The purpose of the buildfile is to define your projects, and the various tasks a
 
 There are several mechanisms for developing extensions and build features across projects which we cover in more details in the section "Extending Buildr":extending.html.  Here we will talk about using extensions that are distributed in the form of RubyGems.
 
-"RubyGems":http://rubygems.org provides the @gem@ command line tool that you can use to search, install, upgrade, package and distribute gems. It installs all gems into a local repository that is shared across your builds and all other Ruby applications you may have running.  You can install a gem from a local file, or download and install it from any number of remote repositories.
+"RubyGems":https://rubygems.org provides the @gem@ command line tool that you can use to search, install, upgrade, package and distribute gems. It installs all gems into a local repository that is shared across your builds and all other Ruby applications you may have running.  You can install a gem from a local file, or download and install it from any number of remote repositories.
 
-RubyGems is preconfigured to use the "RubyForge":http://rubygems.org repository.  You'll find a large number of open source Ruby libraries there, including Buildr itself and all its dependencies.
+RubyGems is preconfigured to use the "RubyGems.org":https://rubygems.org repository.  You'll find a large number of open source Ruby libraries there, including Buildr itself and all its dependencies.
 
-You can also set up your own private repository and use it instead or in addition to RubyForge.  Use the @gem sources@ command to add repositories, and the @gem server@ command to run a remote repository.  You can see all available options by running @gem help@.
+You can also set up your own private repository and use it instead or in addition to RubyGems.org.  Use the @gem sources@ command to add repositories, and the @gem server@ command to run a remote repository.  You can see all available options by running @gem help@.
 
 If your build depends on other gems, you will want to specify these dependencies as part of your build and check that configuration into source control.  That way you can have a specific environment that will guarantee repeatable builds, whether you're building a particular version, moving between branches, or joining an existing project.  Buildr will take care of installing all the necessary dependencies, which you can then manage with the @gem@ command.
 


### PR DESCRIPTION
This PR corrects a wrong paragraph.

- RubyForge also no longer exists
- Use `https` in these links

