### PR TITLE
CI: Pick OpenJDK8, which exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 jdk:
-  - oraclejdk8
+  - openjdk8
 rvm:
   - 2.3.1
   - jruby-1.7.27


### PR DESCRIPTION
TL;DR: This PR "fixes the build" so that it doesn't fail immediately, but runs the test suite.

https://travis-ci.org/github/apache/buildr/pull_requests

## Current

Currently, the `oraclejdk8` is set as jdk. 

Output in CI now: jdk selection fails when attempting to use a now-unsupported JDK

```
install-jdk.sh 2020-01-14

Expected feature release number in range of 9 to 15, but got: 8
```

[Example of failed build](https://travis-ci.org/github/apache/buildr/jobs/658529962)

## Solution

This PR changes it to use OpenJDK, in Travis.