### PR TITLE
(doc) Copyright year set to 2020 in footer

### DIFF
--- a/doc/_layouts/default.html
+++ b/doc/_layouts/default.html
@@ -76,7 +76,7 @@
         {{ content | toc }}
         {{ content }}
       </div>
-      <div id='footer'>Copyright &copy; 2007-2016 The Apache Software Foundation</div>
+      <div id='footer'>Copyright &copy; 2007-2020 The Apache Software Foundation</div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This PR updates the footer copyright year notice.

Makes it ✨ more alive.